### PR TITLE
Add Playwright end-to-end test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+test-results/

--- a/e2e/index.test.js
+++ b/e2e/index.test.js
@@ -1,0 +1,10 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+test('can input character name', async ({ page }) => {
+  const filePath = 'file://' + path.resolve(__dirname, '../index.html');
+  await page.goto(filePath);
+  const nameInput = page.locator('#name');
+  await nameInput.fill('テストキャラ');
+  await expect(nameInput).toHaveValue('テストキャラ');
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@playwright/test": "^1.52.0",
         "eslint": "^9.28.0",
         "eslint-plugin-vue": "^10.1.0",
         "htmlhint": "^1.4.0",
@@ -1320,6 +1321,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -4625,6 +4642,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -9,18 +9,22 @@
     "lint:css": "stylelint \"**/*.css\"",
     "lint:html": "htmlhint \"**/*.html\"",
     "test": "jest",
-    "e2e": "echo \"No e2e tests yet\""
+    "e2e": "playwright test"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "type": "commonjs",
   "devDependencies": {
+    "@playwright/test": "^1.52.0",
     "eslint": "^9.28.0",
     "eslint-plugin-vue": "^10.1.0",
     "htmlhint": "^1.4.0",
+    "jest": "^29.7.0",
     "stylelint": "^16.20.0",
-    "stylelint-config-standard": "^38.0.0",
-    "jest": "^29.7.0"
+    "stylelint-config-standard": "^38.0.0"
+  },
+  "jest": {
+    "testPathIgnorePatterns": ["<rootDir>/e2e/"]
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,5 @@
+const { defineConfig } = require('@playwright/test');
+module.exports = defineConfig({
+  testDir: './e2e',
+  use: { headless: true }
+});


### PR DESCRIPTION
## Summary
- set up Playwright with a basic test
- ignore Playwright test results
- run Playwright via `npm run e2e`

Preview: https://raw.githack.com/KTakahiro1729/AioniaCS/codex-playwright/index.html

------
https://chatgpt.com/codex/tasks/task_e_684007936f908326bcd423b3955647ea