### PR TITLE
Refactor list item styling and remove custom-list-item class

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -416,13 +416,8 @@ textarea.greyed-out {
    ========================================================================== */
 
 .weakness-list .base-list-item {
-  /* border-bottom and padding are handled by custom-list-item */
   font-size: 0.9em;
   align-items: center;
-}
-
-.weakness-list .base-list-item:last-child {
-  /* padding-bottom is handled by custom-list-item */
 }
 
 .weakness-labels-header {
@@ -498,8 +493,7 @@ textarea.greyed-out {
   display: flex;
   align-items: flex-start;
   gap: 5px;
-
-  /* margin-bottom will be handled by custom-list-item or specific list item styles */
+  margin-bottom: 8px;
 }
 
 .base-list-header {
@@ -520,20 +514,8 @@ textarea.greyed-out {
   color: var(--color-text-muted);
 }
 
-.base-list-item:last-of-type {
-  /* border-bottom is handled by custom-list-item or specific list item styles */
-}
-
 .base-list-item .delete-button-wrapper {
   margin-top: 4px;
-}
-
-.custom-list-item {
-  /* Add custom styling here, for example: */
-  padding: 10px;
-  border: 1px solid var(--color-border-normal);
-  margin-bottom: 10px;
-  border-radius: 4px;
 }
 
 .expert-list {

--- a/index.html
+++ b/index.html
@@ -234,7 +234,7 @@
                 <li
                   v-for="(weakness, index) in character.weaknesses"
                   :key="index"
-                  class="base-list-item custom-list-item"
+                  class="base-list-item"
                 >
                   <div class="flex-weakness-number">{{ index + 1 }}</div>
                   <div class="flex-weakness-text">
@@ -276,7 +276,7 @@
                   <li
                     v-for="(expert, expIndex) in skill.experts"
                     :key="expIndex"
-                    class="base-list-item custom-list-item"
+                    class="base-list-item"
                   >
                     <div class="delete-button-wrapper">
                       <button
@@ -319,7 +319,7 @@
               <li
                 v-for="(specialSkill, index) in specialSkills"
                 :key="index"
-                class="base-list-item special-skill-item custom-list-item"
+                class="base-list-item special-skill-item"
               >
                 <div class="delete-button-wrapper">
                   <button
@@ -514,7 +514,7 @@
               <li
                 v-for="(history, index) in histories"
                 :key="index"
-                class="base-list-item custom-list-item"
+                class="base-list-item"
               >
                 <div class="delete-button-wrapper">
                   <button


### PR DESCRIPTION
This commit refactors the styling of list items by removing the `custom-list-item` class and adjusting the base list item styles. This simplifies the CSS and improves consistency across different list types.  Specifically, it removes redundant styling and ensures proper spacing for list items.