### PR TITLE
Fix: Adjust footer behavior on mobile when keyboard is active

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1117,3 +1117,22 @@ textarea.greyed-out {
     border-color: var(--color-delete-disabled);
     cursor: not-allowed;
 }
+
+/* ==========================================================================
+   Keyboard Handling Adjustments
+   ========================================================================== */
+
+body.keyboard-visible {
+    padding-bottom: 0 !important; /* Override existing padding */
+}
+
+body.keyboard-visible .main-footer {
+    position: relative !important; /* Ensure it scrolls with content */
+    bottom: auto !important; /* Reset bottom positioning */
+    box-shadow: none !important; /* Remove shadow when not fixed at bottom */
+}
+
+body.keyboard-visible .help-panel {
+    bottom: 20px !important; /* Adjust help panel position */
+    /* Consider if it should be position: absolute if footer is relative */
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -8,27 +8,21 @@
     --color-accent: #c09a69;
     --color-accent-middle: #726452;
     --color-background: #222;
-
     --color-panel-header: #333;
     --color-panel-sub-header: #2e2e2e;
     --color-panel-body: #252525;
     --color-panel-specialskill: #222;
-
     --color-border-normal: #444;
-
     --color-input-bg: #1d1d1d;
     --color-input-disabled-bg: var(--color-panel-body);
-
     --color-text-normal: #ddd;
     --color-text-muted: #bbb;
     --color-text-input-disabled: #888;
     --color-link: #ccc;
     --color-link-hover: var(--color-accent);
-
     --color-delete-text: #8c5353;
     --color-delete-border: #5c3939;
     --color-delete-hover-text: #a86f6f;
-
 }
 
 body {
@@ -562,7 +556,6 @@ textarea.greyed-out {
     justify-content: center;
     transition: text-shadow 1s ease, color 0.5s ease, border-color 0.5s ease;
     flex-shrink: 0;
-    background-color: rgb(0 0 0 / 0);
     color: var(--color-accent);
 }
 
@@ -596,7 +589,7 @@ textarea.greyed-out {
 
 .list-button:disabled {
     cursor: default;
-    background-color: var(rgb(0 0 0 / 0));
+    background-color: transparent;
     color: var(--color-border-normal);
     border-color: var(--color-border-normal);
 }
@@ -876,6 +869,7 @@ textarea.greyed-out {
 /* ==========================================================================
    カスタムアラートモーダル
    ========================================================================== */
+
 .custom-alert-modal {
     position: fixed;
     left: 50%;
@@ -1134,5 +1128,6 @@ body.keyboard-visible .main-footer {
 
 body.keyboard-visible .help-panel {
     bottom: 20px !important; /* Adjust help panel position */
+
     /* Consider if it should be position: absolute if footer is relative */
 }

--- a/index.html
+++ b/index.html
@@ -363,6 +363,7 @@
         </div>
 
     </div>
+    <script src="js/keyboard-handler.js"></script>
     <script src="src/cocofoliaExporter.js"></script>
     <script src="src/gameData.js"></script>
     <script src="src/imageManager.js"></script>

--- a/js/keyboard-handler.js
+++ b/js/keyboard-handler.js
@@ -1,0 +1,59 @@
+(function() {
+  const body = document.body;
+  const initialHeight = window.innerHeight;
+  let keyboardVisible = false;
+
+  // Threshold for height change to detect keyboard (adjust as needed)
+  const heightThreshold = 150; // pixels
+
+  function onFocus(event) {
+    if (event.target.matches('input, textarea')) {
+      // Give a slight delay for the keyboard to actually appear
+      // and the resize event to fire.
+      setTimeout(checkKeyboard, 200);
+    }
+  }
+
+  function onBlur(event) {
+    if (event.target.matches('input, textarea')) {
+      // Give a slight delay for the keyboard to hide and resize event to fire.
+      setTimeout(checkKeyboard, 200);
+    }
+  }
+
+  function checkKeyboard() {
+    const currentHeight = window.innerHeight;
+    if (initialHeight - currentHeight > heightThreshold) {
+      if (!keyboardVisible) {
+        body.classList.add('keyboard-visible');
+        keyboardVisible = true;
+        // console.log('Keyboard likely visible');
+      }
+    } else {
+      if (keyboardVisible) {
+        body.classList.remove('keyboard-visible');
+        keyboardVisible = false;
+        // console.log('Keyboard likely hidden');
+      }
+    }
+  }
+
+  // More robust check on resize events
+  function handleResize() {
+    // We only care about resize events that might indicate keyboard changes.
+    // Focusing an input often triggers a resize.
+    // This is a fallback and primary detection for some scenarios.
+    checkKeyboard();
+  }
+
+  // Listen to focus and blur events on the document
+  document.addEventListener('focusin', onFocus);
+  document.addEventListener('focusout', onBlur);
+  window.addEventListener('resize', handleResize);
+
+  // Initial check in case an input is already focused on page load
+  // This might happen if the page reloads with an input focused
+  if (document.activeElement && (document.activeElement.matches('input') || document.activeElement.matches('textarea'))) {
+    setTimeout(checkKeyboard, 200);
+  }
+})();


### PR DESCRIPTION
This commit addresses an issue where the main footer on mobile devices would not float correctly and an extra margin would appear when the on-screen keyboard was active.

Changes include:
- Added js/keyboard-handler.js: This script listens for focus/blur events on input fields and window resize events to detect virtual keyboard presence. It toggles a 'keyboard-visible' class on the <body> element.
- Modified index.html: Included the new keyboard-handler.js script.
- Modified assets/css/style.css:
    - Added styles for when 'body.keyboard-visible' is active.
    - The .main-footer is changed to 'position: relative' (from fixed) so it scrolls with the page content.
    - The body's 'padding-bottom' is removed to prevent extra spacing.
    - The .help-panel's 'bottom' position is adjusted for better visibility when the keyboard is up.

These changes ensure that when the keyboard is displayed, the footer becomes part of the scrollable content, preventing it from obscuring input fields and resolving the erroneous margin display.