### PR TITLE
Centralize Japanese notifications

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,7 @@ import { receiveSharedData } from './libs/sabalessshare/index.js';
 import { receiveDynamicData } from './libs/sabalessshare/dynamic.js';
 import { parseShareUrl } from './libs/sabalessshare/url.js';
 import { DriveStorageAdapter } from './services/driveStorageAdapter.js';
+import { messages } from './locales/ja.js';
 
 // --- Module Imports ---
 // This approach is standard for Vite/ESM projects, making dependencies explicit.
@@ -102,9 +103,9 @@ async function loadCharacterById(id, name) {
       }
     });
   showAsyncToast(loadPromise, {
-    loading: { title: 'Google Drive', message: `Loading ${name}...` },
-    success: { title: 'Loaded', message: `${name} from Drive` },
-    error: (err) => ({ title: 'Load error', message: err.message || 'Unknown error' }),
+    loading: messages.googleDrive.load.loading(name),
+    success: messages.googleDrive.load.success(name),
+    error: (err) => messages.googleDrive.load.error(err),
   });
 }
 
@@ -176,12 +177,12 @@ onMounted(async () => {
     characterStore.histories.splice(0, characterStore.histories.length, ...parsed.histories);
     uiStore.isViewingShared = true;
   } catch (err) {
-    let msg = '共有データ読み込み失敗';
-    if (err.name === 'InvalidLinkError') msg = '共有リンクが不正です';
-    else if (err.name === 'ExpiredLinkError') msg = '共有リンクの有効期限が切れています';
-    else if (err.name === 'PasswordRequiredError') msg = 'パスワードが必要です';
-    else if (err.name === 'DecryptionError') msg = '復号に失敗しました';
-    showToast({ type: 'error', title: '共有データエラー', message: msg });
+    let msg = messages.share.loadError.general;
+    if (err.name === 'InvalidLinkError') msg = messages.share.loadError.invalid;
+    else if (err.name === 'ExpiredLinkError') msg = messages.share.loadError.expired;
+    else if (err.name === 'PasswordRequiredError') msg = messages.share.loadError.passwordRequired;
+    else if (err.name === 'DecryptionError') msg = messages.share.loadError.decryptionFailed;
+    showToast({ type: 'error', title: messages.share.loadError.toastTitle, message: msg });
     console.error('Error loading shared data:', err);
   }
 });

--- a/src/components/ui/CharacterHub.vue
+++ b/src/components/ui/CharacterHub.vue
@@ -54,6 +54,7 @@ import { ref, computed, onMounted } from 'vue';
 import { useUiStore } from '../../stores/uiStore.js';
 import { useCharacterStore } from '../../stores/characterStore.js';
 import { useNotifications } from '../../composables/useNotifications.js';
