### PR TITLE
Integrate pinia stores

### DIFF
--- a/src/components/sections/AdventureLogSection.vue
+++ b/src/components/sections/AdventureLogSection.vue
@@ -14,10 +14,10 @@
       </div>
       <ul id="histories" class="list-reset">
         <BaseListItem
-          v-for="(history, index) in histories"
+          v-for="(history, index) in characterStore.histories"
           :key="index"
           :show-delete-button="true"
-          :can-delete="!(histories.length <= 1 && !hasHistoryContent(history))"
+          :can-delete="!(characterStore.histories.length <= 1 && !hasHistoryContent(history))"
           @delete-item="removeItem(index)"
         >
           <div class="flex-grow">
@@ -63,23 +63,20 @@
 <script setup>
 import BaseInput from '../common/BaseInput.vue';
 import BaseListItem from '../common/BaseListItem.vue';
+import { useCharacterStore } from '../../stores/characterStore.js';
 
-const props = defineProps({
-  histories: { type: Array, default: () => [] },
-});
-
-const emit = defineEmits(['add-item', 'remove-item', 'update:history']);
+const characterStore = useCharacterStore();
 
 function addItem() {
-  emit('add-item');
+  characterStore.addHistoryItem();
 }
 
 function removeItem(index) {
-  emit('remove-item', index);
+  characterStore.removeHistoryItem(index);
 }
 
 function updateField(index, field, value) {
-  emit('update:history', index, field, value);
+  characterStore.updateHistoryItem(index, field, value);
 }
 
 function hasHistoryContent(h) {

--- a/src/components/sections/CharacterBasicInfo.vue
+++ b/src/components/sections/CharacterBasicInfo.vue
@@ -2,27 +2,27 @@
   <div id="character_info" class="character-info">
     <div class="box-title">基本情報</div>
     <div class="box-content">
-      <CharacterImageDisplay v-model:images="character.images" />
+      <CharacterImageDisplay v-model:images="characterStore.character.images" />
       <div class="info-row">
         <div class="info-item info-item--double">
           <label for="name">キャラクター名</label>
-          <input type="text" id="name" v-model="character.name" />
+          <input type="text" id="name" v-model="characterStore.character.name" />
         </div>
         <div class="info-item info-item--double">
           <label for="player_name">プレイヤー名</label>
-          <input type="text" id="player_name" v-model="character.playerName" />
+          <input type="text" id="player_name" v-model="characterStore.character.playerName" />
         </div>
       </div>
       <div class="info-row">
         <div
           class="info-item"
           :class="{
-            'info-item--full': character.species !== 'other',
-            'info-item--double': character.species === 'other',
+            'info-item--full': characterStore.character.species !== 'other',
+            'info-item--double': characterStore.character.species === 'other',
           }"
         >
           <label for="species">種族</label>
-          <select id="species" v-model="character.species" @change="handleSpeciesChange">
+          <select id="species" v-model="characterStore.character.species" @change="handleSpeciesChange">
             <option
               v-for="option in AioniaGameData.speciesOptions"
               :key="option.value"
@@ -31,41 +31,41 @@
             >{{ option.label }}</option>
           </select>
         </div>
-        <div class="info-item info-item--double" v-if="character.species === 'other'">
+        <div class="info-item info-item--double" v-if="characterStore.character.species === 'other'">
           <label for="rare_species">種族名（希少人種）</label>
-          <input type="text" id="rare_species" v-model="character.rareSpecies" />
+          <input type="text" id="rare_species" v-model="characterStore.character.rareSpecies" />
         </div>
       </div>
       <div class="info-row">
         <div class="info-item info-item--quadruple">
           <label for="gender">性別</label>
-          <input type="text" id="gender" v-model="character.gender" />
+          <input type="text" id="gender" v-model="characterStore.character.gender" />
         </div>
         <div class="info-item info-item--quadruple">
           <label for="age">年齢</label>
