### PR TITLE
Refactor equipment markup into reusable component

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,45 +213,24 @@
                     <div class="mb-15">
                         <div class="equipment-container">
                             <div class="equipment-section">
-                                <div class="equipment-item mb-12">
-                                    <label for="weapon1">武器1</label>
-                                    <div class="flex-group">
-                                        <select id="weapon1" v-model="equipments.weapon1.group" class="flex-item-1">
-                                            <option v-for="option in gameData.weaponOptions" :key="option.value"
-                                                :value="option.value">
-                                                {{ option.label }}
-                                            </option>
-                                        </select>
-                                        <input type="text" id="weapon1_name" v-model="equipments.weapon1.name"
-                                            :placeholder="gameData.placeholderTexts.weaponName" class="flex-item-2" />
-                                    </div>
-                                </div>
-                                <div class="equipment-item mb-12">
-                                    <label for="weapon2">武器2</label>
-                                    <div class="flex-group">
-                                        <select id="weapon2" v-model="equipments.weapon2.group" class="flex-item-1">
-                                            <option v-for="option in gameData.weaponOptions" :key="option.value"
-                                                :value="option.value">
-                                                {{ option.label }}
-                                            </option>
-                                        </select>
-                                        <input type="text" id="weapon2_name" v-model="equipments.weapon2.name"
-                                            :placeholder="gameData.placeholderTexts.weaponName" class="flex-item-2" />
-                                    </div>
-                                </div>
-                                <div class="equipment-item">
-                                    <label for="armor">防具</label>
-                                    <div class="flex-group">
-                                        <select id="armor" v-model="equipments.armor.group" class="flex-item-1">
-                                            <option v-for="option in gameData.armorOptions" :key="option.value"
-                                                :value="option.value">
-                                                {{ option.label }}
-                                            </option>
-                                        </select>
-                                        <input type="text" id="armor_name" v-model="equipments.armor.name"
-                                            :placeholder="gameData.placeholderTexts.armorName" class="flex-item-2" />
-                                    </div>
-                                </div>
+                                <equipment-item class="mb-12" label="武器1"
+                                    v-model:model-group="equipments.weapon1.group"
+                                    v-model:model-name="equipments.weapon1.name"
+                                    :options="gameData.weaponOptions"
+                                    :placeholder="gameData.placeholderTexts.weaponName">
+                                </equipment-item>
+                                <equipment-item class="mb-12" label="武器2"
+                                    v-model:model-group="equipments.weapon2.group"
+                                    v-model:model-name="equipments.weapon2.name"
+                                    :options="gameData.weaponOptions"
+                                    :placeholder="gameData.placeholderTexts.weaponName">
+                                </equipment-item>
+                                <equipment-item label="防具"
+                                    v-model:model-group="equipments.armor.group"
+                                    v-model:model-name="equipments.armor.name"
+                                    :options="gameData.armorOptions"
+                                    :placeholder="gameData.placeholderTexts.armorName">
+                                </equipment-item>
                             </div>
                         </div>
                     </div>

--- a/main.js
+++ b/main.js
@@ -301,4 +301,29 @@ const app = createApp({
     }
 });
 
+app.component('equipment-item', {
+    props: {
+        label: String,
+        modelGroup: String,
+        modelName: String,
+        options: Array,
+        placeholder: String
+    },
+    emits: ['update:modelGroup', 'update:modelName'],
+    template: `
+        <div class="equipment-item">
+            <label>{{ label }}</label>
+            <div class="flex-group">
+                <select class="flex-item-1" :value="modelGroup" @input="$emit('update:modelGroup', $event.target.value)">
+                    <option v-for="option in options" :key="option.value" :value="option.value">
+                        {{ option.label }}
+                    </option>
+                </select>
+                <input type="text" class="flex-item-2" :value="modelName" :placeholder="placeholder"
+                    @input="$emit('update:modelName', $event.target.value)" />
+            </div>
+        </div>
+    `
+});
+
 app.mount('#app');


### PR DESCRIPTION
## Summary
- create a new `equipment-item` Vue component
- replace repeated markup in the equipment section with the new component

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f9d4dada08326a14d47bbbc08b50f