### PR TITLE
Fix image component update loop

### DIFF
--- a/sample-data/edge-case_1.json
+++ b/sample-data/edge-case_1.json
@@ -1,0 +1,37 @@
+{
+  "character": {
+    "images": [],
+    "name": "EdgeCase",
+    "playerName": "Tester",
+    "species": "human",
+    "rareSpecies": "mysterious",
+    "occupation": "",
+    "age": "",
+    "gender": "",
+    "height": "",
+    "weight": "",
+    "origin": "",
+    "faith": "",
+    "otherItems": "",
+    "currentScar": 0,
+    "initialScar": 0,
+    "linkCurrentToInitialScar": true,
+    "memo": "",
+    "weaknesses": [
+      { "text": "", "acquired": "--" },
+      { "text": "", "acquired": "--" },
+      { "text": "", "acquired": "--" },
+      { "text": "", "acquired": "--" },
+      { "text": "", "acquired": "--" },
+      { "text": "", "acquired": "--" },
+      { "text": "", "acquired": "--" },
+      { "text": "", "acquired": "--" },
+      { "text": "", "acquired": "--" },
+      { "text": "", "acquired": "--" }
+    ]
+  },
+  "skills": [],
+  "specialSkills": [],
+  "equipments": {},
+  "histories": []
+}

--- a/src/components/ui/CharacterImageDisplay.vue
+++ b/src/components/ui/CharacterImageDisplay.vue
@@ -44,7 +44,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch } from 'vue';
+import { ref, computed, watch, nextTick } from 'vue';
 import { ImageManager } from '../../services/imageManager.js';
 
 const props = defineProps({
@@ -56,11 +56,16 @@ const props = defineProps({
 const emit = defineEmits(['update:images']);
 
 const imagesInternal = ref([...props.images]);
+let updatingFromParent = false;
 
 watch(
   () => props.images,
   (val) => {
+    updatingFromParent = true;
     imagesInternal.value = [...val];
+    nextTick(() => {
+      updatingFromParent = false;
+    });
   },
   { deep: true }
 );
@@ -68,7 +73,9 @@ watch(
 watch(
   imagesInternal,
   (val) => {
-    emit('update:images', val);
+    if (!updatingFromParent) {
+      emit('update:images', val);
+    }
   },
   { deep: true }
 );

--- a/tests/e2e/sampleUpload.test.cjs
+++ b/tests/e2e/sampleUpload.test.cjs
@@ -1,0 +1,22 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+
+const INDEX_HTML_PATH = 'http://localhost:4173/AioniaCS/';
+const sampleDir = path.resolve(__dirname, '../../sample-data');
+const sampleFiles = fs.readdirSync(sampleDir).filter((f) => f.endsWith('.json'));
+
+test.describe('Sample data uploads', () => {
+  for (const file of sampleFiles) {
+    test(`load ${file} without console errors`, async ({ page }) => {
+      await page.goto(INDEX_HTML_PATH);
+      const errors = [];
+      page.on('pageerror', (err) => errors.push(err.message));
+      await page.locator('#load_input_vue').setInputFiles(path.join(sampleDir, file));
+      await expect(page.locator('#name')).toHaveValue(/.+/);
+      for (const msg of errors) {
+        expect(msg).not.toContain('Maximum recursive updates exceeded');
+      }
+    });
+  }
+});

--- a/tests/unit/sampleDataLoad.test.js
+++ b/tests/unit/sampleDataLoad.test.js
@@ -1,0 +1,37 @@
+import fs from "fs";
+import path from "path";
+import { setActivePinia, createPinia } from "pinia";
+import { DataManager } from "../../src/services/dataManager.js";
+import { AioniaGameData } from "../../src/data/gameData.js";
+import { useCharacterStore } from "../../src/stores/characterStore.js";
+
+const sampleDir = path.resolve(__dirname, "../../sample-data");
+const sampleFiles = fs
+  .readdirSync(sampleDir)
+  .filter((f) => f.endsWith(".json"));
+
+describe("DataManager loads sample data", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  test.each(sampleFiles)("load %s without mutation", (filename) => {
+    const dm = new DataManager(AioniaGameData);
+    const store = useCharacterStore();
+    const raw = JSON.parse(
+      fs.readFileSync(path.join(sampleDir, filename), "utf8"),
+    );
+    const parsed = dm.parseLoadedData(raw);
+    Object.assign(store.character, parsed.character);
+    store.skills.splice(0, store.skills.length, ...parsed.skills);
+    store.specialSkills.splice(
+      0,
+      store.specialSkills.length,
+      ...parsed.specialSkills,
+    );
+    Object.assign(store.equipments, parsed.equipments);
+    store.histories.splice(0, store.histories.length, ...parsed.histories);
+    expect(store.character.name).toBe(raw.character.name);
+    expect(store.character.age).toBe(raw.character.age ?? null);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent recursive updates in CharacterImageDisplay
- add unit test to load sample-data
- create edge-case sample JSON
- ensure sample files load without console errors via Playwright

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68498b1222e083269356d1eb6625c990