### PR TITLE
Implement submodule mocks for Jest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Init submodules
+        run: git submodule update --init --recursive
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -27,6 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Init submodules
+        run: git submodule update --init --recursive
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -41,6 +49,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Init submodules
+        run: git submodule update --init --recursive
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -70,6 +82,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Init submodules
+        run: git submodule update --init --recursive
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -96,6 +112,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Init submodules
+        run: git submodule update --init --recursive
       - name: Set build info
         run: |
           echo "VITE_BUILD_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
@@ -129,6 +149,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Init submodules
+        run: git submodule update --init --recursive
       - name: Set build info
         run: |
           echo "VITE_BUILD_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV

--- a/package.json
+++ b/package.json
@@ -53,13 +53,20 @@
     "roots": [
       "<rootDir>/tests/unit"
     ],
+    "modulePaths": [
+      "<rootDir>/src"
+    ],
+    "setupFiles": [
+      "<rootDir>/tests/unit/setup.js"
+    ],
     "testEnvironment": "jsdom",
     "transform": {
       "^.+\\.js$": "babel-jest"
     },
     "moduleNameMapper": {
       "^(\\.{1,2}/.*)\\.js$": "$1",
-      "\\?raw$": "<rootDir>/tests/unit/__mocks__/raw.js"
+      "\\?raw$": "<rootDir>/tests/unit/__mocks__/raw.js",
+      "^@sabalessshare/(.*)$": "<rootDir>/src/libs/sabalessshare/src/$1"
     }
   },
   "lint-staged": {

--- a/tests/unit/__mocks__/sabalessshare.js
+++ b/tests/unit/__mocks__/sabalessshare.js
@@ -1,0 +1,23 @@
+export function createShareLink() {
+  return Promise.resolve("mock-link");
+}
+
+export function receiveSharedData() {
+  return Promise.resolve(new ArrayBuffer(0));
+}
+
+export function createDynamicLink() {
+  return Promise.resolve({ shareLink: "dynamic-link" });
+}
+
+export function receiveDynamicData() {
+  return Promise.resolve(new ArrayBuffer(0));
+}
+
+export function arrayBufferToBase64(buffer) {
+  return Buffer.from(buffer).toString("base64");
+}
+
+export function base64ToArrayBuffer(str) {
+  return Uint8Array.from(Buffer.from(str, "base64")).buffer;
+}

--- a/tests/unit/driveStorageAdapter.test.js
+++ b/tests/unit/driveStorageAdapter.test.js
@@ -1,6 +1,10 @@
 import { DriveStorageAdapter } from "../../src/services/driveStorageAdapter.js";
 import { arrayBufferToBase64 } from "../../src/libs/sabalessshare/src/crypto.js";
 
+jest.mock("../../src/libs/sabalessshare/src/crypto.js", () =>
+  jest.requireActual("./__mocks__/sabalessshare.js"),
+);
+
 describe("DriveStorageAdapter", () => {
   let adapter;
   let gdm;

--- a/tests/unit/setup.js
+++ b/tests/unit/setup.js
@@ -1,0 +1,13 @@
+import { webcrypto } from "crypto";
+
+if (!global.crypto) {
+  global.crypto = webcrypto;
+}
+
+// Ensure TextEncoder and TextDecoder are available
+if (typeof global.TextEncoder === "undefined") {
+  global.TextEncoder = webcrypto.TextEncoder;
+}
+if (typeof global.TextDecoder === "undefined") {
+  global.TextDecoder = webcrypto.TextDecoder;
+}

--- a/vite.config.cjs
+++ b/vite.config.cjs
@@ -1,7 +1,18 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import { resolve } from 'path'
 
 export default defineConfig({
   base: './',
   plugins: [vue()],
+  resolve: {
+    alias: {
+      '@sabalessshare': resolve(__dirname, 'src/libs/sabalessshare/src')
+    }
+  },
+  server: {
+    fs: {
+      allow: ['src/libs/sabalessshare', '.']
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- enable recursive submodules checkout in CI
- configure Jest paths and setup files
- alias SabaLessShare in Vite and allow its path
- add crypto setup for tests and mock SabaLessShare
- update DriveStorageAdapter test to use mocks

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_685235551c9c8326940591892279825b