### PR TITLE
Remove margin utility classes and update style guide

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,0 +1,5 @@
+# Style Guide
+
+This project prefers component-based or BEM-style classes for styling. Avoid using utility classes such as `mb-*`, `mt-*`, or `mr-*` for margins. Instead, define or extend component classes when spacing is needed, or apply inline styles for single-use cases.
+
+The goal is to keep CSS maintainable and descriptive, so class names should reflect the component they style.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -272,31 +272,6 @@ textarea.greyed-out {
     flex: 2;
 }
 
-/* マージン */
-.mb-25 {
-    margin-bottom: 25px;
-}
-
-.mb-15 {
-    margin-bottom: 15px;
-}
-
-.mb-12 {
-    margin-bottom: 12px;
-}
-
-.mt-6 {
-    margin-top: 6px;
-}
-
-.mr-8 {
-    margin-right: 8px;
-}
-
-.mr-4 {
-    margin-right: 4px;
-}
-
 /* 表示制御 */
 .block-label {
     display: block;
@@ -382,7 +357,16 @@ textarea.greyed-out {
     margin-bottom: 0;
 }
 
+/* 傷痕入力フィールド */
+.scar-section__current-input {
+    margin-top: 6px;
+}
+
 /* 装備品セクション */
+.equipment-wrapper {
+    margin-bottom: 15px;
+}
+
 .equipment-container {
     display: flex;
     flex-wrap: wrap;

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
                                 </div>
                                 <input type="number" id="current_scar" v-model.number="character.currentScar"
                                     @input="handleCurrentScarInput"
-                                    :class="{'greyed-out': character.linkCurrentToInitialScar}" min="0" class="mt-6">
+                                    :class="{'greyed-out': character.linkCurrentToInitialScar}" min="0" class="scar-section__current-input">
                             </div>
                             <div class="info-item info-item--double">
                                 <label for="initial_scar">初期値</label>
@@ -232,10 +232,10 @@
             <div id="items_section" class="items">
                 <div class="box-title">所持品</div>
                 <div class="box-content">
-                    <div class="mb-15">
+                    <div class="equipment-wrapper">
                         <div class="equipment-container">
                             <div class="equipment-section">
-                                <div class="equipment-item mb-12">
+                                <div class="equipment-item">
                                     <label for="weapon1">武器1</label>
                                     <div class="flex-group">
                                         <select id="weapon1" v-model="equipments.weapon1.group" class="flex-item-1">
@@ -248,7 +248,7 @@
                                             :placeholder="gameData.placeholderTexts.weaponName" class="flex-item-2" />
                                     </div>
                                 </div>
-                                <div class="equipment-item mb-12">
+                                <div class="equipment-item">
                                     <label for="weapon2">武器2</label>
                                     <div class="flex-group">
                                         <select id="weapon2" v-model="equipments.weapon2.group" class="flex-item-1">


### PR DESCRIPTION
## Summary
- clean up margin utilities from CSS
- update markup to use component classes for margins
- document styling approach in STYLE_GUIDE.md

[Preview link](https://raw.githack.com/KTakahiro1729/AioniaCS/work/index.html)

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*

------
https://chatgpt.com/codex/tasks/task_e_6840eb09670083268a499e582e52926e