### PR TITLE
Update privacy button style

### DIFF
--- a/src/assets/css/_components.css
+++ b/src/assets/css/_components.css
@@ -238,6 +238,22 @@ textarea.greyed-out {
   text-shadow: none;
 }
 
+/* Link-style button */
+.button-link {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  color: var(--color-link);
+  text-decoration: underline;
+  font: inherit;
+}
+
+.button-link:hover {
+  color: var(--color-link-hover);
+}
+
 .delete-button-wrapper {
   width: 30px;
   height: 30px;

--- a/src/layouts/CharacterSheetLayout.vue
+++ b/src/layouts/CharacterSheetLayout.vue
@@ -30,6 +30,6 @@ const emit = defineEmits(['open-privacy']);
       本サイトは<a href="https://www.aioniatrpg.com/" target="_blank" rel="noopener noreferrer">「イチ（フシギ製作所）」様が権利を有する「慈悲なきアイオニア」</a>の二次創作物です(Ver 1.2対応)。<br />
       本サイトは<a href="https://bright-trpg.github.io/aionia_character_maker/" target="_blank" rel="noopener noreferrer">bright-trpg様作成の「慈悲なきアイオニア　キャラクター作成用ツール」</a>をもとに、あろすてりっくが作成しました。
     </p>
-    <button class="button-base" @click="emit('open-privacy')">プライバシーポリシー</button>
+    <button class="button-link" @click="emit('open-privacy')">プライバシーポリシー</button>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- add `.button-link` for hyperlink-like buttons
- restyle privacy policy trigger in the footer to use the new link style

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68513ced7dc48326a5c4536cf740a4fd