-          <input type="number" id="age" v-model.number="character.age" min="0" />
+          <input type="number" id="age" v-model.number="characterStore.character.age" min="0" />
         </div>
         <div class="info-item info-item--quadruple">
           <label for="height">身長</label>
-          <input type="text" id="height" v-model="character.height" />
+          <input type="text" id="height" v-model="characterStore.character.height" />
         </div>
         <div class="info-item info-item--quadruple">
           <label for="weight_char">体重</label>
-          <input type="text" id="weight_char" v-model="character.weight" />
+          <input type="text" id="weight_char" v-model="characterStore.character.weight" />
         </div>
       </div>
       <div class="info-row">
         <div class="info-item info-item--triple">
           <label for="origin">出身地</label>
-          <input type="text" id="origin" v-model="character.origin" />
+          <input type="text" id="origin" v-model="characterStore.character.origin" />
         </div>
         <div class="info-item info-item--triple">
           <label for="occupation">職業</label>
-          <input type="text" id="occupation" v-model="character.occupation" />
+          <input type="text" id="occupation" v-model="characterStore.character.occupation" />
         </div>
         <div class="info-item info-item--triple">
           <label for="faith">信仰</label>
-          <input type="text" id="faith" v-model="character.faith" />
+          <input type="text" id="faith" v-model="characterStore.character.faith" />
         </div>
       </div>
     </div>
@@ -75,13 +75,12 @@
 <script setup>
 import CharacterImageDisplay from '../ui/CharacterImageDisplay.vue';
 import { AioniaGameData } from '../../data/gameData.js';
+import { useCharacterStore } from '../../stores/characterStore.js';
 
-const character = defineModel('character');
+const characterStore = useCharacterStore();
 
 const handleSpeciesChange = () => {
-  if (character.value.species !== 'other') {
-    character.value.rareSpecies = '';
-  }
+  characterStore.handleSpeciesChange();
 };
 </script>
 

--- a/src/components/sections/CharacterMemoSection.vue
+++ b/src/components/sections/CharacterMemoSection.vue
@@ -15,15 +15,14 @@
 <script setup>
 import { computed } from 'vue';
 import { AioniaGameData } from '../../data/gameData.js';
+import { useCharacterStore } from '../../stores/characterStore.js';
 
-const props = defineProps({
-  modelValue: { type: String, default: '' },
-});
-const emit = defineEmits(['update:modelValue']);
-
+const characterStore = useCharacterStore();
 const localValue = computed({
-  get: () => props.modelValue,
-  set: (val) => emit('update:modelValue', val),
+  get: () => characterStore.character.memo,
+  set: (val) => {
+    characterStore.character.memo = val;
+  },
 });
 </script>
 

--- a/src/components/sections/ItemsSection.vue
+++ b/src/components/sections/ItemsSection.vue
@@ -8,7 +8,7 @@
             <div class="equipment-item">
               <label for="weapon1">武器1</label>
               <div class="flex-group">
-                <select id="weapon1" v-model="localEquipments.weapon1.group" class="flex-item-1">
+                <select id="weapon1" v-model="characterStore.equipments.weapon1.group" class="flex-item-1">
                   <option
                     v-for="option in gameData.weaponOptions"
                     :key="option.value"
@@ -18,7 +18,7 @@
                 <input
                   type="text"
                   id="weapon1_name"
-                  v-model="localEquipments.weapon1.name"
+                  v-model="characterStore.equipments.weapon1.name"
                   :placeholder="gameData.placeholderTexts.weaponName"
                   class="flex-item-2"
                 />
@@ -27,7 +27,7 @@
             <div class="equipment-item">
               <label for="weapon2">武器2</label>
               <div class="flex-group">
-                <select id="weapon2" v-model="localEquipments.weapon2.group" class="flex-item-1">
+                <select id="weapon2" v-model="characterStore.equipments.weapon2.group" class="flex-item-1">
                   <option
                     v-for="option in gameData.weaponOptions"
                     :key="option.value"
