### PR TITLE
Add flashOutputButtonMessage helper

### DIFF
--- a/main.js
+++ b/main.js
@@ -227,11 +227,15 @@ const app = createApp({
             }
         },
 
-        setOutputButtonSuccess() {
-            this.outputButtonText = this.gameData.uiMessages.outputButton.success;
+        flashOutputButtonMessage(key) {
+            this.outputButtonText = this.gameData.uiMessages.outputButton[key];
             setTimeout(() => {
                 this.outputButtonText = this.gameData.uiMessages.outputButton.default;
             }, 3000);
+        },
+
+        setOutputButtonSuccess() {
+            this.flashOutputButtonMessage('success');
         },
 
         fallbackCopyTextToClipboard(text) {
@@ -248,21 +252,12 @@ const app = createApp({
             try {
                 const successful = document.execCommand('copy');
                 if (successful) {
-                    this.outputButtonText = this.gameData.uiMessages.outputButton.successFallback;
-                    setTimeout(() => {
-                        this.outputButtonText = this.gameData.uiMessages.outputButton.default;
-                    }, 3000);
+                    this.flashOutputButtonMessage('successFallback');
                 } else {
-                    this.outputButtonText = this.gameData.uiMessages.outputButton.failed;
-                    setTimeout(() => {
-                        this.outputButtonText = this.gameData.uiMessages.outputButton.default;
-                    }, 3000);
+                    this.flashOutputButtonMessage('failed');
                 }
             } catch (err) {
-                this.outputButtonText = this.gameData.uiMessages.outputButton.error;
-                setTimeout(() => {
-                    this.outputButtonText = this.gameData.uiMessages.outputButton.default;
-                }, 3000);
+                this.flashOutputButtonMessage('error');
             }
 
             document.body.removeChild(textArea);


### PR DESCRIPTION
## Summary
- centralize output button status messages with `flashOutputButtonMessage`
- use the new helper in `setOutputButtonSuccess` and `fallbackCopyTextToClipboard`

Preview: https://raw.githack.com/KTakahiro1729/AioniaCS/work/index.html

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fc99cd84c83269fd21d8d56c78bb8