### PR TITLE
Refactor scar weakness section

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,8 @@ import { CocofoliaExporter } from './services/cocofoliaExporter.js';
 import { ImageManager } from './services/imageManager.js';
 import { GoogleDriveManager } from './services/googleDriveManager.js';
 import { deepClone, createWeaknessArray } from './utils/utils.js';
+import ScarWeaknessSection from './components/sections/ScarWeaknessSection.vue';
+import { useWeaknessManagement } from './composables/features/useWeaknessManagement.js';
 
 // --- Template Refs ---
 // These refs will be linked to elements in the template via `ref="..."`.
@@ -148,19 +150,7 @@ const experienceStatusClass = computed(() =>
     : 'status-display--experience-ok'
 );
 
-const sessionNamesForWeaknessDropdown = computed(() => {
-  const defaultOptions = [...AioniaGameData.weaknessAcquisitionOptions];
-  const sessionOptions = histories
-    .map((h) => h.sessionName)
-    .filter((name) => name && name.trim() !== '')
-    .map((name) => ({ value: name, text: name, disabled: false }));
-  const helpOption = {
-    value: 'help-text',
-    text: AioniaGameData.uiMessages.weaknessDropdownHelp,
-    disabled: true,
-  };
-  return defaultOptions.concat(sessionOptions, helpOption);
-});
+const { sessionNamesForWeaknessDropdown } = useWeaknessManagement(ref(histories));
 
 const canSignInToGoogle = computed(() => isGapiInitialized.value && isGisInitialized.value && !isSignedIn.value);
 const canOperateDrive = computed(() => isSignedIn.value && driveFolderId.value);
@@ -172,23 +162,6 @@ const toggleDriveMenu = () => {
   showDriveMenu.value = !showDriveMenu.value;
 };
 
