### PR TITLE
Fix modal event forwarding

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -73,6 +73,10 @@ async function openHub() {
       saveToDrive: saveCharacterToDrive,
     },
     buttons: [],
+    on: {
+      'sign-in': handleSignInClick,
+      'sign-out': handleSignOutClick,
+    },
   });
 }
 

--- a/src/components/modals/BaseModal.vue
+++ b/src/components/modals/BaseModal.vue
@@ -10,7 +10,12 @@
           <div class="modal-title">{{ modal.title }}</div>
         </div>
         <div class="modal-message" v-if="modal.message">{{ modal.message }}</div>
-        <component :is="modal.component" v-bind="modal.props" ref="inner" />
+        <component
+          :is="modal.component"
+          v-bind="modal.props"
+          v-on="modal.events"
+          ref="inner"
+        />
         <div class="modal-actions">
           <button
             v-for="(btn, index) in modal.buttons"

--- a/src/stores/modalStore.js
+++ b/src/stores/modalStore.js
@@ -9,6 +9,7 @@ export const useModalStore = defineStore("modal", {
     component: shallowRef(null),
     props: {},
     buttons: [],
+    events: {},
     resolvePromise: null,
     rejectPromise: null,
   }),
@@ -21,6 +22,7 @@ export const useModalStore = defineStore("modal", {
         this.component = options.component || null;
         this.props = options.props || {};
         this.buttons = options.buttons || [];
+        this.events = options.on || {};
         this.resolvePromise = resolve;
         this.rejectPromise = reject;
       });
@@ -32,6 +34,7 @@ export const useModalStore = defineStore("modal", {
       this.component = null;
       this.props = {};
       this.buttons = [];
+      this.events = {};
       this.resolvePromise = null;
       this.rejectPromise = null;
     },

--- a/tests/unit/stores/modalStore.test.js
+++ b/tests/unit/stores/modalStore.test.js
@@ -23,4 +23,13 @@ describe("modalStore", () => {
     expect(store.component).toBe(component);
     expect(store.props.foo).toBe("bar");
   });
+
+  test("showModal stores events and resets", () => {
+    const store = useModalStore();
+    const handler = jest.fn();
+    store.showModal({ on: { foo: handler } });
+    expect(store.events.foo).toBe(handler);
+    store.hideModal();
+    expect(store.events).toEqual({});
+  });
 });


### PR DESCRIPTION
## Summary
- keep event handlers in `modalStore`
- forward them to injected components in `BaseModal`
- connect `CharacterHub` sign-in events via new `showModal` option
- test event handler storage/reset

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`

------
https://chatgpt.com/codex/tasks/task_e_685153d2e2c48326ba8313336cbfa69e