### PR TITLE
Refactor character info into components

### DIFF
--- a/src/components/sections/CharacterBasicInfo.vue
+++ b/src/components/sections/CharacterBasicInfo.vue
@@ -1,0 +1,90 @@
+<template>
+  <div id="character_info" class="character-info">
+    <div class="box-title">基本情報</div>
+    <div class="box-content">
+      <CharacterImageDisplay v-model:images="character.images" />
+      <div class="info-row">
+        <div class="info-item info-item--double">
+          <label for="name">キャラクター名</label>
+          <input type="text" id="name" v-model="character.name" />
+        </div>
+        <div class="info-item info-item--double">
+          <label for="player_name">プレイヤー名</label>
+          <input type="text" id="player_name" v-model="character.playerName" />
+        </div>
+      </div>
+      <div class="info-row">
+        <div
+          class="info-item"
+          :class="{
+            'info-item--full': character.species !== 'other',
+            'info-item--double': character.species === 'other',
+          }"
+        >
+          <label for="species">種族</label>
+          <select id="species" v-model="character.species" @change="handleSpeciesChange">
+            <option
+              v-for="option in AioniaGameData.speciesOptions"
+              :key="option.value"
+              :value="option.value"
+              :disabled="option.disabled"
+            >{{ option.label }}</option>
+          </select>
+        </div>
+        <div class="info-item info-item--double" v-if="character.species === 'other'">
+          <label for="rare_species">種族名（希少人種）</label>
+          <input type="text" id="rare_species" v-model="character.rareSpecies" />
+        </div>
+      </div>
+      <div class="info-row">
+        <div class="info-item info-item--quadruple">
+          <label for="gender">性別</label>
+          <input type="text" id="gender" v-model="character.gender" />
+        </div>
+        <div class="info-item info-item--quadruple">
+          <label for="age">年齢</label>
+          <input type="number" id="age" v-model.number="character.age" min="0" />
+        </div>
+        <div class="info-item info-item--quadruple">
+          <label for="height">身長</label>
+          <input type="text" id="height" v-model="character.height" />
+        </div>
+        <div class="info-item info-item--quadruple">
+          <label for="weight_char">体重</label>
+          <input type="text" id="weight_char" v-model="character.weight" />
+        </div>
+      </div>
+      <div class="info-row">
+        <div class="info-item info-item--triple">
+          <label for="origin">出身地</label>
+          <input type="text" id="origin" v-model="character.origin" />
+        </div>
+        <div class="info-item info-item--triple">
+          <label for="occupation">職業</label>
+          <input type="text" id="occupation" v-model="character.occupation" />
+        </div>
+        <div class="info-item info-item--triple">
+          <label for="faith">信仰</label>
+          <input type="text" id="faith" v-model="character.faith" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import CharacterImageDisplay from '../ui/CharacterImageDisplay.vue';
+import { AioniaGameData } from '../../data/gameData.js';
+
+const character = defineModel('character');
+
+const handleSpeciesChange = () => {
+  if (character.value.species !== 'other') {
+    character.value.rareSpecies = '';
+  }
+};
+</script>
+
+<style scoped>
+</style>
+

--- a/src/components/ui/CharacterImageDisplay.vue
+++ b/src/components/ui/CharacterImageDisplay.vue
@@ -1,0 +1,133 @@
+<template>
+  <div class="character-image-container">
+    <div class="image-display-area">
+      <div class="image-display-wrapper" v-if="imagesInternal.length > 0">
+        <img
+          v-if="currentImageSrc"
+          :src="currentImageSrc"
+          class="character-image-display"
+          alt="Character Image"
+        />
+        <button
+          @click="previousImage"
+          class="button-base button-imagenav button-imagenav--prev"
+          :disabled="imagesInternal.length <= 1"
+          aria-label="前の画像"
+        >&lt;</button>
+        <button
+          @click="nextImage"
+          class="button-base button-imagenav button-imagenav--next"
+          :disabled="imagesInternal.length <= 1"
+          aria-label="次の画像"
+        >&gt;</button>
+        <div class="image-count-display">{{ currentImageIndex + 1 }} / {{ imagesInternal.length }}</div>
+      </div>
+      <div class="character-image-placeholder" v-else>No Image</div>
+    </div>
+    <div class="image-controls">
+      <input
+        type="file"
+        id="character_image_upload"
+        @change="handleImageUpload"
+        accept="image/*"
+        style="display: none"
+      />
+      <label for="character_image_upload" class="button-base imagefile-button imagefile-button--upload">画像を追加</label>
+      <button
+        :disabled="!currentImageSrc"
+        @click="removeCurrentImage"
+        class="button-base imagefile-button imagefile-button--delete"
+        aria-label="現在の画像を削除"
+      >削除</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue';
+import { ImageManager } from '../../services/imageManager.js';
+
+const props = defineProps({
+  images: {
+    type: Array,
+    default: () => [],
+  },
+});
+const emit = defineEmits(['update:images']);
+
+const imagesInternal = ref([...props.images]);
+
+watch(
+  () => props.images,
+  (val) => {
+    imagesInternal.value = [...val];
+  },
+  { deep: true }
+);
+
+watch(
+  imagesInternal,
+  (val) => {
+    emit('update:images', val);
+  },
+  { deep: true }
+);
+
+const currentImageIndex = ref(0);
+
+const currentImageSrc = computed(() => {
+  if (
+    imagesInternal.value.length > 0 &&
+    currentImageIndex.value >= 0 &&
+    currentImageIndex.value < imagesInternal.value.length
+  ) {
+    return imagesInternal.value[currentImageIndex.value];
+  }
+  return null;
+});
+
+const nextImage = () => {
+  if (imagesInternal.value.length > 0) {
+    currentImageIndex.value =
+      (currentImageIndex.value + 1) % imagesInternal.value.length;
+  }
+};
+
+const previousImage = () => {
+  if (imagesInternal.value.length > 0) {
+    currentImageIndex.value =
+      (currentImageIndex.value - 1 + imagesInternal.value.length) %
+      imagesInternal.value.length;
+  }
+};
+
+const removeCurrentImage = () => {
+  if (imagesInternal.value.length > 0 && currentImageIndex.value >= 0) {
+    imagesInternal.value.splice(currentImageIndex.value, 1);
+    if (imagesInternal.value.length === 0) {
+      currentImageIndex.value = -1;
+    } else if (currentImageIndex.value >= imagesInternal.value.length) {
+      currentImageIndex.value = imagesInternal.value.length - 1;
+    }
+  }
+};
+
+const handleImageUpload = async (event) => {
+  const file = event.target.files[0];
+  if (!file) return;
+  try {
+    const imageData = await ImageManager.loadImage(file);
+    imagesInternal.value.push(imageData);
+    currentImageIndex.value = imagesInternal.value.length - 1;
+  } catch (error) {
+    console.error('Error loading image:', error);
+    alert('画像の読み込みに失敗しました：' + error.message);
+  } finally {
+    event.target.value = null;
+  }
+};
+</script>
+
+<style scoped>
+</style>
+


### PR DESCRIPTION
## Summary
- create `CharacterImageDisplay` component for avatar management
- create `CharacterBasicInfo` section component using the image display
- simplify `App.vue` by using the new components and removing old image logic

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_6849520587608326a15a6144ebff1259