### PR TITLE
Refactor custom alert to reusable utility

### DIFF
--- a/index.html
+++ b/index.html
@@ -341,6 +341,7 @@
     <script src="cocofoliaExporter.js"></script>
     <script src="gameData.js"></script>
     <script src="dataManager.js"></script>
+    <script src="utils.js"></script>
     <script src="main.js"></script>
 </body>
 

--- a/main.js
+++ b/main.js
@@ -269,26 +269,7 @@ const app = createApp({
         },
 
         showCustomAlert(message) {
-            const alertModalId = 'custom-alert-modal';
-            let modal = document.getElementById(alertModalId);
-            if (!modal) {
-                modal = document.createElement('div');
-                modal.id = alertModalId;
-                modal.classList.add('custom-alert-modal'); // CSSクラスを追加
-
-                const messageP = document.createElement('p');
-                messageP.classList.add('custom-alert-message'); // CSSクラスを追加
-                modal.appendChild(messageP);
-
-                const closeButton = document.createElement('button');
-                closeButton.textContent = 'OK';
-                closeButton.classList.add('custom-alert-button'); // CSSクラスを追加
-                closeButton.onclick = () => modal.remove();
-                modal.appendChild(closeButton);
-                document.body.appendChild(modal);
-            }
-            modal.querySelector('p').textContent = message;
-            modal.style.display = 'block';
+            window.showCustomAlert(message);
         }
     },
     mounted() {

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,29 @@
+(function(window) {
+    function showCustomAlert(message) {
+        const alertModalId = 'custom-alert-modal';
+        let modal = document.getElementById(alertModalId);
+        if (!modal) {
+            modal = document.createElement('div');
+            modal.id = alertModalId;
+            modal.classList.add('custom-alert-modal');
+
+            const messageP = document.createElement('p');
+            messageP.classList.add('custom-alert-message');
+            modal.appendChild(messageP);
+
+            const closeButton = document.createElement('button');
+            closeButton.textContent = 'OK';
+            closeButton.classList.add('custom-alert-button');
+            closeButton.onclick = () => {
+                modal.style.display = 'none';
+            };
+            modal.appendChild(closeButton);
+            document.body.appendChild(modal);
+        }
+        modal.querySelector('p').textContent = message;
+        modal.style.display = 'block';
+    }
+
+    window.showCustomAlert = showCustomAlert;
+})(window);
+


### PR DESCRIPTION
## Summary
- centralize alert modal logic in new `utils.js`
- reuse existing modal element to avoid rebuilding it each time
- wrap Vue method `showCustomAlert` to call the utility
- include `utils.js` in `index.html`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f9d2fd638832694a8916ff97fdae8