### PR TITLE
Implement appDataFolder drive logic

### DIFF
--- a/src/services/googleDriveManager.js
+++ b/src/services/googleDriveManager.js
@@ -541,6 +541,113 @@ export class GoogleDriveManager {
     const picker = pickerBuilder.build();
     picker.setVisible(true);
   }
+
+  /**
+   * Ensures the character index file exists in appDataFolder.
+   * @returns {Promise<{id:string,name:string}|null>} index file info
+   */
+  async ensureIndexFile() {
+    const fileList =
+      (
+        await gapi.client.drive.files.list({
+          q: "name='character_index.json' and trashed=false",
+          spaces: "appDataFolder",
+          fields: "files(id,name)",
+        })
+      ).result.files || [];
+
+    if (fileList.length > 0) {
+      this.indexFileId = fileList[0].id;
+      return fileList[0];
+    }
+
+    const created = await this.saveFile(
+      "appDataFolder",
+      "character_index.json",
+      "[]",
+    );
+    if (created) this.indexFileId = created.id;
+    return created;
+  }
+
+  /**
+   * Reads and parses the character index file.
+   * @returns {Promise<Array>}
+   */
+  async readIndexFile() {
+    const info = await this.ensureIndexFile();
+    if (!info) return [];
+    const content = await this.loadFileContent(info.id);
+    try {
+      return JSON.parse(content || "[]");
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Writes the given index array back to the index file.
+   * @param {Array} indexData
+   */
+  async writeIndexFile(indexData) {
+    const info = await this.ensureIndexFile();
+    if (!info) return null;
+    return this.saveFile(
+      "appDataFolder",
+      "character_index.json",
+      JSON.stringify(indexData, null, 2),
+      info.id,
+    );
+  }
+
+  async addIndexEntry(entry) {
+    const index = await this.readIndexFile();
+    index.push(entry);
+    await this.writeIndexFile(index);
+  }
+
+  async renameIndexEntry(id, newName) {
+    const index = await this.readIndexFile();
+    index.forEach((e) => {
+      if (e.id === id) e.name = newName;
+    });
+    await this.writeIndexFile(index);
+  }
+
+  async removeIndexEntry(id) {
+    const index = await this.readIndexFile();
+    const filtered = index.filter((e) => e.id !== id);
+    await this.writeIndexFile(filtered);
+  }
+
+  /**
+   * Creates a character data file in appDataFolder.
+   * @param {object} data character JSON object
+   * @param {string} name file name
+   */
+  async createCharacterFile(data, name) {
+    return this.saveFile("appDataFolder", name, JSON.stringify(data, null, 2));
+  }
+
+  async updateCharacterFile(id, data, name) {
+    return this.saveFile(
+      "appDataFolder",
+      name,
+      JSON.stringify(data, null, 2),
+      id,
+    );
+  }
+
+  async loadCharacterFile(id) {
+    const content = await this.loadFileContent(id);
+    return content ? JSON.parse(content) : null;
+  }
+
+  async deleteCharacterFile(id) {
+    if (!gapi.client || !gapi.client.drive) return null;
+    await gapi.client.drive.files.delete({ fileId: id });
+    await this.removeIndexEntry(id);
+  }
 }
 
 // Make the class available globally for now, to be instantiated in main.js

--- a/tests/unit/googleDriveManager.test.js
+++ b/tests/unit/googleDriveManager.test.js
@@ -1,0 +1,71 @@
+import { GoogleDriveManager } from "../../src/services/googleDriveManager.js";
+import { jest } from "@jest/globals";
+
+describe("GoogleDriveManager appDataFolder", () => {
+  let gdm;
+
+  beforeEach(() => {
+    global.gapi = {
+      client: {
+        drive: {
+          files: {
+            list: jest.fn(),
+            get: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+        request: jest.fn(),
+      },
+    };
+    gdm = new GoogleDriveManager("k", "c");
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("ensureIndexFile creates new index when absent", async () => {
+    gapi.client.drive.files.list.mockResolvedValue({ result: { files: [] } });
+    gapi.client.request.mockResolvedValue({
+      result: { id: "1", name: "character_index.json" },
+    });
+    const info = await gdm.ensureIndexFile();
+    expect(info.id).toBe("1");
+    expect(gapi.client.request).toHaveBeenCalled();
+  });
+
+  test("readIndexFile returns parsed data", async () => {
+    gapi.client.drive.files.list.mockResolvedValue({
+      result: { files: [{ id: "10", name: "character_index.json" }] },
+    });
+    gapi.client.drive.files.get.mockResolvedValue({
+      body: '[{"id":"a","name":"Alice"}]',
+    });
+    const index = await gdm.readIndexFile();
+    expect(index).toEqual([{ id: "a", name: "Alice" }]);
+    expect(gapi.client.drive.files.get).toHaveBeenCalledWith({
+      fileId: "10",
+      alt: "media",
+    });
+  });
+
+  test("createCharacterFile uploads JSON to appDataFolder", async () => {
+    gapi.client.request.mockResolvedValue({
+      result: { id: "c1", name: "char.json" },
+    });
+    const data = { foo: "bar" };
+    const res = await gdm.createCharacterFile(data, "char.json");
+    expect(res.id).toBe("c1");
+    expect(gapi.client.request).toHaveBeenCalled();
+  });
+
+  test("deleteCharacterFile removes file and index entry", async () => {
+    jest.spyOn(gdm, "removeIndexEntry").mockResolvedValue();
+    gapi.client.drive.files.delete.mockResolvedValue({});
+    await gdm.deleteCharacterFile("d1");
+    expect(gapi.client.drive.files.delete).toHaveBeenCalledWith({
+      fileId: "d1",
+    });
+    expect(gdm.removeIndexEntry).toHaveBeenCalledWith("d1");
+  });
+});


### PR DESCRIPTION
## Summary
- extend `googleDriveManager` with appDataFolder features
- create unit tests for new Google Drive logic

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_684d83a513488326938d647954066df3