### PR TITLE
Implement unified close button and modal refactor

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@ import CharacterSheetLayout from './layouts/CharacterSheetLayout.vue';
 import TopLeftControls from './components/ui/TopLeftControls.vue';
 import MainFooter from './components/ui/MainFooter.vue';
 import HelpPanel from './components/ui/HelpPanel.vue';
-import PrivacyPolicyModal from './components/ui/PrivacyPolicyModal.vue';
+import PrivacyPolicyModal from './components/modals/contents/PrivacyPolicyModal.vue';
 import NotificationContainer from './components/notifications/NotificationContainer.vue';
 import BaseModal from './components/modals/BaseModal.vue';
 import CharacterHub from './components/ui/CharacterHub.vue';
@@ -63,16 +63,15 @@ const {
 } = useHelp(helpPanelRef, mainFooter);
 
 const { showToast, showAsyncToast } = useNotifications();
-const isPrivacyPolicyVisible = ref(false);
-
-function openPrivacyPolicy() {
-  isPrivacyPolicyVisible.value = true;
-}
-
-function closePrivacyPolicy() {
-  isPrivacyPolicyVisible.value = false;
-}
 const { showModal } = useModal();
+
+async function openPrivacyPolicy() {
+  await showModal({
+    title: 'プライバシーポリシー',
+    component: PrivacyPolicyModal,
+    buttons: [{ label: '閉じる', value: 'close', variant: 'secondary' }],
+  });
+}
 
 async function openHub() {
   await showModal({

--- a/src/assets/css/_notifications.css
+++ b/src/assets/css/_notifications.css
@@ -235,6 +235,19 @@
     inset 0 1px 0 rgb(255 255 255 / 5%);
   position: relative;
 }
+.modal-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: 20px;
+  cursor: pointer;
+}
+.modal-close:hover {
+  color: var(--color-text-normal);
+}
 .modal--critical::before {
   content: "";
   position: absolute;

--- a/src/components/modals/BaseModal.vue
+++ b/src/components/modals/BaseModal.vue
@@ -2,6 +2,7 @@
   <transition name="modal">
     <div class="modal-overlay" v-if="modal.isVisible">
       <div :class="['modal', modal.type ? `modal--${modal.type}` : '']">
+        <button class="modal-close close-cross" @click="modalStore.hideModal">×</button>
         <div class="modal-header" v-if="modal.title">
           <div class="modal-icon" v-if="modal.type === 'critical'">!</div>
           <div class="modal-title">{{ modal.title }}</div>

--- a/src/components/modals/contents/PrivacyPolicyModal.vue
+++ b/src/components/modals/contents/PrivacyPolicyModal.vue
@@ -1,22 +1,11 @@
 <template>
-  <transition name="modal">
-    <div class="modal-overlay" v-if="isVisible">
-      <div class="modal privacy-policy-modal">
-        <button class="modal-close close-cross" @click="$emit('close')">×</button>
-        <div class="privacy-policy-modal__content" v-html="sanitized" />
-      </div>
-    </div>
-  </transition>
+  <div class="privacy-policy-modal__content" v-html="sanitized" />
 </template>
 
 <script setup>
 import { computed } from 'vue';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
-
-const props = defineProps({
-  isVisible: Boolean,
-});
 
 const policyText = `# プライバシーポリシー (Privacy Policy)
 


### PR DESCRIPTION
## Summary
- add close button to `BaseModal` and style it
- refactor `PrivacyPolicyModal` to be used inside the modal system
- invoke modal in `App.vue` using the new API

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_685145b8dc888326996e36c9ae3b6ec0