### PR TITLE
Improve shared UI tests

### DIFF
--- a/tests/e2e/index.test.cjs
+++ b/tests/e2e/index.test.cjs
@@ -144,7 +144,7 @@ test.describe("Character Sheet E2E Tests", () => {
 
     // Skipping this test as it requires a pre-made ZIP file with specific internal structure,
     // which cannot be dynamically created with current tooling.
-    test.skip("loads character data and image from ZIP file", async ({
+  test.skip("loads character data and image from ZIP file", async ({
       page,
     }) => {
       // This test assumes `tests/fixtures/test_char.zip` is structured correctly:
@@ -171,5 +171,21 @@ test.describe("Character Sheet E2E Tests", () => {
       const imageCountDisplay = page.locator(".image-count-display");
       await expect(imageCountDisplay).toHaveText("1 / 1"); // Assuming one image in the test zip
     });
+  });
+
+  test("help panel opens and closes", async ({ page }) => {
+    await page.locator(".footer-help-icon").click();
+    const panel = page.locator(".help-panel");
+    await expect(panel).toBeVisible();
+    await page.locator(".help-close").click();
+    await expect(panel).not.toBeVisible();
+  });
+
+  test("share dialog opens and closes", async ({ page }) => {
+    await page.locator(".footer-button--share").click();
+    const overlay = page.locator(".share-dialog-overlay");
+    await expect(overlay).toBeVisible();
+    await page.locator('.share-dialog button:has-text("閉じる")').click();
+    await expect(overlay).not.toBeVisible();
   });
 });

--- a/tests/unit/stores/uiStore.test.js
+++ b/tests/unit/stores/uiStore.test.js
@@ -1,0 +1,51 @@
+import { setActivePinia, createPinia } from "pinia";
+import { useUiStore } from "../../../src/stores/uiStore.js";
+import { useCharacterStore } from "../../../src/stores/characterStore.js";
+import { jest } from "@jest/globals";
+
+jest.mock("../../../src/stores/characterStore.js");
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+describe("uiStore getters", () => {
+  test("experienceStatusClass indicates over limit", () => {
+    useCharacterStore.mockReturnValue({
+      currentExperiencePoints: 150,
+      maxExperiencePoints: 100,
+    });
+    const store = useUiStore();
+    expect(store.experienceStatusClass).toBe("status-display--experience-over");
+  });
+
+  test("experienceStatusClass indicates within limit", () => {
+    useCharacterStore.mockReturnValue({
+      currentExperiencePoints: 50,
+      maxExperiencePoints: 100,
+    });
+    const store = useUiStore();
+    expect(store.experienceStatusClass).toBe("status-display--experience-ok");
+  });
+
+  test("canSignInToGoogle checks initialization and sign-in", () => {
+    useCharacterStore.mockReturnValue({});
+    const store = useUiStore();
+    store.isGapiInitialized = true;
+    store.isGisInitialized = true;
+    store.isSignedIn = false;
+    expect(store.canSignInToGoogle).toBe(true);
+    store.isSignedIn = true;
+    expect(store.canSignInToGoogle).toBe(false);
+  });
+
+  test("canOperateDrive checks drive readiness", () => {
+    useCharacterStore.mockReturnValue({});
+    const store = useUiStore();
+    store.isSignedIn = true;
+    store.driveFolderId = "foo";
+    expect(store.canOperateDrive).toBe("foo");
+    store.driveFolderId = null;
+    expect(store.canOperateDrive).toBe(null);
+  });
+});


### PR DESCRIPTION
## Summary
- add uiStore unit tests
- test help panel and share dialog interactions with Playwright

## Testing
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_684a1d56557c8326bb1089bbc2c5ef52