### PR TITLE
Improve share options modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "moduleNameMapper": {
       "^(\\.{1,2}/.*)\\.js$": "$1",
       "\\?raw$": "<rootDir>/tests/unit/__mocks__/raw.js",
-      "^@sabalessshare/(.*)$": "<rootDir>/src/libs/sabalessshare/src/$1"
+      "^@sabalessshare/(.*)$": "<rootDir>/src/libs/sabalessshare/src/$1",
+      "^@vue/test-utils$": "<rootDir>/node_modules/@vue/test-utils/dist/vue-test-utils.cjs.js"
     }
   },
   "lint-staged": {

--- a/src/components/modals/BaseModal.vue
+++ b/src/components/modals/BaseModal.vue
@@ -34,6 +34,7 @@
               v-for="(btn, index) in modal.buttons"
               :key="index"
               :class="['modal-button', `modal-button--${btn.variant || 'secondary'}`]"
+              :disabled="btn.disabled"
               @click="resolve(btn.value)"
             >
               {{ btn.label }}

--- a/src/components/modals/contents/ShareOptions.vue
+++ b/src/components/modals/contents/ShareOptions.vue
@@ -1,41 +1,71 @@
 <template>
   <div class="share-options">
-    <div class="share-options__row">
-      <label><input type="radio" value="snapshot" v-model="type" />スナップショット</label>
-      <label><input type="radio" value="dynamic" v-model="type" />ライブリンク</label>
-    </div>
-    <div class="share-options__row">
-      <label><input type="checkbox" v-model="includeFull" />全文・画像を含める</label>
-      <p v-if="showTruncateWarning" class="share-options__warning">全文を含めないと内容が省略されます</p>
-    </div>
-    <div class="share-options__row">
-      <label>パスワード <input type="text" v-model="password" /></label>
-    </div>
-    <div class="share-options__row">
-      <label>有効期限
-        <select v-model="expires">
-          <option value="1">1日</option>
-          <option value="7">7日</option>
-          <option value="0">無期限</option>
-        </select>
-      </label>
-    </div>
-    <button v-if="needSignin" @click="handleSignin">Google Drive にサインイン</button>
+    <section class="share-options__section">
+      <h3 class="share-options__heading">共有の種類</h3>
+      <div class="share-options__row">
+        <label class="share-options__option">
+          <input type="radio" value="snapshot" v-model="type" />この瞬間の状態を共有（スナップショット）
+        </label>
+      </div>
+      <div class="share-options__row">
+        <label class="share-options__option">
+          <input type="radio" value="dynamic" v-model="type" />編集を反映するリンク（ライブリンク）
+        </label>
+        <span class="share-options__note">Google Drive連携が必要です</span>
+      </div>
+    </section>
+    <section class="share-options__section">
+      <h3 class="share-options__heading">追加オプション</h3>
+      <div class="share-options__row">
+        <label class="share-options__option">
+          <input type="checkbox" v-model="includeFull" />全文・画像を含める
+        </label>
+        <span class="share-options__note">Google Drive連携が必要です</span>
+      </div>
+      <p v-if="showTruncateWarning" class="share-options__warning">内容が一部省略される可能性があります</p>
+      <div class="share-options__row">
+        <label class="share-options__option">
+          <input type="checkbox" v-model="enablePassword" />パスワード保護
+        </label>
+      </div>
+      <div class="share-options__row" v-if="enablePassword">
+        <input type="text" v-model="password" class="share-options__password-input" />
+      </div>
+      <div class="share-options__row">
+        <label class="share-options__option">有効期限
+          <select v-model="expires">
+            <option value="1">1日</option>
+            <option value="7">7日</option>
+            <option value="0">無期限</option>
+          </select>
+        </label>
+      </div>
+    </section>
+    <button class="button-base share-options__signin" v-if="needSignin" @click="handleSignin">Google Drive にサインイン</button>
   </div>
 </template>
 
 <script setup>
-import { ref, computed, defineExpose } from 'vue';
+import { ref, computed, defineExpose, watchEffect } from 'vue';
+import { useModalStore } from '../../../stores/modalStore.js';
 const props = defineProps({ signedIn: Boolean, longData: Boolean });
 const emit = defineEmits(['signin']);
 const type = ref('snapshot');
 const includeFull = ref(false);
+const enablePassword = ref(false);
 const password = ref('');
 const expires = ref('0');
+const modalStore = useModalStore();
 const needSignin = computed(() => (type.value === 'dynamic' || includeFull.value) && !props.signedIn);
 const showTruncateWarning = computed(() => props.longData && !includeFull.value);
+const canGenerate = computed(() => !needSignin.value);
+watchEffect(() => {
+  if (modalStore.buttons.length > 0) {
+    modalStore.buttons[0].disabled = !canGenerate.value;
+  }
+});
 
-defineExpose({ type, includeFull, password, expires });
+defineExpose({ type, includeFull, password, expires, enablePassword });
 
 function handleSignin() {
   if (window.__driveSignIn) window.__driveSignIn();
@@ -43,7 +73,20 @@ function handleSignin() {
 </script>
 
 <style scoped>
+.share-options__section {
+  margin-bottom: 16px;
+}
+.share-options__heading {
+  margin-bottom: 8px;
+}
+.share-options__note {
+  margin-left: 6px;
+  color: var(--color-text-muted);
+}
 .share-options__warning {
   color: #f88;
+}
+.share-options__signin {
+  margin-top: 10px;
 }
 </style>

--- a/src/components/ui/MainFooter.vue
+++ b/src/components/ui/MainFooter.vue
@@ -120,12 +120,13 @@ async function handleShareClick() {
     return;
   }
   window.__driveSignIn = props.signIn;
+  const generateButton = { label: '生成', value: 'generate', variant: 'primary', disabled: true };
   const result = await showModal({
     component: ShareOptions,
     props: { signedIn: uiStore.isSignedIn, longData: isLongData() },
     title: '共有リンクを生成',
     buttons: [
-      { label: '生成', value: 'generate', variant: 'primary' },
+      generateButton,
       { label: 'キャンセル', value: 'cancel', variant: 'secondary' },
     ],
   });

--- a/tests/unit/components/ShareOptions.test.js
+++ b/tests/unit/components/ShareOptions.test.js
@@ -1,0 +1,46 @@
+import * as Vue from "vue";
+global.Vue = Vue;
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import { nextTick } from "vue";
+import ShareOptions from "../../../src/components/modals/contents/ShareOptions.vue";
+import { useModalStore } from "../../../src/stores/modalStore.js";
+
+describe("ShareOptions", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  test("generate button disabled when sign-in required", async () => {
+    const modalStore = useModalStore();
+    modalStore.buttons = [
+      { label: "生成", value: "generate", variant: "primary" },
+    ];
+    const wrapper = mount(ShareOptions, {
+      props: { signedIn: false, longData: false },
+    });
+
+    await wrapper.find('input[value="dynamic"]').setValue();
+    await nextTick();
+    expect(modalStore.buttons[0].disabled).toBe(true);
+
+    await wrapper.setProps({ signedIn: true });
+    await nextTick();
+    expect(modalStore.buttons[0].disabled).toBe(false);
+  });
+
+  test("truncate warning shown only when full content disabled", async () => {
+    const modalStore = useModalStore();
+    modalStore.buttons = [
+      { label: "生成", value: "generate", variant: "primary" },
+    ];
+    const wrapper = mount(ShareOptions, {
+      props: { signedIn: true, longData: true },
+    });
+    expect(wrapper.find(".share-options__warning").exists()).toBe(true);
+
+    await wrapper.find('input[type="checkbox"]').setChecked();
+    await nextTick();
+    expect(wrapper.find(".share-options__warning").exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- restructure ShareOptions.vue with clearer sections
- disable modal primary action until sign-in is satisfied
- adjust BaseModal to honor disabled buttons
- add unit tests for ShareOptions logic

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_6853dae5c1ac8326a699c0eeca1b9bb5