### PR TITLE
Implement dynamic footer buttons

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,7 +14,6 @@ import { parseShareUrl } from "./libs/sabalessshare/src/url.js";
 import { DriveStorageAdapter } from "./services/driveStorageAdapter.js";
 import { messages } from "./locales/ja.js";
 import { useHeaderVisibility } from "./composables/useHeaderVisibility.js";
-import { useDynamicButtons } from "./composables/useDynamicButtons.js";
 import { useAppModals } from "./composables/useAppModals.js";
 import { useAppInitialization } from "./composables/useAppInitialization.js";
 
@@ -48,6 +47,7 @@ const {
     handleSignOutClick,
     promptForDriveFolder,
     saveCharacterToDrive,
+    saveOrUpdateCurrentCharacterInDrive,
 } = useGoogleDrive(dataManager);
 
 const {
@@ -128,7 +128,6 @@ const currentExperiencePoints = computed(
 const currentWeight = computed(() => characterStore.currentWeight);
 const experienceStatusClass = computed(() => uiStore.experienceStatusClass);
 
-const { saveButton, loadButton } = useDynamicButtons();
 
 // --- Watchers (formerly `watch`) ---
 
@@ -256,21 +255,15 @@ onMounted(async () => {
         :current-experience-points="currentExperiencePoints"
         :max-experience-points="maxExperiencePoints"
         :current-weight="currentWeight"
-        :data-manager="dataManager"
-        :sign-in="handleSignInClick"
-        :save-title="saveButton.title"
-        :save-label="saveButton.label"
-        :save-icon="saveButton.icon"
-        :load-title="loadButton.title"
-        :load-label="loadButton.label"
-        :load-icon="loadButton.icon"
+        :save-local="saveData"
+        :handle-file-upload="handleFileUpload"
+        :open-hub="openHub"
+        :save-to-drive="saveOrUpdateCurrentCharacterInDrive"
         :experience-label="messages.ui.footer.experience"
         :io-label="messages.ui.footer.io"
         :share-label="messages.ui.footer.share"
         :copy-edit-label="messages.ui.footer.copyEdit"
         :is-viewing-shared="uiStore.isViewingShared"
-        @save="saveData"
-        @file-upload="handleFileUpload"
         @io="openIoModal"
         @share="openShareModal"
     />

--- a/src/components/ui/MainFooter.vue
+++ b/src/components/ui/MainFooter.vue
@@ -7,32 +7,46 @@
         <div class="footer-button-container">
             <button
                 class="button-base footer-button footer-button--save"
-                @click="$emit('save')"
-                :title="saveTitle"
+                @click="handleSave"
+                :title="saveButton.title"
             >
                 <span
                     class="icon-svg icon-svg--footer"
-                    :class="saveIcon"
+                    :class="saveButton.icon"
                 ></span>
-                {{ saveLabel }}
+                {{ saveButton.label }}
             </button>
         </div>
         <div class="footer-button-container">
             <label
+                v-if="!uiStore.isSignedIn"
                 class="button-base footer-button footer-button--load"
                 for="load_input_vue"
-                :title="loadTitle"
+                :title="loadButton.title"
             >
                 <span
                     class="icon-svg icon-svg--footer"
-                    :class="loadIcon"
+                    :class="loadButton.icon"
                 ></span>
-                {{ loadLabel }}
+                {{ loadButton.label }}
             </label>
+            <button
+                v-else
+                class="button-base footer-button footer-button--load"
+                @click="props.openHub"
+                :title="loadButton.title"
+            >
+                <span
+                    class="icon-svg icon-svg--footer"
+                    :class="loadButton.icon"
+                ></span>
+                {{ loadButton.label }}
+            </button>
             <input
+                v-if="!uiStore.isSignedIn"
                 type="file"
                 id="load_input_vue"
-                @change="(e) => $emit('file-upload', e)"
+                @change="(e) => props.handleFileUpload(e)"
                 accept=".json,.txt,.zip"
                 class="hidden"
             />
@@ -56,7 +70,9 @@
 </template>
 
 <script setup>
-import { ref, defineExpose, defineEmits } from "vue";
+import { defineProps } from "vue";
+import { useUiStore } from "../../stores/uiStore.js";
+import { useDynamicButtons } from "../../composables/useDynamicButtons.js";
 
 const props = defineProps({
     experienceStatusClass: String,
@@ -65,20 +81,25 @@ const props = defineProps({
     maxExperiencePoints: Number,
     currentWeight: Number,
     isViewingShared: Boolean,
-    dataManager: Object,
-    signIn: Function,
-    saveTitle: String,
-    saveLabel: String,
-    saveIcon: String,
-    loadTitle: String,
-    loadLabel: String,
-    loadIcon: String,
+    saveLocal: Function,
+    handleFileUpload: Function,
+    openHub: Function,
+    saveToDrive: Function,
     ioLabel: String,
     shareLabel: String,
     copyEditLabel: String,
 });
 
-const emit = defineEmits(["save", "file-upload", "io", "share", "copy-edit"]);
+const uiStore = useUiStore();
+const { saveButton, loadButton } = useDynamicButtons();
+
+function handleSave() {
+    if (uiStore.isSignedIn) {
+        props.saveToDrive();
+    } else {
+        props.saveLocal();
+    }
+}
 </script>
 
 <style scoped></style>

--- a/src/composables/useDynamicButtons.js
+++ b/src/composables/useDynamicButtons.js
@@ -6,17 +6,25 @@ export function useDynamicButtons() {
   const uiStore = useUiStore();
 
   const saveButton = computed(() => {
-    return uiStore.isSignedIn
-      ? {
-          label: messages.ui.buttons.saveCloud,
-          title: messages.ui.buttons.saveCloudTitle,
-          icon: "icon-svg-cloud-upload",
-        }
-      : {
-          label: messages.ui.buttons.saveLocal,
-          title: messages.ui.buttons.saveLocalTitle,
-          icon: "icon-svg-local-download",
-        };
+    if (!uiStore.isSignedIn) {
+      return {
+        label: messages.ui.buttons.saveLocal,
+        title: messages.ui.buttons.saveLocalTitle,
+        icon: "icon-svg-local-download",
+      };
+    }
+    if (!uiStore.currentDriveFileId) {
+      return {
+        label: messages.ui.buttons.saveCloudNew,
+        title: messages.ui.buttons.saveCloudTitle,
+        icon: "icon-svg-cloud-upload",
+      };
+    }
+    return {
+      label: messages.ui.buttons.saveCloudOverwrite,
+      title: messages.ui.buttons.saveCloudTitle,
+      icon: "icon-svg-cloud-upload",
+    };
   });
 
   const loadButton = computed(() => {

--- a/src/composables/useGoogleDrive.js
+++ b/src/composables/useGoogleDrive.js
@@ -158,6 +158,15 @@ export function useGoogleDrive(dataManager) {
     );
   }
 
+  function saveOrUpdateCurrentCharacterInDrive() {
+    return saveCharacterToDrive(
+      uiStore.currentDriveFileId,
+      uiStore.currentDriveFileId
+        ? uiStore.currentDriveFileName
+        : characterStore.character.name,
+    );
+  }
+
   function initializeGoogleDrive() {
     const apiKey = "AIzaSyBXvh_XH2XdHedIO5AaZKWLl1NJm7UAHnU";
     const clientId =
@@ -217,5 +226,6 @@ export function useGoogleDrive(dataManager) {
     promptForDriveFolder,
     saveCharacterToDrive,
     handleSaveToDriveClick,
+    saveOrUpdateCurrentCharacterInDrive,
   };
 }

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -134,6 +134,8 @@ export const messages = {
     viewModeBanner: "閲覧モードで表示中",
     buttons: {
       saveCloud: "Drive保存",
+      saveCloudNew: "新規保存",
+      saveCloudOverwrite: "上書保存",
       saveCloudTitle: "Google Driveに保存",
       loadCloud: "Drive読込",
       loadCloudTitle: "Google Driveから読込む",

--- a/tests/unit/composables/useDynamicButtons.test.js
+++ b/tests/unit/composables/useDynamicButtons.test.js
@@ -1,0 +1,41 @@
+import { setActivePinia, createPinia } from "pinia";
+import { useDynamicButtons } from "../../../src/composables/useDynamicButtons.js";
+import { useUiStore } from "../../../src/stores/uiStore.js";
+import { messages } from "../../../src/locales/ja.js";
+
+describe("useDynamicButtons", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  test("local labels when signed out", () => {
+    const uiStore = useUiStore();
+    uiStore.isSignedIn = false;
+    const { saveButton, loadButton } = useDynamicButtons();
+    expect(saveButton.value.label).toBe(messages.ui.buttons.saveLocal);
+    expect(loadButton.value.label).toBe(messages.ui.buttons.loadLocal);
+  });
+
+  test("new save label when no file id", () => {
+    const uiStore = useUiStore();
+    uiStore.isSignedIn = true;
+    uiStore.currentDriveFileId = null;
+    const { saveButton } = useDynamicButtons();
+    expect(saveButton.value.label).toBe(messages.ui.buttons.saveCloudNew);
+  });
+
+  test("overwrite label when file exists", () => {
+    const uiStore = useUiStore();
+    uiStore.isSignedIn = true;
+    uiStore.currentDriveFileId = "1";
+    const { saveButton } = useDynamicButtons();
+    expect(saveButton.value.label).toBe(messages.ui.buttons.saveCloudOverwrite);
+  });
+
+  test("load button uses drive when signed in", () => {
+    const uiStore = useUiStore();
+    uiStore.isSignedIn = true;
+    const { loadButton } = useDynamicButtons();
+    expect(loadButton.value.label).toBe(messages.ui.buttons.loadCloud);
+  });
+});

--- a/tests/unit/composables/useGoogleDrive.test.js
+++ b/tests/unit/composables/useGoogleDrive.test.js
@@ -60,4 +60,31 @@ describe("useGoogleDrive", () => {
       "foo",
     );
   });
+
+  test("saveOrUpdateCurrentCharacterInDrive chooses create or update", async () => {
+    const createFile = jest.fn().mockResolvedValue({ id: "1" });
+    const updateFile = jest.fn().mockResolvedValue({ id: "2" });
+    const dataManager = {
+      googleDriveManager: {
+        createCharacterFile: createFile,
+        updateCharacterFile: updateFile,
+      },
+      saveDataToAppData: jest.fn((c, s, ss, e, h, id, name) => {
+        return id ? updateFile(id, {}, name) : createFile({}, name);
+      }),
+    };
+    const { saveOrUpdateCurrentCharacterInDrive } = useGoogleDrive(dataManager);
+    const uiStore = useUiStore();
+    uiStore.currentDriveFileId = null;
+    await saveOrUpdateCurrentCharacterInDrive();
+    expect(createFile).toHaveBeenCalled();
+    uiStore.currentDriveFileId = "abc";
+    uiStore.currentDriveFileName = "c.json";
+    await saveOrUpdateCurrentCharacterInDrive();
+    expect(updateFile).toHaveBeenCalledWith(
+      "abc",
+      expect.any(Object),
+      "c.json",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- adjust localization messages for new save labels
- compute button states in `useDynamicButtons`
- expose a drive save wrapper in `useGoogleDrive`
- update `MainFooter` to run save/load actions directly
- adapt `App.vue` for new footer API
- add unit tests for buttons and drive helper

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`

------
https://chatgpt.com/codex/tasks/task_e_6854b7c583248326ba187f80b2d6e58f