### PR TITLE
Remove unused files and add password modal

### DIFF
--- a/src/components/modals/contents/PasswordPromptModal.vue
+++ b/src/components/modals/contents/PasswordPromptModal.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="password-prompt-modal">
+    <input
+      ref="inputEl"
+      v-model="password"
+      type="password"
+      class="password-prompt-modal__input"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, defineExpose } from 'vue';
+
+const password = ref('');
+const inputEl = ref(null);
+
+onMounted(() => {
+  if (inputEl.value) inputEl.value.focus();
+});
+
+defineExpose({ password });
+</script>
+
+<style scoped>
+.password-prompt-modal {
+  display: flex;
+  justify-content: center;
+}
+.password-prompt-modal__input {
+  width: 100%;
+  padding: 8px;
+  box-sizing: border-box;
+}
+</style>

--- a/src/composables/useGoogleDrive.js
+++ b/src/composables/useGoogleDrive.js
@@ -197,19 +197,27 @@ export function useGoogleDrive(dataManager) {
       }
     };
 
-    const gapiPoll = setInterval(() => {
-      if (window.gapi && window.gapi.load) {
-        handleGapiLoaded();
-        clearInterval(gapiPoll);
+    if (window.gapi && window.gapi.load) {
+      handleGapiLoaded();
+    } else {
+      const gapiScript = document.querySelector(
+        'script[src="https://apis.google.com/js/api.js"]',
+      );
+      if (gapiScript) {
+        gapiScript.addEventListener("load", handleGapiLoaded, { once: true });
       }
-    }, 100);
+    }
 
-    const gisPoll = setInterval(() => {
-      if (window.google && window.google.accounts) {
-        handleGisLoaded();
-        clearInterval(gisPoll);
+    if (window.google && window.google.accounts) {
+      handleGisLoaded();
+    } else {
+      const gisScript = document.querySelector(
+        'script[src="https://accounts.google.com/gsi/client"]',
+      );
+      if (gisScript) {
+        gisScript.addEventListener("load", handleGisLoaded, { once: true });
       }
-    }, 100);
+    }
   }
 
   onMounted(() => {

--- a/src/services/characterService.js
+++ b/src/services/characterService.js
@@ -1,4 +1,0 @@
-(function (global) {
-  function CharacterService() {}
-  global.CharacterService = CharacterService;
-})(window);

--- a/src/services/experienceCalculator.js
+++ b/src/services/experienceCalculator.js
@@ -1,4 +1,0 @@
-(function (global) {
-  function ExperienceCalculator() {}
-  global.ExperienceCalculator = ExperienceCalculator;
-})(window);


### PR DESCRIPTION
## Summary
- delete unused characterService and experienceCalculator
- simplify Google API initialization by using script load events
- add PasswordPromptModal component
- use the modal when prompting for shared link passwords

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68553ae582148326b2afa873df89279e