### PR TITLE
Refactor Drive init and password prompt modal

### DIFF
--- a/src/components/modals/contents/PasswordPromptModal.vue
+++ b/src/components/modals/contents/PasswordPromptModal.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="password-prompt-modal">
+    <input
+      type="password"
+      v-model="password"
+      class="password-prompt-modal__input"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, defineExpose } from 'vue';
+const password = ref('');
+
+defineExpose({ password });
+</script>
+
+<style scoped>
+.password-prompt-modal__input {
+  margin-bottom: 10px;
+}
+</style>

--- a/src/services/characterService.js
+++ b/src/services/characterService.js
@@ -1,4 +1,0 @@
-(function (global) {
-  function CharacterService() {}
-  global.CharacterService = CharacterService;
-})(window);

--- a/src/services/experienceCalculator.js
+++ b/src/services/experienceCalculator.js
@@ -1,4 +1,0 @@
-(function (global) {
-  function ExperienceCalculator() {}
-  global.ExperienceCalculator = ExperienceCalculator;
-})(window);


### PR DESCRIPTION
## Summary
- remove unused service files
- replace polling Drive init with script load hooks
- add a simple password prompt modal
- use modal for password entry instead of `window.prompt`

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68553f9d6b2c8326aede515fd30e4b1d