### PR TITLE
Fix jest test environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@babel/preset-env": "^7.24.7",
         "@playwright/test": "^1.52.0",
         "@vitejs/plugin-vue": "^5.2.3",
+        "babel-jest": "^29.7.0",
         "cross-env": "^7.0.3",
         "eslint": "^9.28.0",
         "eslint-plugin-vue": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:js": "eslint src/ tests/ --ext .js",
     "lint:css": "stylelint \"**/*.css\"",
     "lint:html": "htmlhint \"**/*.html\"",
-    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "jest",
     "e2e": "playwright test",
     "pree2e": "playwright install",
     "prepare": "husky"
@@ -31,6 +31,7 @@
     "htmlhint": "^1.4.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
+    "babel-jest": "^29.7.0",
     "lint-staged": "^16.1.0",
     "prettier": "^3.5.3",
     "stylelint": "^16.20.0",
@@ -44,7 +45,13 @@
     "roots": [
       "<rootDir>/tests/unit"
     ],
-    "testEnvironment": "jsdom"
+    "testEnvironment": "jsdom",
+    "transform": {
+      "^.+\\.js$": "babel-jest"
+    },
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
+    }
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
Updated Jest configuration to use `babel-jest` and removed `--experimental-vm-modules` so that unit tests run successfully. [Preview link](https://raw.githack.com/KTakahiro1729/AioniaCS/work/index.html)

------
https://chatgpt.com/codex/tasks/task_e_684850d8ac788326aec1700ce345ce1d