### PR TITLE
Display build metadata on preview sites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set build info
+        run: |
+          echo "VITE_BUILD_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          echo "VITE_BUILD_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "VITE_BUILD_DATE=$(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_ENV
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -124,6 +129,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set build info
+        run: |
+          echo "VITE_BUILD_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          echo "VITE_BUILD_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "VITE_BUILD_DATE=$(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_ENV
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/src/assets/css/_layout.css
+++ b/src/assets/css/_layout.css
@@ -159,6 +159,13 @@
   background: var(--color-text-muted);
 }
 
+.footer-build-info {
+  margin-left: auto;
+  font-size: 0.8em;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
 /* ヘルプ表示 */
 .help-panel {
   position: fixed;

--- a/src/components/ui/MainFooter.vue
+++ b/src/components/ui/MainFooter.vue
@@ -54,6 +54,9 @@
     >
       {{ isViewingShared ? '自分用にコピーして編集' : '共有' }}
     </button>
+    <div class="footer-build-info" v-if="buildInfo">
+      {{ buildInfo }}
+    </div>
   </div>
 </template>
 
@@ -87,6 +90,14 @@ const helpIcon = ref(null);
 defineExpose({ outputButton, helpIcon });
 
 const uiStore = useUiStore();
+
+const buildBranch = import.meta.env.VITE_BUILD_BRANCH;
+const buildHash = import.meta.env.VITE_BUILD_HASH;
+const buildDate = import.meta.env.VITE_BUILD_DATE;
+const buildInfo =
+  buildBranch && buildHash && buildDate
+    ? `${buildBranch} (${buildHash}) ${buildDate}`
+    : '';
 
 function handleShareClick() {
   if (props.isViewingShared) {


### PR DESCRIPTION
## Summary
- inject build info in dev/manual preview jobs
- show build info in the footer when provided
- add styling for the build info line

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_684fc57b852883268aa43f9c94e11648