### PR TITLE
Refactor: Unify adventure log terminology in HTML and CSS

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -107,7 +107,7 @@ body {
     grid-area: memo;
 }
 
-.session-history {
+.adventure-log-section {
     grid-area: history;
 }
 
@@ -931,7 +931,7 @@ textarea.greyed-out {
         gap: 20px;
     }
 
-    .session-history .history-item-inputs {
+    .adventure-log-section .history-item-inputs {
         flex-flow: row nowrap;
     }
 

--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@
                 </div>
             </div>
 
-            <div id="adventure_log_section" class="session-history">
+            <div id="adventure_log_section" class="adventure-log-section">
                 <div class="box-title">冒険の記録</div>
                 <div class="box-content">
                     <div class="base-list-header">


### PR DESCRIPTION
The terms "session-history" (as a CSS class) and "adventure_log_section" (as an HTML ID) were used for the same UI element, causing inconsistency. Your user-facing title for this section is "冒険の記録" (Adventure Log).

This commit aligns these terms by:
1. Changing the CSS class in `index.html` from `session-history` to `adventure-log-section`.
2. Updating the corresponding CSS selectors in `assets/css/style.css` from `.session-history` to `.adventure-log-section`.

These changes improve code clarity and consistency. Internal JavaScript data structures (e.g., the `histories` variable and its `sessionName` property) remain unchanged to maintain backward compatibility with saved data and limit the scope of this refactor.