+import { messages } from '../../locales/ja.js';
 
 const props = defineProps({
   dataManager: Object,
@@ -111,14 +112,9 @@ function formatDate(date) {
 
 
 async function confirmLoad(ch) {
-  const result = await showModal({
-    title: '読込確認',
-    message: `${ch.characterName || ch.name} を読み込みますか？`,
-    buttons: [
-      { label: '読込', value: 'load', variant: 'primary' },
-      { label: 'キャンセル', value: 'cancel', variant: 'secondary' },
-    ],
-  });
+  const result = await showModal(
+    messages.characterHub.loadConfirm(ch.characterName || ch.name),
+  );
   if (result.value === 'load') {
     await props.loadCharacter(ch.id, ch.name);
   }
@@ -126,19 +122,14 @@ async function confirmLoad(ch) {
 
 
 async function deleteChar(ch) {
-  const result = await showModal({
-    title: '削除確認',
-    message: `${ch.characterName || ch.name} を削除しますか？`,
-    buttons: [
-      { label: '削除', value: 'delete', variant: 'primary' },
-      { label: 'キャンセル', value: 'cancel', variant: 'secondary' },
-    ],
-  });
+  const result = await showModal(
+    messages.characterHub.deleteConfirm(ch.characterName || ch.name),
+  );
   if (result.value === 'delete' && props.dataManager.googleDriveManager) {
     if (ch.id.startsWith('temp-')) {
       uiStore.cancelPendingDriveSave(ch.id);
       uiStore.removeDriveCharacter(ch.id);
-      showToast({ type: 'success', title: '削除完了', message: '' });
+      showToast({ type: 'success', ...messages.characterHub.delete.successToast });
       return;
     }
     const previous = [...uiStore.driveCharacters];
@@ -150,9 +141,9 @@ async function deleteChar(ch) {
         throw err;
       });
     showAsyncToast(deletePromise, {
-      loading: { title: '削除', message: '削除中...' },
-      success: { title: '削除完了', message: '' },
-      error: (err) => ({ title: '削除失敗', message: err.message || '' }),
+      loading: messages.characterHub.delete.asyncToast.loading,
+      success: messages.characterHub.delete.asyncToast.success,
+      error: (err) => messages.characterHub.delete.asyncToast.error(err),
     });
     await deletePromise;
   }
@@ -175,9 +166,9 @@ async function exportLocal(ch) {
       }
     });
   showAsyncToast(exportPromise, {
-    loading: { title: 'エクスポート', message: 'エクスポート中...' },
-    success: { title: 'エクスポート完了', message: '' },
-    error: (err) => ({ title: 'エクスポート失敗', message: err.message || '' }),
+    loading: messages.characterHub.export.loading,
+    success: messages.characterHub.export.success,
+    error: (err) => messages.characterHub.export.error(err),
   });
 }
 

--- a/src/components/ui/CharacterHub.vue
+++ b/src/components/ui/CharacterHub.vue
@@ -129,7 +129,7 @@ async function deleteChar(ch) {
     if (ch.id.startsWith('temp-')) {
       uiStore.cancelPendingDriveSave(ch.id);
       uiStore.removeDriveCharacter(ch.id);
-      showToast({ type: 'success', ...messages.characterHub.delete.successToast });
+      showToast({ type: 'success', ...messages.characterHub.delete.successToast() });
       return;
     }
     const previous = [...uiStore.driveCharacters];
@@ -141,8 +141,8 @@ async function deleteChar(ch) {
         throw err;
       });
     showAsyncToast(deletePromise, {
-      loading: messages.characterHub.delete.asyncToast.loading,
-      success: messages.characterHub.delete.asyncToast.success,
+      loading: messages.characterHub.delete.asyncToast.loading(),
+      success: messages.characterHub.delete.asyncToast.success(),
       error: (err) => messages.characterHub.delete.asyncToast.error(err),
     });
     await deletePromise;
@@ -166,8 +166,8 @@ async function exportLocal(ch) {
       }
     });
   showAsyncToast(exportPromise, {
-    loading: messages.characterHub.export.loading,
-    success: messages.characterHub.export.success,
+    loading: messages.characterHub.export.loading(),
+    success: messages.characterHub.export.success(),
     error: (err) => messages.characterHub.export.error(err),
   });
 }

--- a/src/components/ui/CharacterImageDisplay.vue
+++ b/src/components/ui/CharacterImageDisplay.vue
@@ -48,6 +48,7 @@ import { ref, computed, watch, nextTick } from 'vue';
 import { ImageManager } from '../../services/imageManager.js';
 import { useUiStore } from '../../stores/uiStore.js';
 import { useNotifications } from '../../composables/useNotifications.js';
