### PR TITLE
Enhance modal system with close control

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -21,6 +21,7 @@ import TopLeftControls from './components/ui/TopLeftControls.vue';
 import MainFooter from './components/ui/MainFooter.vue';
 import HelpPanel from './components/ui/HelpPanel.vue';
 import NotificationContainer from './components/notifications/NotificationContainer.vue';
+import BaseModal from './components/modals/BaseModal.vue';
 import CharacterHub from './components/ui/CharacterHub.vue';
 import ShareOptions from './components/modals/contents/ShareOptions.vue';
 import { useModal } from './composables/useModal.js';
@@ -210,15 +211,8 @@ onMounted(async () => {
     :help-text="AioniaGameData.helpText"
     @close="closeHelpPanel"
   />
-  <CharacterHub
-    v-if="uiStore.isHubVisible"
-    :data-manager="dataManager"
-    :load-character="loadCharacterById"
-    :save-to-drive="saveCharacterToDrive"
-    @sign-in="handleSignInClick"
-    @sign-out="handleSignOutClick"
-    @close="closeHub"
-  />
+  <!-- CharacterHub and ShareModal are now injected via BaseModal -->
+  <BaseModal />
   <NotificationContainer />
 </template>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,9 +20,7 @@ import CharacterSheetLayout from './layouts/CharacterSheetLayout.vue';
 import TopLeftControls from './components/ui/TopLeftControls.vue';
 import MainFooter from './components/ui/MainFooter.vue';
 import HelpPanel from './components/ui/HelpPanel.vue';
-import PrivacyPolicyModal from './components/modals/contents/PrivacyPolicyModal.vue';
 import NotificationContainer from './components/notifications/NotificationContainer.vue';
-import BaseModal from './components/modals/BaseModal.vue';
 import CharacterHub from './components/ui/CharacterHub.vue';
 import ShareOptions from './components/modals/contents/ShareOptions.vue';
 import { useModal } from './composables/useModal.js';
@@ -64,16 +62,6 @@ const {
 
 const { showToast, showAsyncToast } = useNotifications();
 const { showModal } = useModal();
-
-async function openPrivacyPolicy() {
-  await showModal({
-    component: PrivacyPolicyModal,
-    title: 'プライバシーポリシー',
-    buttons: [
-      { label: '閉じる', value: 'close', variant: 'secondary' },
-    ],
-  });
-}
 
 async function openHub() {
   await showModal({
@@ -195,7 +183,7 @@ onMounted(async () => {
     @open-hub="openHub"
   />
   <div v-if="uiStore.isViewingShared" class="view-mode-banner">閲覧モードで表示中</div>
-  <CharacterSheetLayout @open-privacy="openPrivacyPolicy" />
+  <CharacterSheetLayout />
   <MainFooter
     ref="mainFooter"
     :help-state="helpState"
@@ -231,7 +219,6 @@ onMounted(async () => {
     @sign-out="handleSignOutClick"
     @close="closeHub"
   />
-  <ShareModal v-if="uiStore.isShareModalVisible" :data-manager="dataManager" />
   <NotificationContainer />
 </template>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@ import CharacterSheetLayout from './layouts/CharacterSheetLayout.vue';
 import TopLeftControls from './components/ui/TopLeftControls.vue';
 import MainFooter from './components/ui/MainFooter.vue';
 import HelpPanel from './components/ui/HelpPanel.vue';
-import PrivacyPolicyModal from './components/ui/PrivacyPolicyModal.vue';
+import PrivacyPolicyModal from './components/modals/contents/PrivacyPolicyModal.vue';
 import NotificationContainer from './components/notifications/NotificationContainer.vue';
 import BaseModal from './components/modals/BaseModal.vue';
 import CharacterHub from './components/ui/CharacterHub.vue';
@@ -63,16 +63,17 @@ const {
 } = useHelp(helpPanelRef, mainFooter);
 
 const { showToast, showAsyncToast } = useNotifications();
-const isPrivacyPolicyVisible = ref(false);
-
-function openPrivacyPolicy() {
-  isPrivacyPolicyVisible.value = true;
-}
-
-function closePrivacyPolicy() {
-  isPrivacyPolicyVisible.value = false;
-}
 const { showModal } = useModal();
+
+async function openPrivacyPolicy() {
+  await showModal({
+    component: PrivacyPolicyModal,
+    title: 'プライバシーポリシー',
+    buttons: [
+      { label: '閉じる', value: 'close', variant: 'secondary' },
+    ],
+  });
+}
 
 async function openHub() {
   await showModal({

--- a/src/assets/css/_notifications.css
+++ b/src/assets/css/_notifications.css
@@ -235,6 +235,15 @@
     inset 0 1px 0 rgb(255 255 255 / 5%);
   position: relative;
 }
+.modal-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  color: var(--color-accent);
+  cursor: pointer;
+}
 .modal--critical::before {
   content: "";
   position: absolute;

--- a/src/assets/css/_notifications.css
+++ b/src/assets/css/_notifications.css
@@ -243,6 +243,10 @@
   border: none;
   color: var(--color-accent);
   cursor: pointer;
+  transition: color 0.2s ease;
+}
+.modal-close:hover {
+  color: var(--color-accent-light);
 }
 .modal--critical::before {
   content: "";

--- a/src/components/modals/BaseModal.vue
+++ b/src/components/modals/BaseModal.vue
@@ -2,6 +2,9 @@
   <transition name="modal">
     <div class="modal-overlay" v-if="modal.isVisible">
       <div :class="['modal', modal.type ? `modal--${modal.type}` : '']">
+        <button class="modal-close close-cross" @click="modalStore.hideModal()">
+          ×
+        </button>
         <div class="modal-header" v-if="modal.title">
           <div class="modal-icon" v-if="modal.type === 'critical'">!</div>
           <div class="modal-title">{{ modal.title }}</div>

--- a/src/components/modals/BaseModal.vue
+++ b/src/components/modals/BaseModal.vue
@@ -1,6 +1,6 @@
 <template>
   <transition name="modal">
-    <div class="modal-overlay" v-if="modal.isVisible">
+    <div class="modal-overlay" v-if="modal.isVisible" @click.self="modalStore.hideModal()">
       <div :class="['modal', modal.type ? `modal--${modal.type}` : '']">
         <button class="modal-close close-cross" @click="modalStore.hideModal()">
           ×

--- a/src/components/modals/contents/PrivacyPolicyModal.vue
+++ b/src/components/modals/contents/PrivacyPolicyModal.vue
@@ -1,22 +1,11 @@
 <template>
-  <transition name="modal">
-    <div class="modal-overlay" v-if="isVisible">
-      <div class="modal privacy-policy-modal">
-        <button class="modal-close close-cross" @click="$emit('close')">×</button>
-        <div class="privacy-policy-modal__content" v-html="sanitized" />
-      </div>
-    </div>
-  </transition>
+  <div class="privacy-policy-modal__content" v-html="sanitized" />
 </template>
 
 <script setup>
 import { computed } from 'vue';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
-
-const props = defineProps({
-  isVisible: Boolean,
-});
 
 const policyText = `# プライバシーポリシー (Privacy Policy)
 

--- a/src/layouts/CharacterSheetLayout.vue
+++ b/src/layouts/CharacterSheetLayout.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { useCharacterStore } from '../stores/characterStore.js';
-import { defineEmits } from 'vue';
+import { useModal } from '../composables/useModal.js';
+import PrivacyPolicyModal from '../components/modals/contents/PrivacyPolicyModal.vue';
 
 import CharacterBasicInfo from '../components/sections/CharacterBasicInfo.vue';
 import ScarWeaknessSection from '../components/sections/ScarWeaknessSection.vue';
@@ -11,7 +12,15 @@ import CharacterMemoSection from '../components/sections/CharacterMemoSection.vu
 import AdventureLogSection from '../components/sections/AdventureLogSection.vue';
 
 const characterStore = useCharacterStore();
-const emit = defineEmits(['open-privacy']);
+const { showModal } = useModal();
+
+async function openPrivacyPolicy() {
+  await showModal({
+    component: PrivacyPolicyModal,
+    title: 'プライバシーポリシー',
+    buttons: [{ label: '閉じる', value: 'close', variant: 'secondary' }],
+  });
+}
 </script>
 
 <template>
@@ -30,6 +39,6 @@ const emit = defineEmits(['open-privacy']);
       本サイトは<a href="https://www.aioniatrpg.com/" target="_blank" rel="noopener noreferrer">「イチ（フシギ製作所）」様が権利を有する「慈悲なきアイオニア」</a>の二次創作物です(Ver 1.2対応)。<br />
       本サイトは<a href="https://bright-trpg.github.io/aionia_character_maker/" target="_blank" rel="noopener noreferrer">bright-trpg様作成の「慈悲なきアイオニア　キャラクター作成用ツール」</a>をもとに、あろすてりっくが作成しました。
     </p>
-    <button class="button-base" @click="emit('open-privacy')">プライバシーポリシー</button>
+    <button class="button-base" @click="openPrivacyPolicy">プライバシーポリシー</button>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- add universal close button in `BaseModal.vue`
- expose modal close styles in `_notifications.css`
- refactor `PrivacyPolicyModal` to work as modal content
- call modal system from `openPrivacyPolicy`

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68514868622c83268227486b9e5312db