### PR TITLE
Fix experience points property naming

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,7 +323,7 @@
             </div>
             <div class="status-display-container">
                 <div :class="['status-display', experienceStatusClass]"> 経験点 {{ currentExperiencePoints }} / {{
-                    maxExperimentPoints }} </div>
+                    maxExperiencePoints }} </div>
                 <div class="status-display status-display--weight"> 荷重: {{ currentWeight }} </div>
             </div>
             <div class="footer-button footer-button--save" @click="saveData"> データ保存 </div>

--- a/main.js
+++ b/main.js
@@ -36,7 +36,7 @@ const app = createApp({
         };
     },
     computed: {
-        maxExperimentPoints() {
+        maxExperiencePoints() {
             const initialScarExp = Number(this.character.initialScar) || 0;
             const creationWeaknessExp = this.character.weaknesses.reduce((sum, weakness) => {
                 return sum + (weakness.text && weakness.text.trim() !== '' && weakness.acquired === '作成時' ? this.gameData.experiencePointValues.weakness : 0);
@@ -66,7 +66,7 @@ const app = createApp({
             return weight;
         },
         experienceStatusClass() {
-            return this.currentExperiencePoints > this.maxExperimentPoints ? 'status-display--experience-over' : 'status-display--experience-ok';
+            return this.currentExperiencePoints > this.maxExperiencePoints ? 'status-display--experience-over' : 'status-display--experience-ok';
         },
         sessionNamesForWeaknessDropdown() {
             const defaultOptions = [...this.gameData.weaknessAcquisitionOptions];


### PR DESCRIPTION
## Summary
- rename `maxExperimentPoints` to `maxExperiencePoints`
- update computed property references in JS and HTML

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_683f856a9ce88326b2c4c35e2e0b4a5c