+import { messages } from '../../locales/ja.js';
 
 const props = defineProps({
   images: {
@@ -132,7 +133,7 @@ const handleImageUpload = async (event) => {
     currentImageIndex.value = imagesInternal.value.length - 1;
   } catch (error) {
     console.error('Error loading image:', error);
-    showToast({ type: 'error', title: '画像読み込み失敗', message: error.message });
+    showToast({ type: 'error', ...messages.image.loadError(error) });
   } finally {
     event.target.value = null;
   }

--- a/src/components/ui/ShareModal.vue
+++ b/src/components/ui/ShareModal.vue
@@ -23,6 +23,7 @@ import ShareOptions from '../notifications/ShareOptions.vue';
 import { useUiStore } from '../../stores/uiStore.js';
 import { useShare } from '../../composables/useShare.js';
 import { useNotifications } from '../../composables/useNotifications.js';
+import { messages } from '../../locales/ja.js';
 
 const props = defineProps({ dataManager: Object });
 
@@ -41,7 +42,7 @@ async function generate() {
     expiresInDays: Number(options.value.expires.value) || 0,
   };
   if ((opts.type === 'dynamic' || opts.includeFull) && !uiStore.isSignedIn) {
-    showToast({ type: 'error', title: 'Drive', message: 'サインインしてください' });
+    showToast({ type: 'error', ...messages.share.needSignIn });
     return;
   }
   try {
@@ -49,7 +50,7 @@ async function generate() {
     await copyLink(link);
     uiStore.closeShareModal();
   } catch (err) {
-    showToast({ type: 'error', title: '共有リンク生成失敗', message: err.message });
+    showToast({ type: 'error', ...messages.share.generateFailed(err) });
   }
 }
 </script>

--- a/src/components/ui/ShareModal.vue
+++ b/src/components/ui/ShareModal.vue
@@ -42,7 +42,7 @@ async function generate() {
     expiresInDays: Number(options.value.expires.value) || 0,
   };
   if ((opts.type === 'dynamic' || opts.includeFull) && !uiStore.isSignedIn) {
-    showToast({ type: 'error', ...messages.share.needSignIn });
+    showToast({ type: 'error', ...messages.share.needSignIn() });
     return;
   }
   try {

--- a/src/composables/useDataExport.js
+++ b/src/composables/useDataExport.js
@@ -4,6 +4,7 @@ import { CocofoliaExporter } from "../services/cocofoliaExporter.js";
 import { AioniaGameData } from "../data/gameData.js";
 import { useCharacterStore } from "../stores/characterStore.js";
 import { useNotifications } from "./useNotifications.js";
+import { messages } from "../locales/ja.js";
 
 export function useDataExport(footerRef) {
   const characterStore = useCharacterStore();
@@ -11,7 +12,7 @@ export function useDataExport(footerRef) {
   const cocofoliaExporter = new CocofoliaExporter();
   const { showToast } = useNotifications();
 
-  const outputButtonText = ref(AioniaGameData.uiMessages.outputButton.default);
+  const outputButtonText = ref(messages.outputButton.default);
 
   function saveData() {
     dataManager.saveData(
@@ -48,8 +49,7 @@ export function useDataExport(footerRef) {
       (errorMessage) =>
         showToast({
           type: "error",
-          title: "読み込み失敗",
-          message: errorMessage,
+          ...messages.dataExport.loadError(errorMessage),
         }),
     );
   }
@@ -57,7 +57,7 @@ export function useDataExport(footerRef) {
   function playOutputAnimation() {
     const button = footerRef.value?.outputButton;
     if (!button || button.classList.contains("is-animating")) return;
-    const buttonMessages = AioniaGameData.uiMessages.outputButton;
+    const buttonMessages = messages.outputButton;
     const timings = buttonMessages.animationTimings;
 
     button.classList.add("is-animating", "state-1");
@@ -121,17 +121,16 @@ export function useDataExport(footerRef) {
       if (successful) {
         playOutputAnimation();
       } else {
-        outputButtonText.value = AioniaGameData.uiMessages.outputButton.failed;
+        outputButtonText.value = messages.outputButton.failed;
         setTimeout(() => {
-          outputButtonText.value =
-            AioniaGameData.uiMessages.outputButton.default;
+          outputButtonText.value = messages.outputButton.default;
         }, 3000);
       }
     } catch (err) {
       console.error(err);
-      outputButtonText.value = AioniaGameData.uiMessages.outputButton.error;
+      outputButtonText.value = messages.outputButton.error;
       setTimeout(() => {
-        outputButtonText.value = AioniaGameData.uiMessages.outputButton.default;
+        outputButtonText.value = messages.outputButton.default;
       }, 3000);
     }
     document.body.removeChild(textArea);
@@ -155,7 +154,6 @@ export function useDataExport(footerRef) {
     const textToCopy = JSON.stringify(cocofoliaCharacter, null, 2);
     copyToClipboard(textToCopy);
   }
-
 
   return {
     dataManager,

--- a/src/composables/useGoogleDrive.js
+++ b/src/composables/useGoogleDrive.js
@@ -3,6 +3,7 @@ import { GoogleDriveManager } from "../services/googleDriveManager.js";
 import { useUiStore } from "../stores/uiStore.js";
 import { useCharacterStore } from "../stores/characterStore.js";
 import { useNotifications } from "./useNotifications.js";
+import { messages } from "../locales/ja.js";
 
 export function useGoogleDrive(dataManager) {
   const uiStore = useUiStore();
@@ -27,12 +28,9 @@ export function useGoogleDrive(dataManager) {
       });
     });
     showAsyncToast(signInPromise, {
-      loading: { title: "Google Drive", message: "Signing in..." },
-      success: { title: "Signed in", message: "" },
-      error: (err) => ({
-        title: "Sign-in failed",
-        message: err.message || err.details || "Please try again.",
-      }),
+      loading: messages.googleDrive.signIn.loading,
+      success: messages.googleDrive.signIn.success,
+      error: (err) => messages.googleDrive.signIn.error(err),
     });
   }
 
@@ -41,7 +39,7 @@ export function useGoogleDrive(dataManager) {
     googleDriveManager.value.handleSignOut(() => {
       uiStore.isSignedIn = false;
       uiStore.clearDriveCharacters();
-      showToast({ type: "success", title: "Signed out", message: "" });
+      showToast({ type: "success", ...messages.googleDrive.signOut.success });
     });
   }
 
@@ -52,8 +50,7 @@ export function useGoogleDrive(dataManager) {
       if (err || !folder) {
         showToast({
           type: "error",
-          title: "Drive",
-          message: err?.message || "フォルダ選択をキャンセルしました",
+          ...messages.googleDrive.folderPicker.error(err),
         });
         return;
       }
@@ -110,9 +107,9 @@ export function useGoogleDrive(dataManager) {
         });
 
       showAsyncToast(savePromise, {
-        loading: { title: "Google Drive", message: "Saving..." },
-        success: { title: "Saved", message: "" },
-        error: (err) => ({ title: "Save failed", message: err.message || "" }),
+        loading: messages.googleDrive.save.loading,
+        success: messages.googleDrive.save.success,
+        error: (err) => messages.googleDrive.save.error(err),
       });
       return savePromise;
     } else {
@@ -146,9 +143,9 @@ export function useGoogleDrive(dataManager) {
         });
 
       showAsyncToast(savePromise, {
-        loading: { title: "Google Drive", message: "Saving..." },
-        success: { title: "Saved", message: "" },
-        error: (err) => ({ title: "Save failed", message: err.message || "" }),
+        loading: messages.googleDrive.save.loading,
+        success: messages.googleDrive.save.success,
+        error: (err) => messages.googleDrive.save.error(err),
       });
       return savePromise;
     }
@@ -176,11 +173,7 @@ export function useGoogleDrive(dataManager) {
         await googleDriveManager.value.onGapiLoad();
         console.info("Google API Ready");
       } catch {
-        showToast({
-          type: "error",
-          title: "Google API Error",
-          message: "Initializing failed",
-        });
+        showToast({ type: "error", ...messages.googleDrive.apiInitError });
       }
     };
 
@@ -192,11 +185,7 @@ export function useGoogleDrive(dataManager) {
         await googleDriveManager.value.onGisLoad();
         console.info("Google Sign-In Ready");
       } catch {
-        showToast({
-          type: "error",
-          title: "Google Sign-In Error",
-          message: "Initializing failed",
-        });
+        showToast({ type: "error", ...messages.googleDrive.signInInitError });
       }
     };
 

--- a/src/composables/useGoogleDrive.js
+++ b/src/composables/useGoogleDrive.js
@@ -28,8 +28,8 @@ export function useGoogleDrive(dataManager) {
       });
     });
     showAsyncToast(signInPromise, {
-      loading: messages.googleDrive.signIn.loading,
-      success: messages.googleDrive.signIn.success,
+      loading: messages.googleDrive.signIn.loading(),
+      success: messages.googleDrive.signIn.success(),
       error: (err) => messages.googleDrive.signIn.error(err),
     });
   }
