### PR TITLE
Fix e2e server target and tweak Playwright speed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,7 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - name: Run e2e tests
-        run: |
-          npx vite dev --base / &
-          npx wait-on http://localhost:5173/ --timeout 60000 && npm run e2e
+        run: npm run e2e
 
   deploy_production:
     name: Deploy to Production

--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -2,6 +2,7 @@ const { defineConfig } = require('@playwright/test');
 
 module.exports = defineConfig({
   testDir: './tests/e2e',
+  workers: process.env.CI ? 2 : undefined,
   use: {
     headless: true,
     baseURL: 'http://localhost:4173/AioniaCS/'

--- a/tests/e2e/index.test.cjs
+++ b/tests/e2e/index.test.cjs
@@ -1,7 +1,7 @@
 const { test, expect } = require("@playwright/test");
 const path = require("path");
 
-const INDEX_HTML_PATH = "http://localhost:4173/AioniaCS/";
+const INDEX_HTML_PATH = "/";
 const SAMPLE_IMAGE_PATH = path.resolve(__dirname, "../fixtures/sample.png");
 const SAMPLE_IMAGE_PATH_2 = path.resolve(__dirname, "../fixtures/sample2.png"); // Assume another sample image for multi-image tests
 const TEST_ZIP_PATH = path.resolve(__dirname, "../fixtures/test_char.zip");


### PR DESCRIPTION
## Summary
- fix e2e test server URL handling
- run Playwright directly in CI
- use two workers in CI to speed up runs

Preview: https://raw.githack.com/KTakahiro1729/AioniaCS/fix-e2e-tests/index.html

------
https://chatgpt.com/codex/tasks/task_e_6848ee9bc4f883268e49ae6504098044