### PR TITLE
Add weakness array helper and use across app

### DIFF
--- a/dataManager.js
+++ b/dataManager.js
@@ -91,9 +91,7 @@ class DataManager {
           ? externalData.linkCurrentToInitialScar
           : true,
         memo: externalData.character_memo || '',
-        weaknesses: Array(this.gameData.config.maxWeaknesses)
-          .fill(null)
-          .map(() => ({ text: '', acquired: '--' }))
+        weaknesses: createWeaknessArray(this.gameData.config.maxWeaknesses)
       },
       skills: [],
       specialSkills: [],
@@ -259,9 +257,7 @@ class DataManager {
     // キャラクターデータの正規化
     const defaultCharacter = {
       ...this.gameData.defaultCharacterData,
-      weaknesses: Array(this.gameData.config.maxWeaknesses)
-        .fill(null)
-        .map(() => ({ text: '', acquired: '--' }))
+      weaknesses: createWeaknessArray(this.gameData.config.maxWeaknesses)
     };
 
     const normalizedData = {

--- a/index.html
+++ b/index.html
@@ -335,6 +335,7 @@
     </div>
     <script src="cocofoliaExporter.js"></script>
     <script src="gameData.js"></script>
+    <script src="utils.js"></script>
     <script src="dataManager.js"></script>
     <script src="main.js"></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -2,9 +2,7 @@ const { createApp, watch, nextTick } = Vue;
 
 // Base character data copied from gameData with weaknesses initialized
 const baseChar = JSON.parse(JSON.stringify(window.AioniaGameData.defaultCharacterData));
-baseChar.weaknesses = Array(window.AioniaGameData.config.maxWeaknesses)
-    .fill(null)
-    .map(() => ({ text: '', acquired: '--' }));
+baseChar.weaknesses = createWeaknessArray(window.AioniaGameData.config.maxWeaknesses);
 
 const app = createApp({
     data() {

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,7 @@
+// Utility functions for Aionia CS
+function createWeaknessArray(max) {
+  return Array(max).fill(null).map(() => ({ text: '', acquired: '--' }));
+}
+
+// expose globally
+window.createWeaknessArray = createWeaknessArray;


### PR DESCRIPTION
## Summary
- add `utils.js` with `createWeaknessArray` utility
- initialize weakness array using the utility in `main.js`
- use the helper in `DataManager` when generating character data
- load the new helper script in `index.html`

Preview the updated site [here](https://raw.githack.com/KTakahiro1729/AioniaCS/work/index.html).


------
https://chatgpt.com/codex/tasks/task_e_683fe530aa3c83268731cac90dbd317b