@@ -39,7 +39,7 @@ export function useGoogleDrive(dataManager) {
     googleDriveManager.value.handleSignOut(() => {
       uiStore.isSignedIn = false;
       uiStore.clearDriveCharacters();
-      showToast({ type: "success", ...messages.googleDrive.signOut.success });
+      showToast({ type: "success", ...messages.googleDrive.signOut.success() });
     });
   }
 
@@ -107,8 +107,8 @@ export function useGoogleDrive(dataManager) {
         });
 
       showAsyncToast(savePromise, {
-        loading: messages.googleDrive.save.loading,
-        success: messages.googleDrive.save.success,
+        loading: messages.googleDrive.save.loading(),
+        success: messages.googleDrive.save.success(),
         error: (err) => messages.googleDrive.save.error(err),
       });
       return savePromise;
@@ -143,8 +143,8 @@ export function useGoogleDrive(dataManager) {
         });
 
       showAsyncToast(savePromise, {
-        loading: messages.googleDrive.save.loading,
-        success: messages.googleDrive.save.success,
+        loading: messages.googleDrive.save.loading(),
+        success: messages.googleDrive.save.success(),
         error: (err) => messages.googleDrive.save.error(err),
       });
       return savePromise;
@@ -173,7 +173,7 @@ export function useGoogleDrive(dataManager) {
         await googleDriveManager.value.onGapiLoad();
         console.info("Google API Ready");
       } catch {
-        showToast({ type: "error", ...messages.googleDrive.apiInitError });
+        showToast({ type: "error", ...messages.googleDrive.apiInitError() });
       }
     };
 
