### PR TITLE
Centralize App initialization logic

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,11 +7,6 @@ import { useHelp } from "./composables/useHelp.js";
 import { useDataExport } from "./composables/useDataExport.js";
 import { useKeyboardHandling } from "./composables/useKeyboardHandling.js";
 import { usePrint } from "./composables/usePrint.js";
-import { base64ToArrayBuffer } from "./libs/sabalessshare/src/crypto.js";
-import { receiveSharedData } from "./libs/sabalessshare/src/index.js";
-import { receiveDynamicData } from "./libs/sabalessshare/src/dynamic.js";
-import { parseShareUrl } from "./libs/sabalessshare/src/url.js";
-import { DriveStorageAdapter } from "./services/driveStorageAdapter.js";
 import { messages } from "./locales/ja.js";
 import { useHeaderVisibility } from "./composables/useHeaderVisibility.js";
 import { useAppModals } from "./composables/useAppModals.js";
@@ -59,7 +54,7 @@ const {
     closeHelpPanel,
 } = useHelp(helpPanelRef, mainHeader);
 
-const { showToast, showAsyncToast } = useNotifications();
+const { showAsyncToast } = useNotifications();
 const { showModal } = useModal();
 
 function refreshHubList() {
@@ -162,75 +157,7 @@ useHeaderVisibility();
 
 // --- Lifecycle Hooks ---
 const { initialize } = useAppInitialization(dataManager);
-onMounted(async () => {
-    const params = parseShareUrl(window.location);
-    if (!params) return;
-    try {
-        let buffer;
-        if (params.mode === "dynamic") {
-            const adapter = new DriveStorageAdapter(
-                dataManager.googleDriveManager
-            );
-            buffer = await receiveDynamicData({
-                location: window.location,
-                adapter,
-                passwordPromptHandler: async () =>
-                    Promise.resolve(
-                        window.prompt(messages.ui.prompts.sharedDataPassword) ||
-                            null
-                    ),
-            });
-        } else {
-            buffer = await receiveSharedData({
-                location: window.location,
-                downloadHandler: async (id) => {
-                    const text =
-                        await dataManager.googleDriveManager.loadFileContent(
-                            id
-                        );
-                    if (!text) throw new Error("no data");
-                    const { ciphertext, iv } = JSON.parse(text);
-                    return {
-                        ciphertext: base64ToArrayBuffer(ciphertext),
-                        iv: new Uint8Array(base64ToArrayBuffer(iv)),
-                    };
-                },
-                passwordPromptHandler: async () =>
-                    Promise.resolve(
-                        window.prompt(messages.ui.prompts.sharedDataPassword) ||
-                            null
-                    ),
-            });
-        }
-        const parsed = JSON.parse(new TextDecoder().decode(buffer));
-        Object.assign(characterStore.character, parsed.character);
-        characterStore.skills.splice(
-            0,
-            characterStore.skills.length,
-            ...parsed.skills
-        );
-        characterStore.specialSkills.splice(
-            0,
-            characterStore.specialSkills.length,
-            ...parsed.specialSkills
-        );
-        Object.assign(characterStore.equipments, parsed.equipments);
-        characterStore.histories.splice(
-            0,
-            characterStore.histories.length,
-            ...parsed.histories
-        );
-        uiStore.isViewingShared = true;
-    } catch (err) {
-        let key = "general";
-        if (err.name === "InvalidLinkError") key = "invalid";
-        else if (err.name === "ExpiredLinkError") key = "expired";
-        else if (err.name === "PasswordRequiredError") key = "passwordRequired";
-        else if (err.name === "DecryptionError") key = "decryptionFailed";
-        showToast({ type: "error", ...messages.share.loadError.toast(key) });
-        console.error("Error loading shared data:", err);
-    }
-});
+onMounted(initialize);
 </script>
 
 <template>

--- a/src/composables/useAppInitialization.js
+++ b/src/composables/useAppInitialization.js
@@ -29,7 +29,7 @@ export function useAppInitialization(dataManager) {
           adapter,
           passwordPromptHandler: async () =>
             Promise.resolve(
-              window.prompt("共有データのパスワードを入力してください") || null,
+              window.prompt(messages.ui.prompts.sharedDataPassword) || null,
             ),
         });
       } else {
@@ -47,7 +47,7 @@ export function useAppInitialization(dataManager) {
           },
           passwordPromptHandler: async () =>
             Promise.resolve(
-              window.prompt("共有データのパスワードを入力してください") || null,
+              window.prompt(messages.ui.prompts.sharedDataPassword) || null,
             ),
         });
       }


### PR DESCRIPTION
## Summary
- remove duplicate logic in `App.vue`
- use initialization composable for URL share handling
- use locale prompt strings in `useAppInitialization`

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68553ae12ee48326b6e24f2f88aa37f4