### PR TITLE
refactor: extract items section

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,8 @@ import { CocofoliaExporter } from './services/cocofoliaExporter.js';
 import { ImageManager } from './services/imageManager.js';
 import { GoogleDriveManager } from './services/googleDriveManager.js';
 import { deepClone, createWeaknessArray } from './utils/utils.js';
+import ItemsSection from './components/sections/ItemsSection.vue';
+import { useEquipmentManagement } from './composables/features/useEquipmentManagement.js';
 
 // --- Template Refs ---
 // These refs will be linked to elements in the template via `ref="..."`.
@@ -132,15 +134,7 @@ const currentExperiencePoints = computed(() => {
   return skillExp + expertExp + specialSkillExp;
 });
 
-const currentWeight = computed(() => {
-  const weaponWeights = AioniaGameData.equipmentWeights.weapon;
-  const armorWeights = AioniaGameData.equipmentWeights.armor;
-  let weight = 0;
-  weight += weaponWeights[equipments.weapon1.group] || 0;
-  weight += weaponWeights[equipments.weapon2.group] || 0;
-  weight += armorWeights[equipments.armor.group] || 0;
-  return weight;
-});
+const { currentWeight } = useEquipmentManagement(ref(equipments));
 
 const experienceStatusClass = computed(() =>
   currentExperiencePoints.value > maxExperiencePoints.value
@@ -1047,48 +1041,10 @@ onBeforeUnmount(() => {
             </div>
         </div>
     </div>
-    <div id="items_section" class="items">
-        <div class="box-title">所持品</div>
-        <div class="box-content">
-            <div class="equipment-wrapper">
-              <div class="equipment-container">
-                <div class="equipment-section">
-                  <div class="equipment-item">
-                    <label for="weapon1">武器1</label>
-                    <div class="flex-group">
-                      <select id="weapon1" v-model="equipments.weapon1.group" class="flex-item-1">
-                        <option v-for="option in AioniaGameData.weaponOptions" :key="option.value" :value="option.value">{{ option.label }}</option>
-                      </select>
-                      <input type="text" id="weapon1_name" v-model="equipments.weapon1.name" :placeholder="AioniaGameData.placeholderTexts.weaponName" class="flex-item-2"/>
-                    </div>
-                  </div>
-                  <div class="equipment-item">
-                    <label for="weapon2">武器2</label>
-                    <div class="flex-group">
-                      <select id="weapon2" v-model="equipments.weapon2.group" class="flex-item-1">
-                        <option v-for="option in AioniaGameData.weaponOptions" :key="option.value" :value="option.value">{{ option.label }}</option>
-                      </select>
-                      <input type="text" id="weapon2_name" v-model="equipments.weapon2.name" :placeholder="AioniaGameData.placeholderTexts.weaponName" class="flex-item-2"/>
-                    </div>
-                  </div>
-                  <div class="equipment-item">
-                    <label for="armor">防具</label>
-                    <div class="flex-group">
-                      <select id="armor" v-model="equipments.armor.group" class="flex-item-1">
-                        <option v-for="option in AioniaGameData.armorOptions" :key="option.value" :value="option.value">{{ option.label }}</option>
-                      </select>
-                      <input type="text" id="armor_name" v-model="equipments.armor.name" :placeholder="AioniaGameData.placeholderTexts.armorName" class="flex-item-2"/>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div>
-              <label for="other_items" class="block-label">その他所持品</label>
-              <textarea id="other_items" class="items-textarea" v-model="character.otherItems"></textarea>
-            </div>
-        </div>
-    </div>
+    <ItemsSection
+      v-model:equipments="equipments"
+      v-model:otherItems="character.otherItems"
+    />
     <div id="character_memo" class="character-memo">
         <div class="box-title">キャラクターメモ</div>
         <div class="box-content">

--- a/src/components/sections/ItemsSection.vue
+++ b/src/components/sections/ItemsSection.vue
@@ -1,0 +1,123 @@
+<template>
+  <div id="items_section" class="items">
+    <div class="box-title">所持品</div>
+    <div class="box-content">
+      <div class="equipment-wrapper">
+        <div class="equipment-container">
+          <div class="equipment-section">
+            <div class="equipment-item">
+              <label for="weapon1">武器1</label>
+              <div class="flex-group">
+                <select id="weapon1" v-model="localEquipments.weapon1.group" class="flex-item-1">
+                  <option
+                    v-for="option in gameData.weaponOptions"
+                    :key="option.value"
+                    :value="option.value"
+                  >{{ option.label }}</option>
+                </select>
+                <input
+                  type="text"
+                  id="weapon1_name"
+                  v-model="localEquipments.weapon1.name"
+                  :placeholder="gameData.placeholderTexts.weaponName"
+                  class="flex-item-2"
+                />
+              </div>
+            </div>
+            <div class="equipment-item">
+              <label for="weapon2">武器2</label>
+              <div class="flex-group">
+                <select id="weapon2" v-model="localEquipments.weapon2.group" class="flex-item-1">
+                  <option
+                    v-for="option in gameData.weaponOptions"
+                    :key="option.value"
+                    :value="option.value"
+                  >{{ option.label }}</option>
+                </select>
+                <input
+                  type="text"
+                  id="weapon2_name"
+                  v-model="localEquipments.weapon2.name"
+                  :placeholder="gameData.placeholderTexts.weaponName"
+                  class="flex-item-2"
+                />
+              </div>
+            </div>
+            <div class="equipment-item">
+              <label for="armor">防具</label>
+              <div class="flex-group">
+                <select id="armor" v-model="localEquipments.armor.group" class="flex-item-1">
+                  <option
+                    v-for="option in gameData.armorOptions"
+                    :key="option.value"
+                    :value="option.value"
+                  >{{ option.label }}</option>
+                </select>
+                <input
+                  type="text"
+                  id="armor_name"
+                  v-model="localEquipments.armor.name"
+                  :placeholder="gameData.placeholderTexts.armorName"
+                  class="flex-item-2"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div>
+        <label for="other_items" class="block-label">その他所持品</label>
+        <textarea id="other_items" class="items-textarea" v-model="localOtherItems"></textarea>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { watch, reactive, ref } from 'vue'
+import { AioniaGameData as gameData } from '../../data/gameData.js'
+
+const props = defineProps({
+  equipments: Object,
+  otherItems: String
+})
+
+const emit = defineEmits(['update:equipments', 'update:otherItems'])
+
+const localEquipments = reactive({
+  weapon1: { group: '', name: '' },
+  weapon2: { group: '', name: '' },
+  armor: { group: '', name: '' }
+})
+
+Object.assign(localEquipments, props.equipments)
+const localOtherItems = ref(props.otherItems)
+
+watch(
+  () => props.equipments,
+  (val) => {
+    Object.assign(localEquipments, val)
+  }
+)
+watch(
+  () => props.otherItems,
+  (val) => {
+    localOtherItems.value = val
+  }
+)
+
+watch(
+  localEquipments,
+  (val) => {
+    emit('update:equipments', val)
+  },
+  { deep: true }
+)
+
+watch(
+  localOtherItems,
+  (val) => {
+    emit('update:otherItems', val)
+  }
+)
+</script>

--- a/src/composables/features/useEquipmentManagement.js
+++ b/src/composables/features/useEquipmentManagement.js
@@ -1,0 +1,16 @@
+import { computed } from "vue";
+import { AioniaGameData } from "../../data/gameData.js";
+
+export function useEquipmentManagement(equipmentsRef) {
+  const currentWeight = computed(() => {
+    const weaponWeights = AioniaGameData.equipmentWeights.weapon;
+    const armorWeights = AioniaGameData.equipmentWeights.armor;
+    let weight = 0;
+    weight += weaponWeights[equipmentsRef.value.weapon1.group] || 0;
+    weight += weaponWeights[equipmentsRef.value.weapon2.group] || 0;
+    weight += armorWeights[equipmentsRef.value.armor.group] || 0;
+    return weight;
+  });
+
+  return { currentWeight };
+}


### PR DESCRIPTION
## Summary
- move weight calc to `useEquipmentManagement`
- cut out Items section from `App.vue` into new component
- use new component and composable in `App.vue`

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_6849517d3188832689811670d7134e7d