### PR TITLE
Add free-input option for special skills

### DIFF
--- a/src/components/sections/SpecialSkillsSection.vue
+++ b/src/components/sections/SpecialSkillsSection.vue
@@ -31,7 +31,15 @@
                   :value="option.value"
                 >{{ option.label }}</option>
               </select>
+              <input
+                v-if="specialSkill.group === 'free'"
+                type="text"
+                v-model="specialSkill.name"
+                class="flex-item-2"
+                :disabled="uiStore.isViewingShared"
+              />
               <select
+                v-else
                 v-model="specialSkill.name"
                 @change="updateSpecialSkillNoteVisibility(index)"
                 :disabled="!specialSkill.group || uiStore.isViewingShared"
@@ -45,7 +53,15 @@
                 >{{ opt.label }}</option>
               </select>
             </div>
+            <textarea
+              v-if="specialSkill.group === 'free'"
+              v-model="specialSkill.note"
+              class="special-skill-note-input"
+              :placeholder="AioniaGameData.placeholderTexts.specialSkillNote"
+              :disabled="uiStore.isViewingShared"
+            ></textarea>
             <input
+              v-else
               type="text"
               v-model="specialSkill.note"
               v-show="specialSkill.showNote"

--- a/src/data/gameData.js
+++ b/src/data/gameData.js
@@ -230,6 +230,7 @@ export const AioniaGameData = {
     { value: "tactics", label: "戦術" },
     { value: "magic", label: "魔術" },
     { value: "features", label: "特徴" },
+    { value: "free", label: "自由入力" },
   ],
 
   // 種族ラベルマップ


### PR DESCRIPTION
## Summary
- allow user-defined special skills by adding `自由入力` option
- render custom name and note fields when the free option is selected

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68560018e8a0832693f5032d44d6489c