### PR TITLE
Add unit tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,20 @@
 
 本リポジトリは **MIT License** の下で公開しています。
 公式とは関係のない非公式ツールです。
+
+## Development
+
+開発者向けには以下のコマンドを利用できます。
+
+1. 依存関係のインストール
+   ```bash
+   npm install
+   ```
+2. テストの実行
+   ```bash
+   npm test
+   ```
+3. Lint の実行（任意）
+   ```bash
+   npm run lint
+   ```

--- a/__tests__/cocofoliaExporter.test.js
+++ b/__tests__/cocofoliaExporter.test.js
@@ -1,0 +1,71 @@
+global.window = {};
+require('../cocofoliaExporter.js');
+
+const CocofoliaExporter = window.CocofoliaExporter;
+
+describe('CocofoliaExporter', () => {
+  let exporter;
+  beforeEach(() => {
+    exporter = new CocofoliaExporter();
+  });
+
+  test('buildCharacterBasicInfo returns expected lines', () => {
+    const character = {
+      name: 'Alice',
+      playerName: 'Bob',
+      species: 'human',
+      rareSpecies: '',
+      gender: '女性',
+      age: 20,
+      origin: '東京',
+      occupation: '学生',
+      faith: '',
+      height: '160cm',
+      weight: '50kg'
+    };
+    const lines = exporter.buildCharacterBasicInfo(character, { human: '人間' });
+    expect(lines[0]).toBe('名前：Alice（Bob）');
+    expect(lines[1]).toBe('種族：人間');
+  });
+
+  test('truncateCharacterMemo cuts string at punctuation', () => {
+    const memo = 'これはとても長い文章です。途中で切れます';
+    const truncated = exporter.truncateCharacterMemo(memo, 15);
+    expect(truncated).toBe('これはとても長い文章です。…');
+  });
+
+  test('buildCocofoliaCommands assembles commands', () => {
+    const character = { currentScar: 1 };
+    const skills = [
+      { name: '運動', checked: true, canHaveExperts: false, experts: [] },
+      { name: '防御', checked: true, canHaveExperts: false, experts: [] },
+      { name: '白兵', checked: true, canHaveExperts: true, experts: [{ value: '剣' }] }
+    ];
+    const equipments = { weapon1: { group: 'sword', name: '剣' }, weapon2: { group: '', name: '' } };
+    const commands = exporter.buildCocofoliaCommands(character, skills, equipments, { sword: '2d6' });
+    expect(commands).toContain('2d10 〈運動〉');
+    expect(commands).toContain('2d10 〈防御〉');
+    expect(commands).toContain('2d10+2 〈防御（防具）〉');
+    expect(commands).toContain('3d10 〈白兵：剣〉');
+    expect(commands).toContain('2d6 〈ダメージ判定（剣）〉');
+  });
+
+  test('generateCocofoliaData returns object with memo and commands', () => {
+    const data = {
+      character: { name: 'Alice', currentScar: 0, memo: '' , weaknesses: [], otherItems: '' },
+      skills: [],
+      specialSkills: [],
+      equipments: { weapon1: { group: '', name: '' }, weapon2: { group: '', name: '' }, armor: { group: '', name: '' } },
+      currentWeight: 0,
+      speciesLabelMap: { human: '人間' },
+      equipmentGroupLabelMap: {},
+      specialSkillData: {},
+      specialSkillsRequiringNote: [],
+      weaponDamage: {}
+    };
+    const result = exporter.generateCocofoliaData(data);
+    expect(result.kind).toBe('character');
+    expect(result.data.memo).toContain('名前：Alice');
+    expect(result.data.commands).toContain('ダメージチェック');
+  });
+});

