### PR TITLE
Refactor skills section

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,7 @@ import { CocofoliaExporter } from './services/cocofoliaExporter.js';
 import { ImageManager } from './services/imageManager.js';
 import { GoogleDriveManager } from './services/googleDriveManager.js';
 import { deepClone, createWeaknessArray } from './utils/utils.js';
+import SkillsSection from './components/sections/SkillsSection.vue';
 
 // --- Template Refs ---
 // These refs will be linked to elements in the template via `ref="..."`.
@@ -245,16 +246,6 @@ const removeSpecialSkill = (index) => _manageListItem({
   newItemFactory: () => ({ group: "", name: "", note: "", showNote: false }),
   hasContentChecker: hasSpecialSkillContent,
 });
-const addExpert = (skill) => {
-  if (skill.canHaveExperts) _manageListItem({ list: skill.experts, action: "add", newItemFactory: () => ({ value: "" }) });
-};
-const removeExpert = (skill, expertIndex) => _manageListItem({
-  list: skill.experts,
-  action: "remove",
-  index: expertIndex,
-  newItemFactory: () => ({ value: "" }),
-  hasContentChecker: (expert) => expert.value && expert.value.trim() !== "",
-});
 const addHistoryItem = () => _manageListItem({
   list: histories,
   action: "add",
@@ -267,8 +258,6 @@ const removeHistoryItem = (index) => _manageListItem({
   newItemFactory: () => ({ sessionName: "", gotExperiments: null, memo: "" }),
   hasContentChecker: hasHistoryContent,
 });
-
-const expertPlaceholder = (skill) => skill.checked ? AioniaGameData.placeholderTexts.expertSkill : AioniaGameData.placeholderTexts.expertSkillDisabled;
 const handleSpeciesChange = () => { if (character.species !== "other") character.rareSpecies = ""; };
 const availableSpecialSkillNames = (index) => specialSkills[index] ? (AioniaGameData.specialSkillData[specialSkills[index].group] || []) : [];
 const updateSpecialSkillOptions = (index) => {
@@ -944,47 +933,7 @@ onBeforeUnmount(() => {
       </div>
     </div>
 
-    <div id="skills" class="skills">
-      <div class="box-title">技能</div>
-      <ul class="skills-list box-content list-reset">
-        <li v-for="(skill) in skills" :key="skill.id" class="skill-list">
-          <div class="skill-header">
-            <input type="checkbox" :id="skill.id" v-model="skill.checked" />
-            <label :for="skill.id" class="skill-name">{{ skill.name }}</label>
-          </div>
-          <div v-if="skill.canHaveExperts && skill.checked" class="experts-section">
-            <ul class="expert-list list-reset">
-              <li v-for="(expert, expIndex) in skill.experts" :key="expIndex" class="base-list-item">
-                <div class="delete-button-wrapper">
-                  <button
-                    type="button"
-                    class="button-base list-button list-button--delete"
-                    @click="removeExpert(skill, expIndex)"
-                    :disabled="skill.experts.length <= 1 && expert.value===''"
-                    aria-label="専門技能を削除"
-                  >－</button>
-                </div>
-                <input
-                  type="text"
-                  v-model="expert.value"
-                  :placeholder="expertPlaceholder(skill)"
-                  :disabled="!skill.checked"
-                  class="flex-grow"
-                />
-              </li>
-            </ul>
-            <div class="add-button-container-left">
-              <button
-                type="button"
-                class="button-base list-button list-button--add"
-                @click="addExpert(skill)"
-                aria-label="専門技能を追加"
-              >＋</button>
-            </div>
-          </div>
-        </li>
-      </ul>
-    </div>
+    <SkillsSection v-model:skills="skills" />
 
     <div id="special_skills" class="special-skills">
         <div class="box-title">特技</div>

--- a/src/components/sections/SkillsSection.vue
+++ b/src/components/sections/SkillsSection.vue
@@ -1,0 +1,102 @@
+<template>
+  <div id="skills" class="skills">
+    <div class="box-title">技能</div>
+    <ul class="skills-list box-content list-reset">
+      <li v-for="(skill, index) in localSkills" :key="skill.id" class="skill-list">
+        <div class="skill-header">
+          <input type="checkbox" :id="skill.id" v-model="skill.checked" />
+          <label :for="skill.id" class="skill-name">{{ skill.name }}</label>
+        </div>
+        <div v-if="skill.canHaveExperts && skill.checked" class="experts-section">
+          <ul class="expert-list list-reset">
+            <li
+              v-for="(expert, expIndex) in skill.experts"
+              :key="expIndex"
+              class="base-list-item"
+            >
+              <div class="delete-button-wrapper">
+                <button
+                  type="button"
+                  class="button-base list-button list-button--delete"
+                  @click="removeExpert(index, expIndex)"
+                  :disabled="skill.experts.length <= 1 && expert.value === ''"
+                  aria-label="専門技能を削除"
+                >－</button>
+              </div>
+              <input
+                type="text"
+                v-model="expert.value"
+                :placeholder="expertPlaceholder(skill)"
+                :disabled="!skill.checked"
+                class="flex-grow"
+              />
+            </li>
+          </ul>
+          <div class="add-button-container-left">
+            <button
+              type="button"
+              class="button-base list-button list-button--add"
+              @click="addExpert(index)"
+              aria-label="専門技能を追加"
+            >＋</button>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+import { deepClone } from '../../utils/utils.js';
+import { useListManagement } from '../../composables/core/useListManagement.js';
+import { useSkillsManagement } from '../../composables/features/useSkillsManagement.js';
+
+const props = defineProps({
+  skills: {
+    type: Array,
+    required: true,
+  },
+});
+
+const emit = defineEmits(['update:skills']);
+const localSkills = ref(deepClone(props.skills));
+
+watch(
+  () => props.skills,
+  (val) => {
+    localSkills.value = deepClone(val);
+  },
+  { deep: true }
+);
+
+watch(
+  localSkills,
+  (val) => {
+    emit('update:skills', deepClone(val));
+  },
+  { deep: true }
+);
+
+const { addItem, removeItem } = useListManagement();
+const { expertPlaceholder } = useSkillsManagement();
+
+function addExpert(skillIndex) {
+  const skill = localSkills.value[skillIndex];
+  if (skill && skill.canHaveExperts) {
+    addItem(skill.experts, () => ({ value: '' }));
+  }
+}
+
+function removeExpert(skillIndex, expertIndex) {
+  const skill = localSkills.value[skillIndex];
+  if (skill) {
+    removeItem(
+      skill.experts,
+      expertIndex,
+      () => ({ value: '' }),
+      (exp) => exp.value && exp.value.trim() !== ''
+    );
+  }
+}
+</script>

--- a/src/composables/features/useSkillsManagement.js
+++ b/src/composables/features/useSkillsManagement.js
@@ -1,0 +1,12 @@
+import { AioniaGameData } from "../../data/gameData.js";
+
+export function useSkillsManagement() {
+  const expertPlaceholder = (skill) =>
+    skill.checked
+      ? AioniaGameData.placeholderTexts.expertSkill
+      : AioniaGameData.placeholderTexts.expertSkillDisabled;
+
+  return {
+    expertPlaceholder,
+  };
+}


### PR DESCRIPTION
## Summary
- add SkillsSection component for managing basic and expert skills
- move expert placeholder logic into useSkillsManagement composable
- integrate SkillsSection into App.vue and drop old expert methods

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_6849518e17e88326af13af974e7f088c