### PR TITLE
Fix numeric input recursion bug and add tests

### DIFF
--- a/src/components/sections/CharacterBasicInfo.vue
+++ b/src/components/sections/CharacterBasicInfo.vue
@@ -43,7 +43,18 @@
         </div>
         <div class="info-item info-item--quadruple">
           <label for="age">年齢</label>
-          <input type="number" id="age" v-model.number="characterStore.character.age" min="0" />
+          <input
+            type="number"
+            id="age"
+            :value="characterStore.character.age"
+            @input="
+              (e) => {
+                const v = e.target.value;
+                characterStore.character.age = v === '' ? null : parseInt(v, 10);
+              }
+            "
+            min="0"
+          />
         </div>
         <div class="info-item info-item--quadruple">
           <label for="height">身長</label>

--- a/src/components/sections/ScarWeaknessSection.vue
+++ b/src/components/sections/ScarWeaknessSection.vue
@@ -19,8 +19,13 @@
             <input
               type="number"
               id="current_scar"
-              v-model.number="characterStore.character.currentScar"
-              @input="handleCurrentScarInput"
+              :value="characterStore.character.currentScar"
+              @input="(e) => {
+                const val = e.target.value;
+                characterStore.character.currentScar =
+                  val === '' ? '' : parseInt(val, 10);
+                handleCurrentScarInput(e);
+              }"
               :class="{ 'greyed-out': characterStore.character.linkCurrentToInitialScar }"
               min="0"
               class="scar-section__current-input"
@@ -28,7 +33,17 @@
           </div>
           <div class="info-item info-item--double">
             <label for="initial_scar">初期値</label>
-            <input type="number" id="initial_scar" v-model.number="characterStore.character.initialScar" min="0" />
+            <input
+              type="number"
+              id="initial_scar"
+              :value="characterStore.character.initialScar"
+              @input="(e) => {
+                const val = e.target.value;
+                characterStore.character.initialScar =
+                  val === '' ? '' : parseInt(val, 10);
+              }"
+              min="0"
+            />
           </div>
         </div>
       </div>

--- a/tests/e2e/index.test.cjs
+++ b/tests/e2e/index.test.cjs
@@ -144,7 +144,7 @@ test.describe("Character Sheet E2E Tests", () => {
 
     // Skipping this test as it requires a pre-made ZIP file with specific internal structure,
     // which cannot be dynamically created with current tooling.
-    test.skip("loads character data and image from ZIP file", async ({
+  test.skip("loads character data and image from ZIP file", async ({
       page,
     }) => {
       // This test assumes `tests/fixtures/test_char.zip` is structured correctly:
@@ -171,5 +171,25 @@ test.describe("Character Sheet E2E Tests", () => {
       const imageCountDisplay = page.locator(".image-count-display");
       await expect(imageCountDisplay).toHaveText("1 / 1"); // Assuming one image in the test zip
     });
+  });
+
+  test.describe("Sample data loading", () => {
+    const sampleDir = path.resolve(__dirname, "../../sample-data");
+    const sampleFiles = fs
+      .readdirSync(sampleDir)
+      .filter((f) => f.endsWith(".json"));
+
+    for (const file of sampleFiles) {
+      test(`loads ${file} without errors`, async ({ page }) => {
+        const filePath = path.join(sampleDir, file);
+        const fileUploadInput = page.locator("#load_input_vue");
+        await fileUploadInput.setInputFiles(filePath);
+
+        const loaded = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+        await expect(page.locator("#name")).toHaveValue(
+          loaded.character.name || "",
+        );
+      });
+    }
   });
 });

--- a/tests/unit/dataNormalization.test.js
+++ b/tests/unit/dataNormalization.test.js
@@ -1,0 +1,34 @@
+import { DataManager } from "../../src/services/dataManager.js";
+import { AioniaGameData } from "../../src/data/gameData.js";
+
+describe("parseLoadedData edge cases", () => {
+  const dm = new DataManager(AioniaGameData);
+
+  test("keeps null and empty strings for numeric fields", () => {
+    const raw = {
+      character: { age: "", initialScar: "", currentScar: "" },
+    };
+    const parsed = dm.parseLoadedData(raw);
+    expect(parsed.character.age).toBe("");
+    expect(parsed.character.initialScar).toBe("");
+    expect(parsed.character.currentScar).toBe("");
+  });
+
+  test("missing numeric fields use defaults without coercion", () => {
+    const raw = { character: {} };
+    const parsed = dm.parseLoadedData(raw);
+    expect(parsed.character.age).toBeNull();
+    expect(parsed.character.initialScar).toBe(0);
+    expect(parsed.character.currentScar).toBe(0);
+  });
+
+  test("null numeric fields remain null", () => {
+    const raw = {
+      character: { age: null, initialScar: null, currentScar: null },
+    };
+    const parsed = dm.parseLoadedData(raw);
+    expect(parsed.character.age).toBeNull();
+    expect(parsed.character.initialScar).toBeNull();
+    expect(parsed.character.currentScar).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- handle null and empty values safely in numeric inputs
- add tests to ensure loaded JSON values remain uncoerced

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_684981ad47b883268f55affb7fa8cd63