### PR TITLE
Fix help popup width

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -793,8 +793,7 @@ textarea.greyed-out {
     border-radius: 4px;
     box-shadow: 0 5px 15px rgb(0 0 0 / 50%);
     z-index: 1000;
-    max-width: 90%;
-    width: 420px;
+    width: min(420px, calc(100% - 40px));
     font-size: 0.9em;
     color: var(--color-text-normal);
 }
@@ -931,10 +930,6 @@ textarea.greyed-out {
         width: 100%;
     }
 
-    .help-panel {
-        width: calc(100% - 40px);
-        max-width: none;
-    }
 
     .info-row {
         flex-direction: column;


### PR DESCRIPTION
## Summary
- adjust help popup width with `min()` to fit narrow screens

Preview: https://raw.githack.com/KTakahiro1729/AioniaCS/work/index.html

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: Error: Download failed)*

------
https://chatgpt.com/codex/tasks/task_e_6840f8fab01883269b75383ef85905c8