### PR TITLE
Refactor CI workflow using reusable setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,68 +10,20 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Init submodules
-        run: git submodule update --init --recursive
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-      - name: Install dependencies
-        run: npm ci
-      - name: Run lint
-        run: npm run lint
+    uses: ./.github/workflows/reusable-setup.yml
+    with:
+      run-command: npm run lint
 
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Init submodules
-        run: git submodule update --init --recursive
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-      - name: Install dependencies
-        run: npm ci
-      - name: Run tests
-        run: npm test
+    uses: ./.github/workflows/reusable-setup.yml
+    with:
+      run-command: npm test
 
   e2e:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Init submodules
-        run: git submodule update --init --recursive
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-      - name: Install dependencies
-        run: npm ci
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
-      - name: Run e2e tests
-        run: npm run e2e
+    uses: ./.github/workflows/reusable-setup.yml
+    with:
+      run-command: npm run e2e
+      playwright: true
   deploy_production:
     name: Deploy to Production
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/reusable-setup.yml
+++ b/.github/workflows/reusable-setup.yml
@@ -1,0 +1,41 @@
+name: node-setup
+on:
+  workflow_call:
+    inputs:
+      run-command:
+        required: true
+        type: string
+      playwright:
+        required: false
+        type: boolean
+        default: false
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Init submodules
+        run: git submodule update --init --recursive
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Cache Playwright browsers
+        if: ${{ inputs.playwright }}
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+      - name: Install Playwright Browsers
+        if: ${{ inputs.playwright }}
+        run: npx playwright install --with-deps
+      - name: Run command
+        run: ${{ inputs.run-command }}


### PR DESCRIPTION
## Summary
- add a reusable workflow for Node.js setup
- use the new reusable workflow in lint, test and e2e jobs

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68553ad471d08326ab8dcb071f237ad3