### PR TITLE
Introduce form element base classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,20 +24,20 @@
                 <div class="box-content">
                     <div class="info-row">
                         <div class="info-item info-item--full">
-                            <label for="name">キャラクター名</label> <input type="text" id="name" v-model="character.name" />
+                            <label for="name">キャラクター名</label> <input type="text" id="name" v-model="character.name" class="form-element" />
                         </div>
                     </div>
                     <div class="info-row">
                         <div class="info-item info-item--full">
                             <label for="player_name">プレイヤー名</label> <input type="text" id="player_name"
-                                v-model="character.playerName" />
+                                v-model="character.playerName" class="form-element" />
                         </div>
                     </div>
                     <div class="info-row">
                         <div class="info-item"
                             :class="{'info-item--full': character.species !== 'other', 'info-item--double': character.species === 'other'}">
                             <label for="species">種族</label>
-                            <select id="species" v-model="character.species" @change="handleSpeciesChange">
+                            <select id="species" v-model="character.species" @change="handleSpeciesChange" class="form-element form-element--select">
                                 <option v-for="option in gameData.speciesOptions" :key="option.value"
                                     :value="option.value" :disabled="option.disabled">
                                     {{ option.label }}
@@ -46,36 +46,36 @@
                         </div>
                         <div class="info-item info-item--double" v-if="character.species === 'other'">
                             <label for="rare_species">種族名（希少人種）</label>
-                            <input type="text" id="rare_species" v-model="character.rareSpecies" />
+                            <input type="text" id="rare_species" v-model="character.rareSpecies" class="form-element" />
                         </div>
                     </div>
                     <div class="info-row">
                         <div class="info-item info-item--quadruple">
-                            <label for="gender">性別</label> <input type="text" id="gender" v-model="character.gender" />
+                            <label for="gender">性別</label> <input type="text" id="gender" v-model="character.gender" class="form-element" />
                         </div>
                         <div class="info-item info-item--quadruple">
                             <label for="age">年齢</label> <input type="number" id="age" v-model.number="character.age"
-                                min="0" />
+                                min="0" class="form-element" />
                         </div>
                         <div class="info-item info-item--quadruple">
-                            <label for="height">身長</label> <input type="text" id="height" v-model="character.height" />
+                            <label for="height">身長</label> <input type="text" id="height" v-model="character.height" class="form-element" />
                         </div>
                         <div class="info-item info-item--quadruple">
                             <label for="weight_char">体重</label>
-                            <input type="text" id="weight_char" v-model="character.weight" />
+                            <input type="text" id="weight_char" v-model="character.weight" class="form-element" />
                         </div>
 
                     </div>
                     <div class="info-row">
                         <div class="info-item info-item--triple">
-                            <label for="origin">出身地</label> <input type="text" id="origin" v-model="character.origin" />
+                            <label for="origin">出身地</label> <input type="text" id="origin" v-model="character.origin" class="form-element" />
                         </div>
                         <div class="info-item info-item--triple">
                             <label for="occupation">職業</label> <input type="text" id="occupation"
-                                v-model="character.occupation" />
+                                v-model="character.occupation" class="form-element" />
                         </div>
                         <div class="info-item info-item--triple">
-                            <label for="faith">信仰</label> <input type="text" id="faith" v-model="character.faith" />
+                            <label for="faith">信仰</label> <input type="text" id="faith" v-model="character.faith" class="form-element" />
                         </div>
                     </div>
                 </div>
@@ -97,11 +97,11 @@
                                 </div>
                                 <input type="number" id="current_scar" v-model.number="character.currentScar"
                                     @input="handleCurrentScarInput"
-                                    :class="{'greyed-out': character.linkCurrentToInitialScar}" min="0" class="mt-6">
+                                    :class="{'greyed-out': character.linkCurrentToInitialScar}" min="0" class="form-element mt-6">
                             </div>
                             <div class="info-item info-item--double">
                                 <label for="initial_scar">初期値</label>
-                                <input type="number" id="initial_scar" v-model.number="character.initialScar" min="0">
+                                <input type="number" id="initial_scar" v-model.number="character.initialScar" min="0" class="form-element">
                             </div>
                         </div>
                     </div>
