### PR TITLE
Update print flow for mobile devices

### DIFF
--- a/src/composables/useAppModals.js
+++ b/src/composables/useAppModals.js
@@ -18,6 +18,8 @@ import { useShare } from "./useShare.js";
 import { useNotifications } from "./useNotifications.js";
 import { useModalStore } from "../stores/modalStore.js";
 import { messages } from "../locales/ja.js";
+import { openPreviewPage } from "./usePrint.js";
+import { isDesktopDevice } from "../utils/device.js";
 
 export function useAppModals(options) {
   const uiStore = useUiStore();
@@ -37,6 +39,14 @@ export function useAppModals(options) {
     promptForDriveFolder,
     copyEditCallback,
   } = options;
+
+  function handlePrint() {
+    if (isDesktopDevice()) {
+      printCharacterSheet();
+    } else {
+      openPreviewPage();
+    }
+  }
 
   async function openHub() {
     await showModal({
@@ -82,7 +92,7 @@ export function useAppModals(options) {
         "save-local": saveData,
         "load-local": handleFileUpload,
         "output-cocofolia": outputToCocofolia,
-        print: printCharacterSheet,
+        print: handlePrint,
         "drive-folder": promptForDriveFolder,
       },
     });

--- a/src/composables/useHelp.js
+++ b/src/composables/useHelp.js
@@ -1,4 +1,5 @@
 import { ref, computed, onMounted, onBeforeUnmount } from "vue";
+import { isDesktopDevice } from "../utils/device.js";
 
 export function useHelp(helpPanelRef, triggerRef) {
   const helpState = ref("closed");
@@ -44,9 +45,7 @@ export function useHelp(helpPanelRef, triggerRef) {
   }
 
   onMounted(() => {
-    isDesktop.value = !(
-      "ontouchstart" in window || navigator.maxTouchPoints > 0
-    );
+    isDesktop.value = isDesktopDevice();
     document.addEventListener("click", handleClickOutside);
   });
 

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -1,0 +1,3 @@
+export function isDesktopDevice() {
+  return !("ontouchstart" in window || navigator.maxTouchPoints > 0);
+}

--- a/tests/unit/composables/useAppModals.test.js
+++ b/tests/unit/composables/useAppModals.test.js
@@ -1,0 +1,68 @@
+vi.mock("../../../src/composables/useModal.js", () => ({
+  useModal: vi.fn(),
+}));
+
+vi.mock("../../../src/composables/usePrint.js", () => ({
+  openPreviewPage: vi.fn(),
+}));
+
+vi.mock("../../../src/utils/device.js", () => ({
+  isDesktopDevice: vi.fn(),
+}));
+
+import { setActivePinia, createPinia } from "pinia";
+import { useModal } from "../../../src/composables/useModal.js";
+import { useAppModals } from "../../../src/composables/useAppModals.js";
+import { openPreviewPage } from "../../../src/composables/usePrint.js";
+import { isDesktopDevice } from "../../../src/utils/device.js";
+
+function createOptions(printFn) {
+  return {
+    dataManager: {},
+    loadCharacterById: () => {},
+    saveCharacterToDrive: () => {},
+    handleSignInClick: () => {},
+    handleSignOutClick: () => {},
+    refreshHubList: () => {},
+    saveNewCharacter: () => {},
+    saveData: () => {},
+    handleFileUpload: () => {},
+    outputToCocofolia: () => {},
+    printCharacterSheet: printFn,
+    promptForDriveFolder: () => {},
+    copyEditCallback: () => {},
+  };
+}
+
+describe("useAppModals openIoModal", () => {
+  let showModalMock;
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    showModalMock = vi.fn().mockResolvedValue({});
+    useModal.mockReturnValue({ showModal: showModalMock });
+    openPreviewPage.mockClear();
+    isDesktopDevice.mockReset();
+  });
+
+  test("uses printCharacterSheet on desktop", async () => {
+    const printMock = vi.fn();
+    isDesktopDevice.mockReturnValue(true);
+    const { openIoModal } = useAppModals(createOptions(printMock));
+    await openIoModal();
+    const opts = showModalMock.mock.calls[0][0];
+    await opts.on.print();
+    expect(printMock).toHaveBeenCalled();
+    expect(openPreviewPage).not.toHaveBeenCalled();
+  });
+
+  test("opens preview page on mobile", async () => {
+    const printMock = vi.fn();
+    isDesktopDevice.mockReturnValue(false);
+    const { openIoModal } = useAppModals(createOptions(printMock));
+    await openIoModal();
+    const opts = showModalMock.mock.calls[0][0];
+    await opts.on.print();
+    expect(printMock).not.toHaveBeenCalled();
+    expect(openPreviewPage).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add device detection helper
- reuse helper in help panel logic
- switch print handling based on device type
- test `useAppModals` print behaviour

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68563beefb808326b73f7498666cba24