### PR TITLE
Fix HelpPanel Markdown render

### DIFF
--- a/src/components/ui/HelpPanel.vue
+++ b/src/components/ui/HelpPanel.vue
@@ -20,7 +20,7 @@
           <div
             class="accordion__body"
             v-show="activeSection === index"
-            v-html="section.content"
+            v-html="section.html"
           ></div>
         </div>
       </div>
@@ -44,9 +44,16 @@ const activeSection = ref(0);
 
 watch(
   () => props.helpText,
-  (val) => {
+  async (val) => {
     sections.value = parseSections(val);
     activeSection.value = 0;
+    if (sections.value[0]) {
+      const { marked } = await import('marked');
+      const { default: DOMPurify } = await import('dompurify');
+      sections.value[0].html = DOMPurify.sanitize(
+        marked.parse(sections.value[0].content),
+      );
+    }
   },
   { immediate: true },
 );


### PR DESCRIPTION
## Summary
- sanitize and render Markdown inside HelpPanel accordion
- parse initial section on mount to display first entry

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68563c4255d48326a6594f33e81e07cb