@@ -119,10 +119,10 @@
                                 <tr v-for="(weakness, index) in character.weaknesses" :key="index">
                                     <td class="col-number">{{ index + 1 }}</td>
                                     <td>
-                                        <input type="text" v-model="weakness.text">
+                                        <input type="text" v-model="weakness.text" class="form-element">
                                     </td>
                                     <td class="col-acquired">
-                                        <select v-model="weakness.acquired">
+                                        <select v-model="weakness.acquired" class="form-element form-element--select">
                                             <option v-for="option in sessionNamesForWeaknessDropdown"
                                                 :key="option.value" :value="option.value" :disabled="option.disabled">{{
                                                 option.text }}</option>
@@ -154,7 +154,7 @@
                                             <= 1 && expert.value===''">－</button>
                                     </div>
                                     <input type="text" v-model="expert.value" :placeholder="expertPlaceholder(skill)"
-                                        :disabled="!skill.checked" class="flex-grow" />
+                                        :disabled="!skill.checked" class="form-element flex-grow" />
                                 </li>
                             </ul>
                             <div class="add-button-container-left">
@@ -180,7 +180,7 @@
                             <div class="flex-grow">
                                 <div class="flex-group">
                                     <select v-model="specialSkill.group" @change="updateSpecialSkillOptions(index)"
-                                        class="flex-item-1">
+                                        class="form-element form-element--select flex-item-1">
                                         <option v-for="option in gameData.specialSkillGroupOptions" :key="option.value"
                                             :value="option.value">
                                             {{ option.label }}
@@ -188,14 +188,14 @@
                                     </select>
                                     <select v-model="specialSkill.name"
                                         @change="updateSpecialSkillNoteVisibility(index)"
-                                        :disabled="!specialSkill.group" class="flex-item-2">
+                                        :disabled="!specialSkill.group" class="form-element form-element--select flex-item-2">
                                         <option value="">---</option>
                                         <option v-for="opt in availableSpecialSkillNames(index)" :key="opt.value"
                                             :value="opt.value">{{ opt.label }}</option>
                                     </select>
                                 </div>
                                 <input type="text" v-model="specialSkill.note" v-show="specialSkill.showNote"
-                                    class="special-skill-note-input"
+                                    class="form-element special-skill-note-input"
                                     :placeholder="gameData.placeholderTexts.specialSkillNote" />
                             </div>
                         </li>
@@ -216,40 +216,40 @@
                                 <div class="equipment-item mb-12">
                                     <label for="weapon1">武器1</label>
                                     <div class="flex-group">
-                                        <select id="weapon1" v-model="equipments.weapon1.group" class="flex-item-1">
+                                        <select id="weapon1" v-model="equipments.weapon1.group" class="form-element form-element--select flex-item-1">
                                             <option v-for="option in gameData.weaponOptions" :key="option.value"
                                                 :value="option.value">
                                                 {{ option.label }}
                                             </option>
                                         </select>
                                         <input type="text" id="weapon1_name" v-model="equipments.weapon1.name"
-                                            :placeholder="gameData.placeholderTexts.weaponName" class="flex-item-2" />
+                                            :placeholder="gameData.placeholderTexts.weaponName" class="form-element flex-item-2" />
                                     </div>
                                 </div>
                                 <div class="equipment-item mb-12">
                                     <label for="weapon2">武器2</label>
                                     <div class="flex-group">
-                                        <select id="weapon2" v-model="equipments.weapon2.group" class="flex-item-1">
+                                        <select id="weapon2" v-model="equipments.weapon2.group" class="form-element form-element--select flex-item-1">
                                             <option v-for="option in gameData.weaponOptions" :key="option.value"
                                                 :value="option.value">
                                                 {{ option.label }}
                                             </option>
                                         </select>
                                         <input type="text" id="weapon2_name" v-model="equipments.weapon2.name"
-                                            :placeholder="gameData.placeholderTexts.weaponName" class="flex-item-2" />
+                                            :placeholder="gameData.placeholderTexts.weaponName" class="form-element flex-item-2" />
                                     </div>
                                 </div>
                                 <div class="equipment-item">
                                     <label for="armor">防具</label>
                                     <div class="flex-group">