@@ -37,7 +37,7 @@
                 <input
                   type="text"
                   id="weapon2_name"
-                  v-model="localEquipments.weapon2.name"
+                  v-model="characterStore.equipments.weapon2.name"
                   :placeholder="gameData.placeholderTexts.weaponName"
                   class="flex-item-2"
                 />
@@ -46,7 +46,7 @@
             <div class="equipment-item">
               <label for="armor">防具</label>
               <div class="flex-group">
-                <select id="armor" v-model="localEquipments.armor.group" class="flex-item-1">
+                <select id="armor" v-model="characterStore.equipments.armor.group" class="flex-item-1">
                   <option
                     v-for="option in gameData.armorOptions"
                     :key="option.value"
@@ -56,7 +56,7 @@
                 <input
                   type="text"
                   id="armor_name"
-                  v-model="localEquipments.armor.name"
+                  v-model="characterStore.equipments.armor.name"
                   :placeholder="gameData.placeholderTexts.armorName"
                   class="flex-item-2"
                 />
@@ -67,57 +67,15 @@
       </div>
       <div>
         <label for="other_items" class="block-label">その他所持品</label>
-        <textarea id="other_items" class="items-textarea" v-model="localOtherItems"></textarea>
+        <textarea id="other_items" class="items-textarea" v-model="characterStore.character.otherItems"></textarea>
       </div>
     </div>
   </div>
 </template>
 
 <script setup>
-import { watch, reactive, ref } from 'vue'
 import { AioniaGameData as gameData } from '../../data/gameData.js'
+import { useCharacterStore } from '../../stores/characterStore.js'
 
-const props = defineProps({
-  equipments: Object,
-  otherItems: String
-})
-
-const emit = defineEmits(['update:equipments', 'update:otherItems'])
-
-const localEquipments = reactive({
-  weapon1: { group: '', name: '' },
-  weapon2: { group: '', name: '' },
-  armor: { group: '', name: '' }
-})
-
-Object.assign(localEquipments, props.equipments)
-const localOtherItems = ref(props.otherItems)
-
-watch(
-  () => props.equipments,
-  (val) => {
-    Object.assign(localEquipments, val)
-  }
-)
-watch(
-  () => props.otherItems,
-  (val) => {
-    localOtherItems.value = val
-  }
-)
-
-watch(
-  localEquipments,
-  (val) => {
-    emit('update:equipments', val)
-  },
-  { deep: true }
-)
-
-watch(
-  localOtherItems,
-  (val) => {
-    emit('update:otherItems', val)
-  }
-)
+const characterStore = useCharacterStore()
 </script>

--- a/src/components/sections/ScarWeaknessSection.vue
+++ b/src/components/sections/ScarWeaknessSection.vue
@@ -11,7 +11,7 @@
               <input
                 type="checkbox"
                 id="link_current_to_initial_scar_checkbox"
-                v-model="character.linkCurrentToInitialScar"
+                v-model="characterStore.character.linkCurrentToInitialScar"
                 class="link-checkbox"
               />
               <label for="link_current_to_initial_scar_checkbox" class="link-checkbox-label">連動</label>
@@ -19,16 +19,16 @@
             <input
               type="number"
               id="current_scar"
-              v-model.number="character.currentScar"
+              v-model.number="characterStore.character.currentScar"
               @input="handleCurrentScarInput"
-              :class="{ 'greyed-out': character.linkCurrentToInitialScar }"
+              :class="{ 'greyed-out': characterStore.character.linkCurrentToInitialScar }"
               min="0"
               class="scar-section__current-input"
             />
           </div>
           <div class="info-item info-item--double">
             <label for="initial_scar">初期値</label>
-            <input type="number" id="initial_scar" v-model.number="character.initialScar" min="0" />
+            <input type="number" id="initial_scar" v-model.number="characterStore.character.initialScar" min="0" />
           </div>
         </div>
       </div>
@@ -40,7 +40,7 @@
             <div class="flex-weakness-text"><label>弱点</label></div>
             <div class="flex-weakness-acquired"><label>獲得</label></div>
           </li>