-const handleCurrentScarInput = (event) => {
-  const enteredValue = parseInt(event.target.value, 10);
-  if (isNaN(enteredValue)) {
-    if (character.linkCurrentToInitialScar) {
-      nextTick(() => {
-        character.currentScar = character.initialScar;
-      });
-    }
-    return;
-  }
-  if (character.linkCurrentToInitialScar) {
-    if (enteredValue !== character.initialScar) {
-      character.linkCurrentToInitialScar = false;
-      character.currentScar = enteredValue;
-    }
-  }
-};
 
 const handleHelpIconMouseOver = () => {
   if (isDesktop.value && helpState.value === "closed") {
@@ -882,67 +855,10 @@ onBeforeUnmount(() => {
       </div>
     </div>
 
-    <div id="scar_weakness_section" class="scar-weakness">
-      <div class="box-title">傷痕と弱点</div>
-      <div class="box-content">
-        <div class="scar-section">
-          <div class="sub-box-title sub-box-title--scar">傷痕</div>
-          <div class="info-row">
-            <div class="info-item info-item--double">
-              <div class="link-checkbox-container">
-                <label for="current_scar" class="link-checkbox-main-label">現在値</label>
-                <input
-                  type="checkbox"
-                  id="link_current_to_initial_scar_checkbox"
-                  v-model="character.linkCurrentToInitialScar"
-                  class="link-checkbox"
-                />
-                <label for="link_current_to_initial_scar_checkbox" class="link-checkbox-label">連動</label>
-              </div>
-              <input
-                type="number"
-                id="current_scar"
-                v-model.number="character.currentScar"
-                @input="handleCurrentScarInput"
-                :class="{'greyed-out': character.linkCurrentToInitialScar}"
-                min="0"
-                class="scar-section__current-input"
-              />
-            </div>
-            <div class="info-item info-item--double">
-              <label for="initial_scar">初期値</label>
-              <input type="number" id="initial_scar" v-model.number="character.initialScar" min="0"/>
-            </div>
-          </div>
-        </div>
-        <div class="weakness-section">
-          <div class="sub-box-title sub-box-title--weakness">弱点</div>
-          <ul class="weakness-list list-reset">
-            <li class="base-list-header">
-              <div class="flex-weakness-number base-list-header-placeholder"></div>
-              <div class="flex-weakness-text"><label>弱点</label></div>
-              <div class="flex-weakness-acquired"><label>獲得</label></div>
-            </li>
-            <li v-for="(weakness, index) in character.weaknesses" :key="index" class="base-list-item">
-              <div class="flex-weakness-number">{{ index + 1 }}</div>
-              <div class="flex-weakness-text">
-                <input type="text" v-model="weakness.text" />
-              </div>
-              <div class="flex-weakness-acquired">
-                <select v-model="weakness.acquired">
-                  <option
-                    v-for="option in sessionNamesForWeaknessDropdown"
-                    :key="option.value"
-                    :value="option.value"
-                    :disabled="option.disabled"
-                  >{{ option.text }}</option>
-                </select>
-              </div>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
+    <ScarWeaknessSection
+      v-model:character="character"
+      :session-names="sessionNamesForWeaknessDropdown"
+    />
 
     <div id="skills" class="skills">
       <div class="box-title">技能</div>

--- a/src/components/sections/ScarWeaknessSection.vue
+++ b/src/components/sections/ScarWeaknessSection.vue
@@ -1,0 +1,90 @@
+<template>
+  <div id="scar_weakness_section" class="scar-weakness">
+    <div class="box-title">傷痕と弱点</div>
+    <div class="box-content">
+      <div class="scar-section">
+        <div class="sub-box-title sub-box-title--scar">傷痕</div>
+        <div class="info-row">
+          <div class="info-item info-item--double">
+            <div class="link-checkbox-container">
+              <label for="current_scar" class="link-checkbox-main-label">現在値</label>
+              <input
+                type="checkbox"
+                id="link_current_to_initial_scar_checkbox"
+                v-model="character.linkCurrentToInitialScar"
+                class="link-checkbox"
+              />
+              <label for="link_current_to_initial_scar_checkbox" class="link-checkbox-label">連動</label>
+            </div>
+            <input
+              type="number"
+              id="current_scar"
+              v-model.number="character.currentScar"
+              @input="handleCurrentScarInput"
+              :class="{ 'greyed-out': character.linkCurrentToInitialScar }"
+              min="0"
+              class="scar-section__current-input"
+            />
+          </div>
+          <div class="info-item info-item--double">
+            <label for="initial_scar">初期値</label>
+            <input type="number" id="initial_scar" v-model.number="character.initialScar" min="0" />
+          </div>
+        </div>
+      </div>
+      <div class="weakness-section">
+        <div class="sub-box-title sub-box-title--weakness">弱点</div>
+        <ul class="weakness-list list-reset">
+          <li class="base-list-header">
+            <div class="flex-weakness-number base-list-header-placeholder"></div>
+            <div class="flex-weakness-text"><label>弱点</label></div>
+            <div class="flex-weakness-acquired"><label>獲得</label></div>
+          </li>
+          <li v-for="(weakness, index) in character.weaknesses" :key="index" class="base-list-item">
+            <div class="flex-weakness-number">{{ index + 1 }}</div>
+            <div class="flex-weakness-text">
+              <input type="text" v-model="weakness.text" />
+            </div>
+            <div class="flex-weakness-acquired">
+              <select v-model="weakness.acquired">
+                <option
+                  v-for="option in sessionNames"
+                  :key="option.value"
+                  :value="option.value"
+                  :disabled="option.disabled"
+                >{{ option.text }}</option>
+              </select>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { watch } from 'vue';
+
+const props = defineProps({
+  character: { type: Object, required: true },
+  sessionNames: { type: Array, default: () => [] },
+});
+const emit = defineEmits(['update:character']);
+
+watch(
+  () => props.character,
+  (val) => emit('update:character', val),
+  { deep: true }
+);
+
+function handleCurrentScarInput(event) {
+  const enteredValue = parseInt(event.target.value, 10);
+  if (Number.isNaN(enteredValue)) return;
+  if (props.character.linkCurrentToInitialScar && enteredValue !== props.character.initialScar) {
+    props.character.linkCurrentToInitialScar = false;
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/composables/features/useWeaknessManagement.js
+++ b/src/composables/features/useWeaknessManagement.js
@@ -1,0 +1,24 @@
+import { computed, isRef } from "vue";
+import { AioniaGameData } from "../../data/gameData.js";
+
+export function useWeaknessManagement(histories) {
+  const historiesArray = computed(() =>
+    isRef(histories) ? histories.value : histories,
+  );
+
+  const sessionNamesForWeaknessDropdown = computed(() => {
+    const defaultOptions = [...AioniaGameData.weaknessAcquisitionOptions];
+    const sessionOptions = historiesArray.value
+      .map((h) => h.sessionName)
+      .filter((name) => name && name.trim() !== "")
+      .map((name) => ({ value: name, text: name, disabled: false }));
+    const helpOption = {
+      value: "help-text",
+      text: AioniaGameData.uiMessages.weaknessDropdownHelp,
+      disabled: true,
+    };
+    return defaultOptions.concat(sessionOptions, helpOption);
+  });
+
+  return { sessionNamesForWeaknessDropdown };
+}


### PR DESCRIPTION
## Summary
- create composable `useWeaknessManagement` for weakness dropdown options
- move scars and weaknesses UI to `ScarWeaknessSection` component
- use the new composable and component in `App.vue`

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_684951f05370832680dd4babc487c34d