-                                        <select id="armor" v-model="equipments.armor.group" class="flex-item-1">
+                                        <select id="armor" v-model="equipments.armor.group" class="form-element form-element--select flex-item-1">
                                             <option v-for="option in gameData.armorOptions" :key="option.value"
                                                 :value="option.value">
                                                 {{ option.label }}
                                             </option>
                                         </select>
                                         <input type="text" id="armor_name" v-model="equipments.armor.name"
-                                            :placeholder="gameData.placeholderTexts.armorName" class="flex-item-2" />
+                                            :placeholder="gameData.placeholderTexts.armorName" class="form-element flex-item-2" />
                                     </div>
                                 </div>
                             </div>
@@ -257,7 +257,7 @@
                     </div>
                     <div>
                         <label for="other_items" class="block-label">その他所持品</label>
-                        <textarea id="other_items" class="items-textarea" v-model="character.otherItems"></textarea>
+                        <textarea id="other_items" class="form-element form-element--textarea items-textarea" v-model="character.otherItems"></textarea>
                     </div>
                 </div>
             </div>
@@ -266,7 +266,7 @@
                 <div class="box-title">キャラクターメモ</div>
                 <div class="box-content">
                     <textarea id="character_text" :placeholder="gameData.placeholderTexts.characterMemo"
-                        v-model="character.memo" class="character-memo-textarea"></textarea>
+                        v-model="character.memo" class="form-element form-element--textarea character-memo-textarea"></textarea>
                 </div>
             </div>
 
@@ -293,11 +293,11 @@
                             </div>
                             <div class="flex-grow">
                                 <div class="history-item-inputs">
-                                    <div class="flex-history-name"> <input type="text" v-model="history.sessionName" />
+                                    <div class="flex-history-name"> <input type="text" v-model="history.sessionName" class="form-element" />
                                     </div>
                                     <div class="flex-history-exp"> <input type="number"
-                                            v-model.number="history.gotExperiments" min="0" /> </div>
-                                    <div class="flex-history-memo"> <input type="text" v-model="history.memo" />
+                                            v-model.number="history.gotExperiments" min="0" class="form-element" /> </div>
+                                    <div class="flex-history-memo"> <input type="text" v-model="history.memo" class="form-element" />
                                     </div>
                                 </div>
                             </div>

--- a/style.css
+++ b/style.css
@@ -158,10 +158,7 @@ label {
 }
 
 /* 入力フィールド */
-input[type="text"],
-input[type="number"],
-select,
-textarea {
+.form-element {
     padding: 9px 12px;
     border-radius: 3px;
     border: 1px solid #555;
@@ -173,21 +170,18 @@ textarea {
     transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
 }
 
-textarea {
-    font-size: 1.2em;
-    line-height: 1.6;
-}
-
-input[type="text"]:focus,
-input[type="number"]:focus,
-select:focus,
-textarea:focus {
+.form-element:focus {
     border-color: #c09a69;
     outline: 0;
     box-shadow: 0 0 0 0.2rem rgba(192, 154, 105, 0.25);
 }
 
-select {
+.form-element--textarea {
+    font-size: 1.2em;
+    line-height: 1.6;
+}
+
+.form-element--select {
     appearance: auto;
 }
 
@@ -406,8 +400,8 @@ textarea.greyed-out {
     border-bottom: 1px solid #4a4a4a;
 }
 
-.weakness-table td input[type="text"],
-.weakness-table td select {
+.weakness-table td input.form-element,
+.weakness-table td select.form-element--select {
     font-size: 0.9em;
     padding: 7px 10px;
 }
@@ -429,7 +423,7 @@ textarea.greyed-out {
     width: 150px;
 }
 
-.weakness-table td.col-acquired select {
+.weakness-table td.col-acquired select.form-element--select {
     min-width: 120px;
 }
 


### PR DESCRIPTION
## Summary
- create `.form-element` utility styles with optional textarea and select modifiers
- refactor existing form styles to use these classes
- update HTML inputs, selects and textareas to apply the new classes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f8d148d6c8326ac06542909f13af2