### PR TITLE
Refactor clipboard feedback handler

### DIFF
--- a/main.js
+++ b/main.js
@@ -227,11 +227,15 @@ const app = createApp({
             }
         },
 
-        setOutputButtonSuccess() {
-            this.outputButtonText = this.gameData.uiMessages.outputButton.success;
+        showOutputButtonMessage(message) {
+            this.outputButtonText = message;
             setTimeout(() => {
                 this.outputButtonText = this.gameData.uiMessages.outputButton.default;
             }, 3000);
+        },
+
+        setOutputButtonSuccess() {
+            this.showOutputButtonMessage(this.gameData.uiMessages.outputButton.success);
         },
 
         fallbackCopyTextToClipboard(text) {
@@ -248,21 +252,12 @@ const app = createApp({
             try {
                 const successful = document.execCommand('copy');
                 if (successful) {
-                    this.outputButtonText = this.gameData.uiMessages.outputButton.successFallback;
-                    setTimeout(() => {
-                        this.outputButtonText = this.gameData.uiMessages.outputButton.default;
-                    }, 3000);
+                    this.showOutputButtonMessage(this.gameData.uiMessages.outputButton.successFallback);
                 } else {
-                    this.outputButtonText = this.gameData.uiMessages.outputButton.failed;
-                    setTimeout(() => {
-                        this.outputButtonText = this.gameData.uiMessages.outputButton.default;
-                    }, 3000);
+                    this.showOutputButtonMessage(this.gameData.uiMessages.outputButton.failed);
                 }
             } catch (err) {
-                this.outputButtonText = this.gameData.uiMessages.outputButton.error;
-                setTimeout(() => {
-                    this.outputButtonText = this.gameData.uiMessages.outputButton.default;
-                }, 3000);
+                this.showOutputButtonMessage(this.gameData.uiMessages.outputButton.error);
             }
 
             document.body.removeChild(textArea);


### PR DESCRIPTION
## Summary
- add `showOutputButtonMessage` helper
- use the helper for all clipboard success/error states

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_683f9eae11788326893a6017a97d4ab2