### PR TITLE
Unify weakness layout with list style

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,30 +107,25 @@
                     </div>
                     <div class="weakness-section">
                         <div class="box-title sub-box-title sub-box-title--weakness">弱点</div>
-                        <table class="weakness-table">
-                            <thead>
-                                <tr>
-                                    <th class="col-number"></th>
-                                    <th class="col-weakness">弱点</th>
-                                    <th class="col-acquired">獲得</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr v-for="(weakness, index) in character.weaknesses" :key="index">
-                                    <td class="col-number">{{ index + 1 }}</td>
-                                    <td>
-                                        <input type="text" v-model="weakness.text">
-                                    </td>
-                                    <td class="col-acquired">
-                                        <select v-model="weakness.acquired">
-                                            <option v-for="option in sessionNamesForWeaknessDropdown"
-                                                :key="option.value" :value="option.value" :disabled="option.disabled">{{
-                                                option.text }}</option>
-                                        </select>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
+                        <ul class="weakness-list list-reset">
+                            <li class="list-item weakness-labels-header">
+                                <div class="flex-weakness-number"></div>
+                                <div class="flex-weakness-text"><label>弱点</label></div>
+                                <div class="flex-weakness-acquired"><label>獲得</label></div>
+                            </li>
+                            <li v-for="(weakness, index) in character.weaknesses" :key="index" class="list-item">
+                                <div class="flex-weakness-number">{{ index + 1 }}</div>
+                                <div class="flex-weakness-text"><input type="text" v-model="weakness.text" /></div>
+                                <div class="flex-weakness-acquired">
+                                    <select v-model="weakness.acquired">
+                                        <option v-for="option in sessionNamesForWeaknessDropdown"
+                                            :key="option.value" :value="option.value" :disabled="option.disabled">
+                                            {{ option.text }}
+                                        </option>
+                                    </select>
+                                </div>
+                            </li>
+                        </ul>
                     </div>
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -383,57 +383,45 @@ textarea.greyed-out {
 }
 
 /* ==========================================================================
-   弱点テーブル
+   弱点リスト
    ========================================================================== */
 
-.weakness-table {
-    width: 100%;
-    border-collapse: collapse;
-    margin-top: 5px;
-}
-
-.weakness-table th,
-.weakness-table td {
-    padding: 5px;
+.weakness-list .list-item {
     border-bottom: 1px solid #3a3a3a;
-    text-align: left;
-    vertical-align: middle;
+    padding: 5px 0;
+    font-size: 0.9em;
 }
 
-.weakness-table th {
+.weakness-labels-header {
     color: #aaa;
-    font-size: 0.9em;
     border-bottom: 1px solid #4a4a4a;
+    margin-bottom: 5px;
 }
 
-.weakness-table td input[type="text"],
-.weakness-table td select {
-    font-size: 0.9em;
-    padding: 7px 10px;
-}
-
-.weakness-table th.col-number {
-    width: 30px;
-    padding-left: 4px;
-    padding-right: 4px;
+.weakness-labels-header .flex-weakness-number {
     color: transparent;
     user-select: none;
 }
 
-.weakness-table td.col-number {
+.flex-weakness-number {
+    width: 30px;
     text-align: center;
 }
 
-.weakness-table th.col-acquired,
-.weakness-table td.col-acquired {
+.flex-weakness-text {
+    flex: 1;
+    padding-right: 10px;
+}
+
+.flex-weakness-acquired {
     width: 150px;
 }
 
-.weakness-table td.col-acquired select {
+.flex-weakness-acquired select {
     min-width: 120px;
 }
 
-.weakness-table td.col-acquired option[disabled] {
+.flex-weakness-acquired option[disabled] {
     color: #777;
     font-style: italic;
 }
@@ -924,13 +912,12 @@ textarea.greyed-out {
         margin-bottom: 0;
     }
 
-    .weakness-table th.col-acquired,
-    .weakness-table td.col-acquired {
+    .flex-weakness-acquired {
         width: 35%;
         min-width: 110px;
     }
 
-    .weakness-table td.col-acquired select {
+    .flex-weakness-acquired select {
         width: 100%;
     }
 
@@ -962,8 +949,7 @@ textarea.greyed-out {
         font-size: 1.8em;
     }
 
-    .weakness-table th.col-acquired,
-    .weakness-table td.col-acquired {
+    .flex-weakness-acquired {
         width: 40%;
         min-width: 100px;
     }


### PR DESCRIPTION
## Summary
- replace weakness table with list markup for consistency
- style weakness list to match other list components
- adjust responsive CSS

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f854d28348326813af339b35c61d3