--- a/__tests__/cocofoliaExporter.test.js
+++ b/__tests__/cocofoliaExporter.test.js
@@ -52,7 +52,7 @@ describe('CocofoliaExporter', () => {
 
   test('generateCocofoliaData returns object with memo and commands', () => {
     const data = {
-      character: { name: 'Alice', currentScar: 0, memo: '', weaknesses: [], otherItems: '' },
+      character: { name: 'ミーアナック', currentScar: 0, memo: '', weaknesses: [], otherItems: '' },
       skills: [],
       specialSkills: [],
       equipments: { weapon1: { group: '', name: '' }, weapon2: { group: '', name: '' }, armor: { group: '', name: '' } },

--- a/__tests__/cocofoliaExporter.test.js
+++ b/__tests__/cocofoliaExporter.test.js
@@ -11,21 +11,21 @@ describe('CocofoliaExporter', () => {
 
   test('buildCharacterBasicInfo returns expected lines', () => {
     const character = {
-      name: 'Alice',
-      playerName: 'Bob',
-      species: 'human',
+      name: 'ミーアナック',
+      playerName: 'あろすてりっく',
+      species: 'therianthropy',
       rareSpecies: '',
-      gender: '女性',
-      age: 20,
-      origin: '東京',
-      occupation: '学生',
+      gender: '男性',
+      age: 30,
+      origin: 'ラウステン王国',
+      occupation: '商人',
       faith: '',
-      height: '160cm',
+      height: '120cm',
       weight: '50kg'
     };
-    const lines = exporter.buildCharacterBasicInfo(character, { human: '人間' });
-    expect(lines[0]).toBe('名前：Alice（Bob）');
-    expect(lines[1]).toBe('種族：人間');
+    const lines = exporter.buildCharacterBasicInfo(character, { therianthropy: '獣人' });
+    expect(lines[0]).toBe('名前：ミーアナック（あろすてりっく）');
+    expect(lines[1]).toBe('種族：獣人');
   });
 
   test('truncateCharacterMemo cuts string at punctuation', () => {
@@ -52,12 +52,12 @@ describe('CocofoliaExporter', () => {
 
   test('generateCocofoliaData returns object with memo and commands', () => {
     const data = {
-      character: { name: 'Alice', currentScar: 0, memo: '' , weaknesses: [], otherItems: '' },
+      character: { name: 'Alice', currentScar: 0, memo: '', weaknesses: [], otherItems: '' },
       skills: [],
       specialSkills: [],
       equipments: { weapon1: { group: '', name: '' }, weapon2: { group: '', name: '' }, armor: { group: '', name: '' } },
       currentWeight: 0,
-      speciesLabelMap: { human: '人間' },
+      speciesLabelMap: { therianthropy: '獣人' },
       equipmentGroupLabelMap: {},
       specialSkillData: {},
       specialSkillsRequiringNote: [],
@@ -65,7 +65,7 @@ describe('CocofoliaExporter', () => {
     };
     const result = exporter.generateCocofoliaData(data);
     expect(result.kind).toBe('character');
-    expect(result.data.memo).toContain('名前：Alice');
+    expect(result.data.memo).toContain('名前：ミーアナック');
     expect(result.data.commands).toContain('ダメージチェック');
   });
 });

--- a/__tests__/dataManager.test.js
+++ b/__tests__/dataManager.test.js
@@ -1,0 +1,49 @@
+// Set up global window object and load utilities
+global.window = {};
+require('../utils.js');
+require('../gameData.js');
+global.deepClone = window.deepClone;
+global.createWeaknessArray = window.createWeaknessArray;
+require('../dataManager.js');
+
+const DataManager = window.DataManager;
+const gameData = window.AioniaGameData;
+
+describe('DataManager', () => {
+  let dm;
+  beforeEach(() => {
+    dm = new DataManager(gameData);
+  });
+
+  test('convertExternalJsonToInternalFormat converts minimal data', () => {
+    const external = {
+      name: 'foo',
+      player: 'bar',
+      init_weakness1: 'fear',
+      weapon1_type: 'sword',
+      weapon1_name: 'blade',
+      history: [{ name: 'sess1', experiments: '2', stress: 'note' }]
+    };
+    const internal = dm.convertExternalJsonToInternalFormat(external);
+    expect(internal.character.name).toBe('foo');
+    expect(internal.character.playerName).toBe('bar');
+    expect(internal.character.weaknesses[0]).toEqual({ text: 'fear', acquired: '作成時' });
+    expect(internal.equipments.weapon1).toEqual({ group: 'sword', name: 'blade' });
+    expect(internal.histories[0]).toEqual({ sessionName: 'sess1', gotExperiments: 2, memo: 'note' });
+  });
+
+  test('_normalizeLoadedData fills defaults', () => {
+    const result = dm._normalizeLoadedData({});
+    expect(result.character.weaknesses).toHaveLength(gameData.config.maxWeaknesses);
+    result.character.weaknesses.forEach(w => {
+      expect(w).toEqual({ text: '', acquired: '--' });
+    });
+    expect(result.skills).toHaveLength(gameData.baseSkills.length);
+    expect(result.histories).toEqual([{ sessionName: '', gotExperiments: null, memo: '' }]);
+    expect(result.character.linkCurrentToInitialScar).toBe(true);
+  });
+
+  test('_normalizeHistoryData returns default when empty', () => {
+    expect(dm._normalizeHistoryData([])).toEqual([{ sessionName: '', gotExperiments: null, memo: '' }]);
+  });
+});

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,0 +1,21 @@
+require('../utils.js');
+
+describe('deepClone', () => {
+  test('returns a deep copy of objects', () => {
+    const original = { a: 1, b: { c: 2 } };
+    const clone = global.deepClone(original);
+    clone.b.c = 3;
+    expect(original.b.c).toBe(2);
+    expect(clone).not.toBe(original);
+  });
+});
+
+describe('createWeaknessArray', () => {
+  test('creates array of specified length with default objects', () => {
+    const arr = global.createWeaknessArray(3);
+    expect(arr).toHaveLength(3);
+    arr.forEach(item => {
+      expect(item).toEqual({ text: '', acquired: '--' });
+    });
+  });
+});

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { createApp, watch, nextTick } = Vue;
+const { createApp } = Vue;
 
 // Base character data copied from gameData with weaknesses initialized
 const baseChar = deepClone(window.AioniaGameData.defaultCharacterData);
@@ -253,6 +253,7 @@ const app = createApp({
                     this.flashOutputButtonMessage('failed');
                 }
             } catch (err) {
+                console.error(err);
                 this.flashOutputButtonMessage('error');
             }
 

--- a/utils.js
+++ b/utils.js
@@ -4,6 +4,7 @@
       try {
         return structuredClone(obj);
       } catch (e) {
+        console.error(e);
         // fallback below
       }
     }


### PR DESCRIPTION
## Summary
- write test suites for utils, DataManager and CocofoliaExporter
- document how to run tests
- log errors to satisfy lint rules

Preview: https://raw.githack.com/KTakahiro1729/AioniaCS/work/index.html

------
https://chatgpt.com/codex/tasks/task_e_684008116f00832694f10a2a48a1cce2