### PR TITLE
Fix layout offsets for sub box titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,10 +83,11 @@
 
             <div id="scar_weakness_section" class="scar-weakness">
                 <div class="box-title">傷痕と弱点</div>
-                <div class="box-content">
+                <div class="box-content box-content--flush">
                     <div class="scar-section">
                         <div class="box-title sub-box-title sub-box-title--scar">傷痕</div>
-                        <div class="info-row">
+                        <div class="sub-box-content">
+                            <div class="info-row">
                             <div class="info-item info-item--double">
                                 <div class="link-checkbox-container">
                                     <label for="current_scar" class="link-checkbox-main-label">現在値</label>
@@ -105,9 +106,11 @@
                             </div>
                         </div>
                     </div>
+                    </div>
                     <div class="weakness-section">
                         <div class="box-title sub-box-title sub-box-title--weakness">弱点</div>
-                        <table class="weakness-table">
+                        <div class="sub-box-content">
+                            <table class="weakness-table">
                             <thead>
                                 <tr>
                                     <th class="col-number"></th>
@@ -131,6 +134,7 @@
                                 </tr>
                             </tbody>
                         </table>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -123,18 +123,28 @@ body {
     background-color: #2e2e2e;
     border-bottom: 1px solid #4a4a4a;
     padding: 10px 18px;
-    margin-left: -18px;
-    margin-right: -18px;
+    margin: 0;
 }
 
 .sub-box-title--scar {
-    margin-top: -18px;
+    margin-top: 0;
     margin-bottom: 15px;
 }
 
 .sub-box-title--weakness {
     margin-top: 0;
     margin-bottom: 10px;
+}
+
+/* Wrapper for sections that contain a sub-box */
+.box-content--flush {
+    padding-top: 0;
+    padding-left: 0;
+    padding-right: 0;
+}
+
+.sub-box-content {
+    padding: 0 18px;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary
- remove negative margins from `.sub-box-title`
- add wrapper styles to keep alignment when margins are removed
- update scar/weakness section markup to use the new wrapper classes

## Testing
- `tidy -q index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f958349d8832684d0530dd657802b