@@ -185,7 +185,7 @@ export function useGoogleDrive(dataManager) {
         await googleDriveManager.value.onGisLoad();
         console.info("Google Sign-In Ready");
       } catch {
-        showToast({ type: "error", ...messages.googleDrive.signInInitError });
+        showToast({ type: "error", ...messages.googleDrive.signInInitError() });
       }
     };
 

--- a/src/composables/useShare.js
+++ b/src/composables/useShare.js
@@ -4,6 +4,7 @@ import { arrayBufferToBase64 } from "../libs/sabalessshare/crypto.js";
 import { DriveStorageAdapter } from "../services/driveStorageAdapter.js";
 import { useCharacterStore } from "../stores/characterStore.js";
 import { useNotifications } from "./useNotifications.js";
+import { messages } from "../locales/ja.js";
 
 export function useShare(dataManager) {
   const characterStore = useCharacterStore();
@@ -72,13 +73,9 @@ export function useShare(dataManager) {
   async function copyLink(link) {
     try {
       await navigator.clipboard.writeText(link);
-      showToast({
-        type: "success",
-        title: "共有リンクをコピーしました",
-        message: link,
-      });
+      showToast({ type: "success", ...messages.share.copied(link) });
     } catch (err) {
-      showToast({ type: "error", title: "コピー失敗", message: err.message });
+      showToast({ type: "error", ...messages.share.copyFailed(err) });
     }
   }
 

--- a/src/data/gameData.js
+++ b/src/data/gameData.js
@@ -333,27 +333,6 @@ export const AioniaGameData = {
     maxWeaknesses: 10,
   },
 
-  // UIメッセージ
-  uiMessages: {
-    outputButton: {
-      default: "ココフォリア駒出力",
-      success: "コピー完了！",
-      successFallback: "コピー完了！ (fallback)",
-      failed: "コピー失敗 (fallback)",
-      error: "コピーエラー (fallback)",
-      animating: "冒険が始まる――",
-      animationTimings: {
-        state1_bgFill: 500,
-        state2_textHold: 1000,
-        state3_textFadeOut: 500,
-        state4_bgReset: 700,
-      },
-    },
-    weaknessDropdownHelp: "（冒険の記録を追加すると選択肢が増えます）",
-    fileLoadError:
-      "ファイルの読み込みに失敗しました。JSON形式が正しくない可能性があります。",
-  },
-
   // ヘルプテキスト
   helpText: `#### 基本操作
 - **データ保存**: 画面下部の「端末保存」ボタンで、入力内容をお使いの端末にファイル(.json または .zip)としてダウンロードできます。

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -1,14 +1,19 @@
 export const messages = {
   googleDrive: {
     signIn: {
-      loading: { title: "Google Drive", message: "サインインしています..." },
-      success: { title: "サインイン完了", message: "" },
+      loading: () => ({
+        title: "Google Drive",
+        message: "サインインしています...",
+      }),
+      success: () => ({ title: "サインイン完了", message: "" }),
       error: (err) => ({
         title: "サインイン失敗",
         message: err.message || err.details || "もう一度お試しください。",
       }),
     },
-    signOut: { success: { title: "サインアウトしました", message: "" } },
+    signOut: {
+      success: () => ({ title: "サインアウトしました", message: "" }),
+    },
     folderPicker: {
       error: (err) => ({
         title: "Google Drive",
@@ -16,8 +21,8 @@ export const messages = {
       }),
     },
     save: {
-      loading: { title: "Google Drive", message: "保存中..." },
-      success: { title: "保存完了", message: "" },
+      loading: () => ({ title: "Google Drive", message: "保存中..." }),
+      success: () => ({ title: "保存完了", message: "" }),
       error: (err) => ({ title: "保存失敗", message: err.message || "" }),
     },
     load: {
@@ -34,19 +39,22 @@ export const messages = {
         message: err.message || "不明なエラー",
       }),
     },
-    apiInitError: {
+    apiInitError: () => ({
       title: "Google API エラー",
       message: "初期化に失敗しました",
-    },
-    signInInitError: {
+    }),
+    signInInitError: () => ({
       title: "Google サインインエラー",
       message: "初期化に失敗しました",
-    },
+    }),
   },
   share: {
     copied: (link) => ({ title: "共有リンクをコピーしました", message: link }),
     copyFailed: (err) => ({ title: "コピー失敗", message: err.message }),
-    needSignIn: { title: "Google Drive", message: "サインインしてください" },
+    needSignIn: () => ({
+      title: "Google Drive",
+      message: "サインインしてください",
+    }),
     generateFailed: (err) => ({
       title: "共有リンク生成失敗",
       message: err.message,
@@ -64,24 +72,30 @@ export const messages = {
     loadConfirm: (name) => ({
       title: "読込確認",
       message: `${name} を読み込みますか？`,
-      buttons: { load: "読込", cancel: "キャンセル" },
+      buttons: [
+        { label: "読込", value: "load", variant: "primary" },
+        { label: "キャンセル", value: "cancel", variant: "secondary" },
+      ],
     }),
     deleteConfirm: (name) => ({
       title: "削除確認",
       message: `${name} を削除しますか？`,
-      buttons: { delete: "削除", cancel: "キャンセル" },
+      buttons: [
+        { label: "削除", value: "delete", variant: "primary" },
+        { label: "キャンセル", value: "cancel", variant: "secondary" },
+      ],
     }),
     delete: {
-      successToast: { title: "削除完了", message: "" },
+      successToast: () => ({ title: "削除完了", message: "" }),
       asyncToast: {
-        loading: { title: "削除", message: "削除中..." },
-        success: { title: "削除完了", message: "" },
+        loading: () => ({ title: "削除", message: "削除中..." }),
+        success: () => ({ title: "削除完了", message: "" }),
         error: (err) => ({ title: "削除失敗", message: err.message || "" }),
       },
     },
     export: {
-      loading: { title: "エクスポート", message: "エクスポート中..." },
-      success: { title: "エクスポート完了", message: "" },
+      loading: () => ({ title: "エクスポート", message: "エクスポート中..." }),
+      success: () => ({ title: "エクスポート完了", message: "" }),
       error: (err) => ({
         title: "エクスポート失敗",
         message: err.message || "",

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -1,0 +1,116 @@
+export const messages = {
+  googleDrive: {
+    signIn: {
+      loading: { title: "Google Drive", message: "サインインしています..." },
+      success: { title: "サインイン完了", message: "" },
+      error: (err) => ({
+        title: "サインイン失敗",
+        message: err.message || err.details || "もう一度お試しください。",
+      }),
+    },
+    signOut: { success: { title: "サインアウトしました", message: "" } },
+    folderPicker: {
+      error: (err) => ({
+        title: "Google Drive",
+        message: err?.message || "フォルダ選択をキャンセルしました",
+      }),
+    },
+    save: {
+      loading: { title: "Google Drive", message: "保存中..." },
+      success: { title: "保存完了", message: "" },
+      error: (err) => ({ title: "保存失敗", message: err.message || "" }),
+    },
+    load: {
+      loading: (name) => ({
+        title: "Google Drive",
+        message: `${name} を読み込み中...`,
+      }),
+      success: (name) => ({
+        title: "読込完了",
+        message: `${name} を読み込みました`,
+      }),
+      error: (err) => ({
+        title: "読み込みエラー",
+        message: err.message || "不明なエラー",
+      }),
+    },
+    apiInitError: {
+      title: "Google API エラー",
+      message: "初期化に失敗しました",
+    },
+    signInInitError: {
+      title: "Google サインインエラー",
+      message: "初期化に失敗しました",
+    },
+  },
+  share: {
+    copied: (link) => ({ title: "共有リンクをコピーしました", message: link }),
+    copyFailed: (err) => ({ title: "コピー失敗", message: err.message }),
+    needSignIn: { title: "Google Drive", message: "サインインしてください" },
+    generateFailed: (err) => ({
+      title: "共有リンク生成失敗",
+      message: err.message,
+    }),
+    loadError: {
+      general: "共有データ読み込み失敗",
+      invalid: "共有リンクが不正です",
+      expired: "共有リンクの有効期限が切れています",
+      passwordRequired: "パスワードが必要です",
+      decryptionFailed: "復号に失敗しました",
+      toastTitle: "共有データエラー",
+    },
+  },
+  characterHub: {
+    loadConfirm: (name) => ({
+      title: "読込確認",
+      message: `${name} を読み込みますか？`,
+      buttons: { load: "読込", cancel: "キャンセル" },
+    }),
+    deleteConfirm: (name) => ({
+      title: "削除確認",
+      message: `${name} を削除しますか？`,
+      buttons: { delete: "削除", cancel: "キャンセル" },
+    }),
+    delete: {
+      successToast: { title: "削除完了", message: "" },
+      asyncToast: {
+        loading: { title: "削除", message: "削除中..." },
+        success: { title: "削除完了", message: "" },
+        error: (err) => ({ title: "削除失敗", message: err.message || "" }),
+      },
+    },
+    export: {
+      loading: { title: "エクスポート", message: "エクスポート中..." },
+      success: { title: "エクスポート完了", message: "" },
+      error: (err) => ({
+        title: "エクスポート失敗",
+        message: err.message || "",
+      }),
+    },
+  },
+  image: {
+    loadError: (err) => ({ title: "画像読み込み失敗", message: err.message }),
+  },
+  dataExport: {
+    loadError: (msg) => ({ title: "読み込み失敗", message: msg }),
+  },
+  file: {
+    loadError:
+      "ファイルの読み込みに失敗しました。JSON形式が正しくない可能性があります。",
+  },
+  outputButton: {
+    default: "ココフォリア駒出力",
+    success: "コピー完了！",
+    successFallback: "コピー完了！ (fallback)",
+    failed: "コピー失敗 (fallback)",
+    error: "コピーエラー (fallback)",
+    animating: "冒険が始まる――",
+    animationTimings: {
+      state1_bgFill: 500,
+      state2_textHold: 1000,
+      state3_textFadeOut: 500,
+      state4_bgReset: 700,
+    },
+  },
+  weaknessDropdownHelp: "（冒険の記録を追加すると選択肢が増えます）",
+};

--- a/src/services/dataManager.js
+++ b/src/services/dataManager.js
@@ -24,11 +24,6 @@ export class DataManager {
     return sanitized || "Aionia_Character";
   }
 
-  _sanitizeFileName(name) {
-    const sanitized = (name || "").replace(/[\\/:*?"<>|]/g, "_").trim();
-    return sanitized || "Aionia_Character";
-  }
-
   /**
    * キャラクターデータを保存
    */

--- a/src/services/dataManager.js
+++ b/src/services/dataManager.js
@@ -1,5 +1,6 @@
 import { createWeaknessArray, deepClone } from "../utils/utils.js";
 import JSZip from "jszip";
+import { messages } from "../locales/ja.js";
 
 /**
  * データ管理系の機能を担当するクラス
@@ -215,12 +216,7 @@ export class DataManager {
           onSuccess(parsedData);
         } catch (error) {
           console.error("Failed to parse ZIP file:", error);
-          onError(
-            this.gameData.uiMessages.fileLoadError +
-              " (ZIP: " +
-              error.message +
-              ")",
-          );
+          onError(messages.file.loadError + " (ZIP: " + error.message + ")");
         }
       };
       reader.readAsArrayBuffer(file); // Read ZIP as ArrayBuffer
@@ -234,7 +230,7 @@ export class DataManager {
           onSuccess(parsedData);
         } catch (error) {
           console.error("Failed to parse JSON file:", error);
-          onError(this.gameData.uiMessages.fileLoadError);
+          onError(messages.file.loadError);
         }
       };
       reader.readAsText(file);
@@ -414,7 +410,7 @@ export class DataManager {
       console.error("Error loading data from Google Drive:", error);
       // Check if it's a parsing error from JSON.parse or from parseLoadedData
       if (error instanceof SyntaxError) {
-        throw new Error(this.gameData.uiMessages.fileLoadError);
+        throw new Error(messages.file.loadError);
       }
       throw error; // Re-throw other errors
     }

--- a/src/stores/characterStore.js
+++ b/src/stores/characterStore.js
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { AioniaGameData } from "../data/gameData.js";
+import { messages } from "../locales/ja.js";
 import { deepClone, createWeaknessArray } from "../utils/utils.js";
 
 function createCharacter() {
@@ -115,7 +116,7 @@ export const useCharacterStore = defineStore("character", {
         .map((name) => ({ value: name, text: name, disabled: false }));
       const helpOption = {
         value: "help-text",
-        text: AioniaGameData.uiMessages.weaknessDropdownHelp,
+        text: messages.weaknessDropdownHelp,
         disabled: true,
       };
       return defaultOptions.concat(sessionOptions, helpOption);


### PR DESCRIPTION
## Summary
- create `src/locales/ja.js` to store all toast and modal messages
- migrate hard-coded strings across components and composables
- remove old `uiMessages` from game data
- import and use messages where notifications are displayed

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_685148a02afc83269b3432d9d991ca8e