### PR TITLE
Refactor output animation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -25,7 +25,6 @@ import { useModal } from "./composables/useModal.js";
 import { useNotifications } from "./composables/useNotifications.js";
 // --- Template Refs ---
 const mainHeader = ref(null);
-const mainFooter = ref(null);
 const helpPanelRef = ref(null);
 
 const characterStore = useCharacterStore();
@@ -33,7 +32,7 @@ const uiStore = useUiStore();
 useKeyboardHandling();
 
 const { dataManager, saveData, handleFileUpload, outputToCocofolia } =
-    useDataExport(mainFooter);
+    useDataExport();
 const { printCharacterSheet } = usePrint();
 
 const {
@@ -177,7 +176,6 @@ onMounted(initialize);
     </div>
     <CharacterSheetLayout />
     <MainFooter
-        ref="mainFooter"
         :experience-status-class="experienceStatusClass"
         :current-experience-points="currentExperiencePoints"
         :max-experience-points="maxExperiencePoints"

--- a/src/components/common/AnimatedButton.vue
+++ b/src/components/common/AnimatedButton.vue
@@ -1,0 +1,99 @@
+<template>
+  <button
+    class="button-base animated-button"
+    :class="[stateClass, { 'is-animating': isAnimating }]"
+    :disabled="isAnimating"
+    @click="$emit('click')"
+  >
+    {{ currentLabel }}
+  </button>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+
+const props = defineProps({
+  defaultLabel: { type: String, default: '' },
+  animatingLabel: { type: String, default: '' },
+  successLabel: { type: String, default: '' },
+  trigger: { type: Number, default: 0 },
+  timings: {
+    type: Object,
+    default: () => ({
+      state1_bgFill: 500,
+      state2_textHold: 1000,
+      state3_textFadeOut: 500,
+      state4_bgReset: 700,
+    }),
+  },
+});
+
+const emit = defineEmits(['finished']);
+
+const currentLabel = ref(props.defaultLabel);
+const stateClass = ref('');
+const isAnimating = ref(false);
+
+watch(
+  () => props.trigger,
+  () => {
+    startAnimation();
+  },
+);
+
+function startAnimation() {
+  if (isAnimating.value) return;
+  isAnimating.value = true;
+  stateClass.value = 'state-1';
+  setTimeout(() => {
+    stateClass.value = 'state-2';
+    currentLabel.value = props.animatingLabel;
+  }, props.timings.state1_bgFill);
+  setTimeout(() => {
+    stateClass.value = 'state-3';
+  }, props.timings.state1_bgFill + props.timings.state2_textHold);
+  setTimeout(() => {
+    stateClass.value = 'state-4';
+    currentLabel.value = props.successLabel;
+  },
+  props.timings.state1_bgFill +
+    props.timings.state2_textHold +
+    props.timings.state3_textFadeOut);
+  setTimeout(() => {
+    stateClass.value = '';
+    currentLabel.value = props.defaultLabel;
+    isAnimating.value = false;
+    emit('finished');
+  },
+  props.timings.state1_bgFill +
+    props.timings.state2_textHold +
+    props.timings.state3_textFadeOut +
+    props.timings.state4_bgReset);
+}
+</script>
+
+<style scoped>
+.animated-button.state-1 {
+  transition: background-color 0.5s ease-in-out, color 0.5s ease-in-out;
+  background-color: var(--color-accent-light);
+  color: var(--color-accent-light);
+}
+.animated-button.state-2 {
+  transition: color 0.1s ease-in;
+  background-color: var(--color-accent-light);
+  color: var(--color-background);
+}
+.animated-button.state-3 {
+  transition: color 0.5s ease-in-out;
+  background-color: var(--color-accent-light);
+  color: var(--color-accent-light);
+}
+.animated-button.state-4 {
+  transition: background-color 0.7s ease-in-out, color 0.2s ease-in-out 0.5s;
+  background-color: transparent;
+  color: var(--color-accent);
+}
+.animated-button.is-animating {
+  pointer-events: none;
+}
+</style>

--- a/src/components/modals/BaseModal.vue
+++ b/src/components/modals/BaseModal.vue
@@ -25,7 +25,7 @@
           </div>
           <component
             :is="modal.component"
-            v-bind="modal.props"
+            v-bind="componentProps"
             v-on="modal.events"
             ref="inner"
           />
@@ -47,12 +47,25 @@
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { useModalStore } from '../../stores/modalStore.js';
 
 const modalStore = useModalStore();
 const modal = modalStore;
 const inner = ref(null);
+const componentProps = computed(() => {
+  const { componentRef, ...rest } = modal.props;
+  return rest;
+});
+
+watch(
+  () => inner.value,
+  (val) => {
+    if (modal.props && modal.props.componentRef) {
+      modal.props.componentRef.value = val;
+    }
+  },
+);
 
 function resolve(value) {
   modalStore.resolveModal({ value, component: inner.value });

--- a/src/components/modals/contents/IoModal.vue
+++ b/src/components/modals/contents/IoModal.vue
@@ -12,9 +12,15 @@
                 accept=".json,.txt,.zip"
             />
         </label>
-        <button class="button-base" @click="$emit('output-cocofolia')">
-            {{ outputLabel }}
-        </button>
+        <AnimatedButton
+            class="button-base"
+            :trigger="triggerKey"
+            :default-label="outputLabels.default"
+            :animating-label="outputLabels.animating"
+            :success-label="outputLabels.success"
+            :timings="outputTimings"
+            @click="$emit('output-cocofolia')"
+        />
         <button class="button-base" @click="$emit('print')">
             {{ printLabel }}
         </button>
@@ -29,21 +35,32 @@
 </template>
 
 <script setup>
+import { ref, defineExpose } from 'vue';
+import AnimatedButton from '../../common/AnimatedButton.vue';
+
 const props = defineProps({
     signedIn: Boolean,
     saveLocalLabel: String,
     loadLocalLabel: String,
-    outputLabel: String,
+    outputLabels: Object,
+    outputTimings: Object,
     printLabel: String,
     driveFolderLabel: String,
 });
 const emit = defineEmits([
-    "save-local",
-    "load-local",
-    "output-cocofolia",
-    "print",
-    "drive-folder",
+    'save-local',
+    'load-local',
+    'output-cocofolia',
+    'print',
+    'drive-folder',
 ]);
+
+const triggerKey = ref(0);
+function triggerAnimation() {
+    triggerKey.value += 1;
+}
+
+defineExpose({ triggerAnimation });
 </script>
 
 <style scoped>

--- a/src/components/ui/MainFooter.vue
+++ b/src/components/ui/MainFooter.vue
@@ -126,33 +126,6 @@ function handleSave() {
 }
 
 
-.footer-button--output.state-1 {
-  transition:
-    background-color 0.5s ease-in-out,
-    color 0.5s ease-in-out;
-  background-color: var(--color-accent-light);
-  color: var(--color-accent-light);
-}
-
-.footer-button--output.state-2 {
-  transition: color 0.1s ease-in;
-  background-color: var(--color-accent-light);
-  color: var(--color-background);
-}
-
-.footer-button--output.state-3 {
-  transition: color 0.5s ease-in-out;
-  background-color: var(--color-accent-light);
-  color: var(--color-accent-light);
-}
-
-.footer-button--output.state-4 {
-  transition:
-    background-color 0.7s ease-in-out,
-    color 0.2s ease-in-out 0.5s;
-  background-color: transparent;
-  color: var(--color-accent);
-}
 
 .footer-button--load {
   padding: 0;
@@ -163,9 +136,6 @@ function handleSave() {
   user-select: none;
 }
 
-.footer-button--output.is-animating {
-  pointer-events: none;
-}
 
 .footer-button-container {
   position: relative;

--- a/src/composables/useAppModals.js
+++ b/src/composables/useAppModals.js
@@ -1,4 +1,4 @@
-import { reactive } from "vue";
+import { reactive, ref } from "vue";
 import { useModal } from "./useModal.js";
 import { useUiStore } from "../stores/uiStore.js";
 import CharacterHub from "../components/ui/CharacterHub.vue";
@@ -13,6 +13,7 @@ import { messages } from "../locales/ja.js";
 export function useAppModals(options) {
   const uiStore = useUiStore();
   const { showModal } = useModal();
+  const ioModalRef = ref(null);
   const {
     dataManager,
     loadCharacterById,
@@ -24,7 +25,6 @@ export function useAppModals(options) {
     saveData,
     handleFileUpload,
     outputToCocofolia,
-    outputButtonText,
     printCharacterSheet,
     promptForDriveFolder,
     copyEditCallback,
@@ -60,7 +60,13 @@ export function useAppModals(options) {
         signedIn: uiStore.isSignedIn,
         saveLocalLabel: messages.ui.modal.io.buttons.saveLocal,
         loadLocalLabel: messages.ui.modal.io.buttons.loadLocal,
-        outputLabel: messages.ui.modal.io.buttons.output,
+        outputLabels: {
+          default: messages.outputButton.default,
+          animating: messages.outputButton.animating,
+          success: messages.outputButton.success,
+        },
+        outputTimings: messages.outputButton.animationTimings,
+        componentRef: ioModalRef,
         printLabel: messages.ui.modal.io.buttons.print,
         driveFolderLabel: messages.ui.modal.io.buttons.driveFolder,
       },
@@ -68,7 +74,10 @@ export function useAppModals(options) {
       on: {
         "save-local": saveData,
         "load-local": handleFileUpload,
-        "output-cocofolia": outputToCocofolia,
+        "output-cocofolia": () =>
+          outputToCocofolia(() => {
+            ioModalRef.value?.triggerAnimation();
+          }),
         print: printCharacterSheet,
         "drive-folder": promptForDriveFolder,
       },

--- a/src/utils/clipboard.js
+++ b/src/utils/clipboard.js
@@ -1,4 +1,17 @@
-export function copyText() {
-  // TODO: Vue3のComposition API (useClipboard) や
-  // navigator.clipboard.writeText を使った実装に置き換える
+export async function copyText(text) {
+  if (navigator && navigator.clipboard) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  const textArea = document.createElement("textarea");
+  textArea.value = text;
+  textArea.style.cssText = "position: fixed; top: 0; left: 0; opacity: 0;";
+  document.body.appendChild(textArea);
+  textArea.focus();
+  textArea.select();
+  try {
+    document.execCommand("copy");
+  } finally {
+    document.body.removeChild(textArea);
+  }
 }

--- a/tests/unit/components/AnimatedButton.test.js
+++ b/tests/unit/components/AnimatedButton.test.js
@@ -1,0 +1,38 @@
+import { mount } from "@vue/test-utils";
+import AnimatedButton from "../../../src/components/common/AnimatedButton.vue";
+import { nextTick } from "vue";
+
+describe("AnimatedButton", () => {
+  test("animates and emits finished", async () => {
+    vi.useFakeTimers();
+    const wrapper = mount(AnimatedButton, {
+      props: {
+        defaultLabel: "d",
+        animatingLabel: "a",
+        successLabel: "s",
+        timings: {
+          state1_bgFill: 10,
+          state2_textHold: 10,
+          state3_textFadeOut: 10,
+          state4_bgReset: 10,
+        },
+        trigger: 0,
+      },
+    });
+    expect(wrapper.text()).toBe("d");
+    await wrapper.setProps({ trigger: 1 });
+    vi.advanceTimersByTime(10);
+    await nextTick();
+    expect(wrapper.classes()).toContain("state-2");
+    expect(wrapper.text()).toBe("a");
+    vi.advanceTimersByTime(10);
+    await nextTick();
+    vi.advanceTimersByTime(10);
+    await nextTick();
+    expect(wrapper.text()).toBe("s");
+    vi.advanceTimersByTime(10);
+    await nextTick();
+    expect(wrapper.emitted().finished).toBeTruthy();
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- remove obsolete footer output animation styles
- add reusable `AnimatedButton` component for button animations
- update `IoModal` to use `AnimatedButton`
- keep modal component refs with new logic in `BaseModal`
- refactor `useDataExport` and animation trigger flow
- wire callback in `useAppModals` for output copy success
- implement clipboard utility
- add unit tests for `AnimatedButton`

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`

------
https://chatgpt.com/codex/tasks/task_e_68553f92fc6c8326a32ab7afa37eb913