-          <li v-for="(weakness, index) in character.weaknesses" :key="index" class="base-list-item">
+          <li v-for="(weakness, index) in characterStore.character.weaknesses" :key="index" class="base-list-item">
             <div class="flex-weakness-number">{{ index + 1 }}</div>
             <div class="flex-weakness-text">
               <input type="text" v-model="weakness.text" />
@@ -63,25 +63,20 @@
 </template>
 
 <script setup>
-import { watch } from 'vue';
+import { computed } from 'vue';
+import { useCharacterStore } from '../../stores/characterStore.js';
 
-const props = defineProps({
-  character: { type: Object, required: true },
-  sessionNames: { type: Array, default: () => [] },
-});
-const emit = defineEmits(['update:character']);
-
-watch(
-  () => props.character,
-  (val) => emit('update:character', val),
-  { deep: true }
-);
+const characterStore = useCharacterStore();
+const sessionNames = computed(() => characterStore.sessionNamesForWeaknessDropdown);
 
 function handleCurrentScarInput(event) {
   const enteredValue = parseInt(event.target.value, 10);
   if (Number.isNaN(enteredValue)) return;
-  if (props.character.linkCurrentToInitialScar && enteredValue !== props.character.initialScar) {
-    props.character.linkCurrentToInitialScar = false;
+  if (
+    characterStore.character.linkCurrentToInitialScar &&
+    enteredValue !== characterStore.character.initialScar
+  ) {
+    characterStore.character.linkCurrentToInitialScar = false;
   }
 }
 </script>

--- a/src/components/sections/SkillsSection.vue
+++ b/src/components/sections/SkillsSection.vue
@@ -47,49 +47,25 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
-import { deepClone } from '../../utils/utils.js';
 import { useListManagement } from '../../composables/core/useListManagement.js';
 import { useSkillsManagement } from '../../composables/features/useSkillsManagement.js';
+import { useCharacterStore } from '../../stores/characterStore.js';
 
-const props = defineProps({
-  skills: {
-    type: Array,
-    required: true,
-  },
-});
-
-const emit = defineEmits(['update:skills']);
-const localSkills = ref(deepClone(props.skills));
-
-watch(
-  () => props.skills,
-  (val) => {
-    localSkills.value = deepClone(val);
-  },
-  { deep: true }
-);
-
-watch(
-  localSkills,
-  (val) => {
-    emit('update:skills', deepClone(val));
-  },
-  { deep: true }
-);
+const characterStore = useCharacterStore();
+const localSkills = characterStore.skills;
 
 const { addItem, removeItem } = useListManagement();
 const { expertPlaceholder } = useSkillsManagement();
 
 function addExpert(skillIndex) {
-  const skill = localSkills.value[skillIndex];
+  const skill = localSkills[skillIndex];
   if (skill && skill.canHaveExperts) {
     addItem(skill.experts, () => ({ value: '' }));
   }
 }
 
 function removeExpert(skillIndex, expertIndex) {
-  const skill = localSkills.value[skillIndex];
+  const skill = localSkills[skillIndex];
   if (skill) {
     removeItem(
       skill.experts,

--- a/src/components/sections/SpecialSkillsSection.vue
+++ b/src/components/sections/SpecialSkillsSection.vue
@@ -70,44 +70,23 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
 import { AioniaGameData } from '../../data/gameData.js';
-import { deepClone } from "../../utils/utils.js";
+import { useCharacterStore } from '../../stores/characterStore.js';
 
-const props = defineProps({
-  specialSkills: { type: Array, default: () => [] },
-});
-const emit = defineEmits(['update:specialSkills']);
-
-const localSpecialSkills = ref(deepClone(props.specialSkills));
-
-watch(
-  () => props.specialSkills,
-  (val) => {
-    localSpecialSkills.value = deepClone(val);
-  },
-  { deep: true }
-);
-
-watch(
-  localSpecialSkills,
-  (val) => {
-    emit('update:specialSkills', deepClone(val));
-  },
-  { deep: true }
-);
+const characterStore = useCharacterStore();
+const localSpecialSkills = characterStore.specialSkills;
 
 function hasSpecialSkillContent(ss) {
   return !!(ss.group || ss.name || ss.note);
 }
 
 function addSpecialSkillItem() {
-  if (localSpecialSkills.value.length >= AioniaGameData.config.maxSpecialSkills) return;
-  localSpecialSkills.value.push({ group: '', name: '', note: '', showNote: false });
+  if (localSpecialSkills.length >= AioniaGameData.config.maxSpecialSkills) return;
+  localSpecialSkills.push({ group: '', name: '', note: '', showNote: false });
 }
 
 function removeSpecialSkill(index) {
-  const list = localSpecialSkills.value;
+  const list = localSpecialSkills;
   if (list.length > 1) {
     list.splice(index, 1);
   } else if (hasSpecialSkillContent(list[index])) {
@@ -116,12 +95,12 @@ function removeSpecialSkill(index) {
 }
 
 function availableSpecialSkillNames(index) {
-  const item = localSpecialSkills.value[index];
+  const item = localSpecialSkills[index];
   return item ? AioniaGameData.specialSkillData[item.group] || [] : [];
 }
 
 function updateSpecialSkillOptions(index) {
-  const item = localSpecialSkills.value[index];
+  const item = localSpecialSkills[index];
   if (item) {
     item.name = '';
     updateSpecialSkillNoteVisibility(index);
@@ -129,7 +108,7 @@ function updateSpecialSkillOptions(index) {
 }
 
 function updateSpecialSkillNoteVisibility(index) {
-  const item = localSpecialSkills.value[index];
+  const item = localSpecialSkills[index];
   if (item) {
     const skillName = item.name;
     item.showNote = AioniaGameData.specialSkillsRequiringNote.includes(skillName);

--- a/src/composables/features/useEquipmentManagement.js
+++ b/src/composables/features/useEquipmentManagement.js
@@ -1,16 +1,8 @@
 import { computed } from "vue";
-import { AioniaGameData } from "../../data/gameData.js";
+import { useCharacterStore } from "../../stores/characterStore.js";
 
-export function useEquipmentManagement(equipmentsRef) {
-  const currentWeight = computed(() => {
-    const weaponWeights = AioniaGameData.equipmentWeights.weapon;
-    const armorWeights = AioniaGameData.equipmentWeights.armor;
-    let weight = 0;
-    weight += weaponWeights[equipmentsRef.value.weapon1.group] || 0;
-    weight += weaponWeights[equipmentsRef.value.weapon2.group] || 0;
-    weight += armorWeights[equipmentsRef.value.armor.group] || 0;
-    return weight;
-  });
-
+export function useEquipmentManagement() {
+  const characterStore = useCharacterStore();
+  const currentWeight = computed(() => characterStore.currentWeight);
   return { currentWeight };
 }

--- a/src/composables/features/useWeaknessManagement.js
+++ b/src/composables/features/useWeaknessManagement.js
@@ -1,24 +1,10 @@
-import { computed, isRef } from "vue";
-import { AioniaGameData } from "../../data/gameData.js";
+import { computed } from "vue";
+import { useCharacterStore } from "../../stores/characterStore.js";
 
-export function useWeaknessManagement(histories) {
-  const historiesArray = computed(() =>
-    isRef(histories) ? histories.value : histories,
+export function useWeaknessManagement() {
+  const characterStore = useCharacterStore();
+  const sessionNamesForWeaknessDropdown = computed(
+    () => characterStore.sessionNamesForWeaknessDropdown,
   );
-
-  const sessionNamesForWeaknessDropdown = computed(() => {
-    const defaultOptions = [...AioniaGameData.weaknessAcquisitionOptions];
-    const sessionOptions = historiesArray.value
-      .map((h) => h.sessionName)
-      .filter((name) => name && name.trim() !== "")
-      .map((name) => ({ value: name, text: name, disabled: false }));
-    const helpOption = {
-      value: "help-text",
-      text: AioniaGameData.uiMessages.weaknessDropdownHelp,
-      disabled: true,
-    };
-    return defaultOptions.concat(sessionOptions, helpOption);
-  });
-
   return { sessionNamesForWeaknessDropdown };
 }

--- a/src/layouts/CharacterSheetLayout.vue
+++ b/src/layouts/CharacterSheetLayout.vue
@@ -1,5 +1,4 @@
 <script setup>
-import { computed } from 'vue';
 import { useCharacterStore } from '../stores/characterStore.js';
 
 import CharacterBasicInfo from '../components/sections/CharacterBasicInfo.vue';
@@ -11,32 +10,18 @@ import CharacterMemoSection from '../components/sections/CharacterMemoSection.vu
 import AdventureLogSection from '../components/sections/AdventureLogSection.vue';
 
 const characterStore = useCharacterStore();
-const sessionNamesForWeaknessDropdown = computed(
-  () => characterStore.sessionNamesForWeaknessDropdown,
-);
 </script>
 
 <template>
   <div class="tool-title">Aionia TRPG Character Sheet</div>
   <div class="main-grid">
-    <CharacterBasicInfo v-model:character="characterStore.character" />
-    <ScarWeaknessSection
-      v-model:character="characterStore.character"
-      :session-names="sessionNamesForWeaknessDropdown"
-    />
-    <SkillsSection v-model:skills="characterStore.skills" />
-    <SpecialSkillsSection v-model:specialSkills="characterStore.specialSkills" />
-    <ItemsSection
-      v-model:equipments="characterStore.equipments"
-      v-model:otherItems="characterStore.character.otherItems"
-    />
-    <CharacterMemoSection v-model="characterStore.character.memo" />
-    <AdventureLogSection
-      :histories="characterStore.histories"
-      @add-item="characterStore.addHistoryItem()"
-      @remove-item="characterStore.removeHistoryItem"
-      @update:history="characterStore.updateHistoryItem"
-    />
+    <CharacterBasicInfo />
+    <ScarWeaknessSection />
+    <SkillsSection />
+    <SpecialSkillsSection />
+    <ItemsSection />
+    <CharacterMemoSection />
+    <AdventureLogSection />
   </div>
   <div class="copyright-footer">
     <p>

--- a/tests/unit/stores/characterStore.test.js
+++ b/tests/unit/stores/characterStore.test.js
@@ -1,0 +1,31 @@
+import { setActivePinia, createPinia } from "pinia";
+import { useCharacterStore } from "../../../src/stores/characterStore.js";
+import { AioniaGameData } from "../../../src/data/gameData.js";
+
+describe("characterStore", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  test("addSpecialSkillItem respects max limit", () => {
+    const store = useCharacterStore();
+    store.specialSkills.splice(0, store.specialSkills.length); // reset
+    const max = AioniaGameData.config.maxSpecialSkills;
+    for (let i = 0; i < max + 2; i++) {
+      store.addSpecialSkillItem();
+    }
+    expect(store.specialSkills.length).toBeLessThanOrEqual(max);
+  });
+
+  test("currentWeight calculates equipment weight", () => {
+    const store = useCharacterStore();
+    store.equipments.weapon1.group = "combat_small";
+    store.equipments.weapon2.group = "shooting";
+    store.equipments.armor.group = "light_armor";
+    const expected =
+      AioniaGameData.equipmentWeights.weapon["combat_small"] +
+      AioniaGameData.equipmentWeights.weapon["shooting"] +
+      AioniaGameData.equipmentWeights.armor["light_armor"];
+    expect(store.currentWeight).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- remove props between sections and connect them directly to pinia stores
- simplify layout since sections now read from stores
- expose store getters in composables
- add unit tests for characterStore actions and getters

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_684970f74af8832688f5e861320da94f