### PR TITLE
Add console timing for data load flow

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -31,8 +31,17 @@ const characterStore = useCharacterStore();
 const uiStore = useUiStore();
 useKeyboardHandling();
 
-const { dataManager, saveData, handleFileUpload, outputToCocofolia } =
-    useDataExport();
+const {
+    dataManager,
+    saveData,
+    handleFileUpload: dataExportHandleFileUpload,
+    outputToCocofolia,
+} = useDataExport();
+
+function handleFileUpload(event) {
+    console.log(`App.vue: handleFileUpload called at: ${new Date().toISOString()}`);
+    dataExportHandleFileUpload(event);
+}
 const { printCharacterSheet } = usePrint();
 
 const {

--- a/src/components/modals/contents/IoModal.vue
+++ b/src/components/modals/contents/IoModal.vue
@@ -3,12 +3,12 @@
         <button class="button-base" @click="$emit('save-local')">
             {{ saveLocalLabel }}
         </button>
-        <label class="button-base">
+        <label class="button-base" @click="triggerFileUpload">
             {{ loadLocalLabel }}
             <input
                 type="file"
                 class="hidden"
-                @change="(e) => $emit('load-local', e)"
+                @change="onFileSelected"
                 accept=".json,.txt,.zip"
             />
         </label>
@@ -48,7 +48,7 @@ defineProps({
     driveFolderLabel: String,
 });
 
-defineEmits([
+const emit = defineEmits([
     'save-local',
     'load-local',
     'output-cocofolia',
@@ -59,6 +59,15 @@ defineEmits([
 const triggerKey = ref(0);
 function triggerAnimation() {
   triggerKey.value += 1;
+}
+
+function triggerFileUpload() {
+  console.log(`IoModal: triggerFileUpload called at: ${new Date().toISOString()}`);
+}
+
+function onFileSelected(e) {
+  console.log(`IoModal: onFileSelected fired at: ${new Date().toISOString()}`);
+  emit('load-local', e);
 }
 
 function handleCopySuccess(event) {

--- a/src/composables/useDataExport.js
+++ b/src/composables/useDataExport.js
@@ -26,6 +26,7 @@ export function useDataExport() {
     dataManager.handleFileUpload(
       event,
       (parsedData) => {
+        console.time("StoreUpdate");
         Object.assign(characterStore.character, parsedData.character);
         characterStore.skills.splice(
           0,
@@ -43,6 +44,7 @@ export function useDataExport() {
           characterStore.histories.length,
           ...parsedData.histories,
         );
+        console.timeEnd("StoreUpdate");
       },
       (errorMessage) =>
         showToast({

--- a/src/services/dataManager.js
+++ b/src/services/dataManager.js
@@ -131,6 +131,8 @@ export class DataManager {
 
     if (fileName.endsWith(".zip")) {
       reader.onload = async (e) => {
+        console.timeEnd("FileRead");
+        console.time("DataProcessing");
         try {
           const zip = await JSZip.loadAsync(e.target.result);
           const jsonDataFile = zip.file("character_data.json");
@@ -142,7 +144,9 @@ export class DataManager {
           }
 
           const jsonContent = await jsonDataFile.async("string");
+          console.time("JSON_Parse");
           const rawJsonData = JSON.parse(jsonContent);
+          console.timeEnd("JSON_Parse");
 
           const imageFilesData = []; // Intermediate array for image data and paths
           const imageFolder = zip.folder("images");
@@ -208,26 +212,34 @@ export class DataManager {
           );
 
           const parsedData = this.parseLoadedData(rawJsonData);
+          console.timeEnd("DataProcessing");
           onSuccess(parsedData);
         } catch (error) {
           console.error("Failed to parse ZIP file:", error);
           onError(messages.file.loadError + " (ZIP: " + error.message + ")");
         }
       };
+      console.time("FileRead");
       reader.readAsArrayBuffer(file); // Read ZIP as ArrayBuffer
     } else {
       // Assume JSON or other text file
       reader.onload = (e) => {
+        console.timeEnd("FileRead");
+        console.time("DataProcessing");
         const fileContent = e.target.result;
         try {
+          console.time("JSON_Parse");
           const rawJsonData = JSON.parse(fileContent);
+          console.timeEnd("JSON_Parse");
           const parsedData = this.parseLoadedData(rawJsonData);
+          console.timeEnd("DataProcessing");
           onSuccess(parsedData);
         } catch (error) {
           console.error("Failed to parse JSON file:", error);
           onError(messages.file.loadError);
         }
       };
+      console.time("FileRead");
       reader.readAsText(file);
     }
     event.target.value = null;
@@ -669,6 +681,7 @@ export class DataManager {
   }
 
   _normalizeLoadedData(dataToParse) {
+    console.time("Normalization");
     // キャラクターデータの正規化
     const defaultCharacter = {
       ...this.gameData.defaultCharacterData, // This now includes images: []
@@ -701,7 +714,7 @@ export class DataManager {
     ) {
       normalizedData.character.linkCurrentToInitialScar = true;
     }
-
+    console.timeEnd("Normalization");
     return normalizedData;
   }
 

--- a/src/services/dataManager.js
+++ b/src/services/dataManager.js
@@ -124,6 +124,9 @@ export class DataManager {
    */
   handleFileUpload(event, onSuccess, onError) {
     const file = event.target.files[0];
+    console.log(
+      `DataManager: handleFileUpload entered at: ${new Date().toISOString()}`,
+    );
     if (!file) return;
 
     const fileName = file.name;


### PR DESCRIPTION
## Summary
- instrument `dataManager.handleFileUpload` with timing logs
- time normalisation step
- time store updates in `useDataExport`

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`

------
https://chatgpt.com/codex/tasks/task_e_68555f179ca08326bb8ab98b00c41697