### PR TITLE
Implement refreshed header and footer UI

### DIFF
--- a/src/assets/css/_components.css
+++ b/src/assets/css/_components.css
@@ -428,6 +428,14 @@ textarea.greyed-out {
   mask-image: url("../svg/medieval_local_download.svg");
 }
 
+.icon-svg-io {
+  mask-image: url("../svg/medieval_io.svg");
+}
+
+.icon-svg-share {
+  mask-image: url("../svg/medieval_share.svg");
+}
+
 .icon-svg--footer {
   width: 30px;
   height: 30px;

--- a/src/assets/css/_layout.css
+++ b/src/assets/css/_layout.css
@@ -119,6 +119,35 @@
   min-width: 65px;
 }
 
+/* ヘッダー */
+.main-header {
+  display: flex;
+  align-items: center;
+  padding: 10px 25px;
+  border-bottom: 1px solid var(--color-border-normal);
+  background-color: var(--color-background);
+  box-sizing: border-box;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 100;
+  box-shadow: 0 3px 8px rgb(0 0 0 / 50%);
+  justify-content: space-between;
+  transition: transform 0.3s ease;
+}
+
+.main-header--hidden {
+  transform: translateY(-100%);
+}
+
+.main-header__title {
+  flex: 1 1 auto;
+  text-align: center;
+  font-weight: bold;
+  color: var(--color-accent);
+}
+
 /* フッター */
 .main-footer {
   display: flex;

--- a/src/components/modals/contents/IoModal.vue
+++ b/src/components/modals/contents/IoModal.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="io-modal">
+    <button class="button-base button-compact" @click="$emit('print')">印刷</button>
+    <button class="button-base button-compact" @click="$emit('cocofolia')">ココフォリア駒出力</button>
+    <button
+      v-if="props.isSignedIn"
+      class="button-base button-compact"
+      @click="$emit('local-save')"
+    >端末保存</button>
+    <label
+      v-if="props.isSignedIn"
+      class="button-base button-compact"
+    >端末読込
+      <input type="file" class="hidden" @change="(e) => $emit('local-load', e)" accept=".json,.txt,.zip" />
+    </label>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({ isSignedIn: Boolean });
+const emit = defineEmits(['print', 'cocofolia', 'local-save', 'local-load']);
+</script>
+
+<style scoped>
+.io-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+</style>
+

--- a/src/components/ui/MainHeader.vue
+++ b/src/components/ui/MainHeader.vue
@@ -1,0 +1,70 @@
+<template>
+  <div :class="['main-header', { 'main-header--hidden': !headerVisible }]" ref="headerRef">
+    <button
+      v-if="uiStore.isSignedIn"
+      class="button-base icon-button"
+      title="Cloud Hub"
+      @click="$emit('open-hub')"
+    >
+      <span class="icon-svg icon-svg-cloud" aria-label="Cloud"></span>
+    </button>
+    <div class="main-header__title">{{ title }}</div>
+    <div
+      class="footer-help-icon"
+      @mouseover="$emit('help-mouseover')"
+      @mouseleave="$emit('help-mouseleave')"
+      @click="$emit('help-click')"
+      tabindex="0"
+    >
+      ？
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch, onMounted, onBeforeUnmount } from 'vue';
+import { useUiStore } from '../../stores/uiStore.js';
+import { useCharacterStore } from '../../stores/characterStore.js';
+
+const emit = defineEmits(['open-hub', 'help-mouseover', 'help-mouseleave', 'help-click']);
+const uiStore = useUiStore();
+const characterStore = useCharacterStore();
+
+const title = ref('Aionia TRPG Character Sheet');
+const headerRef = ref(null);
+
+watch(
+  () => characterStore.character.name,
+  (val) => {
+    if (val) {
+      title.value = val;
+      document.title = val;
+    }
+  },
+  { immediate: true },
+);
+
+const headerVisible = ref(true);
+let lastScroll = 0;
+function onScroll() {
+  const y = window.scrollY || window.pageYOffset;
+  if (y > lastScroll && y > 50) {
+    headerVisible.value = false;
+  } else if (y < lastScroll) {
+    headerVisible.value = true;
+  }
+  lastScroll = y;
+}
+
+onMounted(() => {
+  window.addEventListener('scroll', onScroll);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('scroll', onScroll);
+});
+</script>
+
+<style scoped>
+</style>
+

--- a/src/layouts/CharacterSheetLayout.vue
+++ b/src/layouts/CharacterSheetLayout.vue
@@ -14,6 +14,14 @@ import AdventureLogSection from '../components/sections/AdventureLogSection.vue'
 const characterStore = useCharacterStore();
 const { showModal } = useModal();
 
+const buildBranch = import.meta.env.VITE_BUILD_BRANCH;
+const buildHash = import.meta.env.VITE_BUILD_HASH;
+const buildDate = import.meta.env.VITE_BUILD_DATE;
+const buildInfo =
+  buildBranch && buildHash && buildDate
+    ? `${buildBranch} (${buildHash}) ${buildDate}`
+    : '';
+
 async function openPrivacyPolicy() {
   await showModal({
     component: PrivacyPolicyModal,
@@ -40,5 +48,6 @@ async function openPrivacyPolicy() {
       本サイトは<a href="https://bright-trpg.github.io/aionia_character_maker/" target="_blank" rel="noopener noreferrer">bright-trpg様作成の「慈悲なきアイオニア　キャラクター作成用ツール」</a>をもとに、あろすてりっくが作成しました。
     </p>
     <button class="button-link" @click="openPrivacyPolicy">プライバシーポリシー</button>
+    <div v-if="buildInfo" class="footer-build-info">{{ buildInfo }}</div>
   </div>
 </template>

--- a/tests/unit/setup.js
+++ b/tests/unit/setup.js
@@ -1,4 +1,6 @@
 import { webcrypto } from "crypto";
+import * as Vue from "vue";
+import * as VueCompilerDOM from "@vue/compiler-dom";
 
 if (!global.crypto) {
   global.crypto = webcrypto;
@@ -11,3 +13,6 @@ if (typeof global.TextEncoder === "undefined") {
 if (typeof global.TextDecoder === "undefined") {
   global.TextDecoder = webcrypto.TextDecoder;
 }
+
+global.Vue = Vue;
+global.VueCompilerDOM = VueCompilerDOM;


### PR DESCRIPTION
## Summary
- add MainHeader with dynamic title and scroll hide
- revamp MainFooter buttons and tooltips
- move build info into CharacterSheetLayout
- create IoModal for additional I/O actions
- style updates for new header and icons
- adjust app logic and tests

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_6852e7d10b4483269102478b143347eb