### PR TITLE
Adjust gap-based spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -284,9 +284,6 @@ textarea.greyed-out {
     margin-bottom: 7px;
 }
 
-.info-row:last-child {
-    margin-bottom: 0;
-}
 
 .info-item {
     flex: 1 1 auto;
@@ -361,9 +358,6 @@ textarea.greyed-out {
     margin-bottom: 12px;
 }
 
-.equipment-item:last-child {
-    margin-bottom: 0;
-}
 
 /* アイテム用テキストエリア */
 .items-textarea {
@@ -485,27 +479,26 @@ textarea.greyed-out {
     display: flex;
     align-items: flex-start;
     gap: 10px;
-    padding: 2px 0;
 }
 
 .list-item:last-of-type {
     border-bottom: none;
-    padding-bottom: 8px;
 }
 
 .list-item .delete-button-wrapper {
     margin-top: 6px;
 }
 
+.expert-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
 .expert-list-item {
     display: flex;
     align-items: center;
     gap: 10px;
-    margin-bottom: 8px;
-}
-
-.expert-list-item:last-child {
-    margin-bottom: 0;
 }
 
 .special-skill-note-input {


### PR DESCRIPTION
## Summary
- remove margin overrides that break consistent gap spacing
- drop padding from list-item rows
- rely on `gap` for expert list spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f958b12e08326aaf703ed72e6533e