### PR TITLE
Implement scroll-responsive header

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,6 @@ import { useDataExport } from "./composables/useDataExport.js";
 import { useKeyboardHandling } from "./composables/useKeyboardHandling.js";
 import { usePrint } from "./composables/usePrint.js";
 import { messages } from "./locales/ja.js";
-import { useHeaderVisibility } from "./composables/useHeaderVisibility.js";
 import { useAppModals } from "./composables/useAppModals.js";
 import { useAppInitialization } from "./composables/useAppInitialization.js";
 
@@ -152,7 +151,6 @@ watch(
     { immediate: true }
 );
 
-useHeaderVisibility();
 
 // --- Lifecycle Hooks ---
 const { initialize } = useAppInitialization(dataManager);

--- a/src/components/ui/MainHeader.vue
+++ b/src/components/ui/MainHeader.vue
@@ -1,7 +1,6 @@
 <template>
     <header
         class="main-header"
-        :class="{ 'main-header--hidden': !uiStore.showHeader }"
         ref="headerEl"
     >
         <button
@@ -28,7 +27,7 @@
 
 <script setup>
 import { ref, computed, defineExpose } from "vue";
-import { useUiStore } from "../../stores/uiStore.js";
+import { useHeaderVisibility } from "../../composables/useHeaderVisibility.js";
 import { useCharacterStore } from "../../stores/characterStore.js";
 
 const props = defineProps({
@@ -48,8 +47,9 @@ const emit = defineEmits([
 const headerEl = ref(null);
 const helpIcon = ref(null);
 
-const uiStore = useUiStore();
 const characterStore = useCharacterStore();
+
+useHeaderVisibility(headerEl);
 
 const titleText = computed(
     () => characterStore.character.name || props.defaultTitle
@@ -73,12 +73,7 @@ defineExpose({ headerEl, helpIcon });
     border-bottom: 1px solid var(--color-border-normal);
     box-shadow: 0 3px 8px rgb(0 0 0 / 50%);
     z-index: 101;
-    transition: transform 0.3s ease;
     will-change: transform;
-}
-
-.main-header--hidden {
-    transform: translateY(-100%);
 }
 
 .main-header__title {

--- a/tests/unit/components/MainHeader.test.js
+++ b/tests/unit/components/MainHeader.test.js
@@ -26,21 +26,6 @@ describe("MainHeader", () => {
     expect(wrapper.find(".main-header__title").text()).toBe("Hero");
   });
 
-  test("hidden class applied when store flag false", async () => {
-    const wrapper = mount(MainHeader, {
-      props: {
-        defaultTitle: "Default",
-        cloudHubLabel: "hub",
-        helpLabel: "?",
-        helpState: "closed",
-      },
-    });
-    const uiStore = useUiStore();
-    uiStore.showHeader = false;
-    await wrapper.vm.$nextTick();
-    expect(wrapper.classes()).toContain("main-header--hidden");
-  });
-
   test("cloud hub hidden when not signed in", async () => {
     const wrapper = mount(MainHeader, {
       props: {

--- a/tests/unit/composables/useHeaderVisibility.test.js
+++ b/tests/unit/composables/useHeaderVisibility.test.js
@@ -1,0 +1,44 @@
+import { mount } from "@vue/test-utils";
+import { ref } from "vue";
+import { useHeaderVisibility } from "../../../src/composables/useHeaderVisibility.js";
+
+vi.stubGlobal("requestAnimationFrame", (fn) => fn());
+
+Object.defineProperty(window, "scrollY", {
+  configurable: true,
+  writable: true,
+  value: 0,
+});
+Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+  configurable: true,
+  get() {
+    return 80;
+  },
+});
+
+const TestComp = {
+  template: "<div ref='header' style='height:80px'></div>",
+  setup() {
+    const header = ref(null);
+    useHeaderVisibility(header);
+    return { header };
+  },
+};
+
+describe("useHeaderVisibility", () => {
+  test("moves header with scroll", async () => {
+    window.scrollY = 0;
+    const wrapper = mount(TestComp, { attachTo: document.body });
+    await wrapper.vm.$nextTick();
+
+    window.scrollY = 100;
+    window.dispatchEvent(new Event("scroll"));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.header.style.transform).toBe("translateY(-80px)");
+
+    window.scrollY = 70;
+    window.dispatchEvent(new Event("scroll"));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.header.style.transform).toBe("translateY(-50px)");
+  });
+});


### PR DESCRIPTION
## Summary
- add new scroll-driven `useHeaderVisibility` composable
- update `MainHeader.vue` to use the new composable and remove old class logic
- drop old header hook from `App.vue`
- adjust unit tests and add tests for the new composable

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`
- `cd src/libs/sabalessshare && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855628c012c8326837a8a6d5bb152c6