### PR TITLE
Switch info rows to grid layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,20 +22,20 @@
             <div id="character_info" class="character-info">
                 <div class="box-title">基本情報</div>
                 <div class="box-content">
-                    <div class="info-row">
+                    <div class="info-row grid">
                         <div class="info-item info-item--full">
                             <label for="name">キャラクター名</label> <input type="text" id="name" v-model="character.name" />
                         </div>
                     </div>
-                    <div class="info-row">
+                    <div class="info-row grid">
                         <div class="info-item info-item--full">
                             <label for="player_name">プレイヤー名</label> <input type="text" id="player_name"
                                 v-model="character.playerName" />
                         </div>
                     </div>
-                    <div class="info-row">
+                    <div class="info-row grid">
                         <div class="info-item"
-                            :class="{'info-item--full': character.species !== 'other', 'info-item--double': character.species === 'other'}">
+                            :class="{'info-item--full': character.species !== 'other', 'col-2': character.species === 'other'}">
                             <label for="species">種族</label>
                             <select id="species" v-model="character.species" @change="handleSpeciesChange">
                                 <option v-for="option in gameData.speciesOptions" :key="option.value"
@@ -44,37 +44,37 @@
                                 </option>
                             </select>
                         </div>
-                        <div class="info-item info-item--double" v-if="character.species === 'other'">
+                        <div class="info-item col-2" v-if="character.species === 'other'">
                             <label for="rare_species">種族名（希少人種）</label>
                             <input type="text" id="rare_species" v-model="character.rareSpecies" />
                         </div>
                     </div>
-                    <div class="info-row">
-                        <div class="info-item info-item--quadruple">
+                    <div class="info-row grid">
+                        <div class="info-item col-4">
                             <label for="gender">性別</label> <input type="text" id="gender" v-model="character.gender" />
                         </div>
-                        <div class="info-item info-item--quadruple">
+                        <div class="info-item col-4">
                             <label for="age">年齢</label> <input type="number" id="age" v-model.number="character.age"
                                 min="0" />
                         </div>
-                        <div class="info-item info-item--quadruple">
+                        <div class="info-item col-4">
                             <label for="height">身長</label> <input type="text" id="height" v-model="character.height" />
                         </div>
-                        <div class="info-item info-item--quadruple">
+                        <div class="info-item col-4">
                             <label for="weight_char">体重</label>
                             <input type="text" id="weight_char" v-model="character.weight" />
                         </div>
 
                     </div>
-                    <div class="info-row">
-                        <div class="info-item info-item--triple">
+                    <div class="info-row grid">
+                        <div class="info-item col-3">
                             <label for="origin">出身地</label> <input type="text" id="origin" v-model="character.origin" />
                         </div>
-                        <div class="info-item info-item--triple">
+                        <div class="info-item col-3">
                             <label for="occupation">職業</label> <input type="text" id="occupation"
                                 v-model="character.occupation" />
                         </div>
-                        <div class="info-item info-item--triple">
+                        <div class="info-item col-3">
                             <label for="faith">信仰</label> <input type="text" id="faith" v-model="character.faith" />
                         </div>
                     </div>
@@ -86,8 +86,8 @@
                 <div class="box-content">
                     <div class="scar-section">
                         <div class="box-title sub-box-title sub-box-title--scar">傷痕</div>
-                        <div class="info-row">
-                            <div class="info-item info-item--double">
+                        <div class="info-row grid">
+                            <div class="info-item col-2">
                                 <div class="link-checkbox-container">
                                     <label for="current_scar" class="link-checkbox-main-label">現在値</label>
                                     <input type="checkbox" id="link_current_to_initial_scar_checkbox"
@@ -99,7 +99,7 @@
                                     @input="handleCurrentScarInput"
                                     :class="{'greyed-out': character.linkCurrentToInitialScar}" min="0" class="mt-6">
                             </div>
-                            <div class="info-item info-item--double">
+                            <div class="info-item col-2">
                                 <label for="initial_scar">初期値</label>
                                 <input type="number" id="initial_scar" v-model.number="character.initialScar" min="0">
                             </div>

--- a/style.css
+++ b/style.css
@@ -278,37 +278,30 @@ textarea.greyed-out {
    ========================================================================== */
 
 .info-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 15px;
     margin-bottom: 7px;
 }
+
+/* Grid system */
+.grid {
+    display: grid;
+    gap: var(--gap, 15px);
+    grid-template-columns: repeat(auto-fit, minmax(var(--col-width, 150px), 1fr));
+}
+
+.col-2 { grid-column: span 2; }
+.col-3 { grid-column: span 3; }
+.col-4 { grid-column: span 4; }
 
 .info-row:last-child {
     margin-bottom: 0;
 }
 
 .info-item {
-    flex: 1 1 auto;
+    min-width: 0;
 }
 
 .info-item--full {
-    flex-basis: 100%;
-}
-
-.info-item--quadruple {
-    flex: 1 1 calc(25% - 12.5px);
-    min-width: 65px;
-}
-
-.info-item--triple {
-    flex: 1 1 calc(33.333% - 10px);
-    min-width: 90px;
-}
-
-.info-item--double {
-    flex: 1 1 calc(50% - 7.5px);
-    min-width: 80px;
+    grid-column: 1 / -1;
 }
 
 /* ==========================================================================
@@ -939,17 +932,9 @@ textarea.greyed-out {
         max-width: none;
     }
 
-    .info-row {
-        flex-direction: column;
+    .grid {
+        grid-template-columns: 1fr;
         gap: 12px;
-    }
-
-    .info-item,
-    .info-item--triple,
-    .info-item--double {
-        flex-basis: auto;
-        min-width: 0;
-        width: 100%;
     }
 
     .equipment-section {


### PR DESCRIPTION
## Summary
- add a grid utility with CSS variable gap
- provide `.col-*` span helpers
- refactor index.html info rows to use the new grid classes
- update responsive rules

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_683f8d2395348326b8b5b9be2f96f72f