### PR TITLE
Handle printing on mobile via preview page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -32,7 +32,7 @@ useKeyboardHandling();
 
 const { dataManager, saveData, handleFileUpload, outputToCocofolia } =
     useDataExport();
-const { printCharacterSheet } = usePrint();
+const { printCharacterSheet, openPreviewPage } = usePrint();
 
 const {
     canSignInToGoogle,
@@ -106,6 +106,7 @@ const { openHub, openIoModal, openShareModal } = useAppModals({
     handleFileUpload,
     outputToCocofolia,
     printCharacterSheet,
+    openPreviewPage,
     promptForDriveFolder,
     copyEditCallback: () => {
         uiStore.isViewingShared = false;

--- a/src/assets/print/print-styles.css
+++ b/src/assets/print/print-styles.css
@@ -17,7 +17,6 @@ body {
   background: white;
   width: 794px;
   position: relative;
-  overflow: hidden;
 }
 
 .page {

--- a/src/composables/useAppModals.js
+++ b/src/composables/useAppModals.js
@@ -17,6 +17,7 @@ const ShareOptions = defineAsyncComponent(
 import { useShare } from "./useShare.js";
 import { useNotifications } from "./useNotifications.js";
 import { useModalStore } from "../stores/modalStore.js";
+import { isDesktopDevice } from "../utils/device.js";
 import { messages } from "../locales/ja.js";
 
 export function useAppModals(options) {
@@ -34,6 +35,7 @@ export function useAppModals(options) {
     handleFileUpload,
     outputToCocofolia,
     printCharacterSheet,
+    openPreviewPage,
     promptForDriveFolder,
     copyEditCallback,
   } = options;
@@ -61,6 +63,9 @@ export function useAppModals(options) {
   }
 
   async function openIoModal() {
+    const handlePrint = isDesktopDevice()
+      ? printCharacterSheet
+      : openPreviewPage;
     await showModal({
       component: IoModal,
       title: messages.ui.modal.io.title,
@@ -82,7 +87,7 @@ export function useAppModals(options) {
         "save-local": saveData,
         "load-local": handleFileUpload,
         "output-cocofolia": outputToCocofolia,
-        print: printCharacterSheet,
+        print: handlePrint,
         "drive-folder": promptForDriveFolder,
       },
     });

--- a/src/composables/useHelp.js
+++ b/src/composables/useHelp.js
@@ -1,4 +1,5 @@
 import { ref, computed, onMounted, onBeforeUnmount } from "vue";
+import { isDesktopDevice } from "../utils/device.js";
 
 export function useHelp(helpPanelRef, triggerRef) {
   const helpState = ref("closed");
@@ -44,9 +45,7 @@ export function useHelp(helpPanelRef, triggerRef) {
   }
 
   onMounted(() => {
-    isDesktop.value = !(
-      "ontouchstart" in window || navigator.maxTouchPoints > 0
-    );
+    isDesktop.value = isDesktopDevice();
     document.addEventListener("click", handleClickOutside);
   });
 

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -1,0 +1,3 @@
+export function isDesktopDevice() {
+  return !("ontouchstart" in window || navigator.maxTouchPoints > 0);
+}

--- a/tests/unit/composables/useAppModals.test.js
+++ b/tests/unit/composables/useAppModals.test.js
@@ -1,0 +1,69 @@
+import { setActivePinia, createPinia } from "pinia";
+import { useAppModals } from "../../../src/composables/useAppModals.js";
+import { useModal } from "../../../src/composables/useModal.js";
+import { isDesktopDevice } from "../../../src/utils/device.js";
+
+vi.mock("../../../src/composables/useModal.js", () => ({
+  useModal: vi.fn(),
+}));
+vi.mock("../../../src/utils/device.js", () => ({
+  isDesktopDevice: vi.fn(),
+}));
+
+describe("useAppModals", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setActivePinia(createPinia());
+    useModal.mockReturnValue({ showModal: vi.fn().mockResolvedValue(null) });
+  });
+
+  test("desktop uses direct print", async () => {
+    isDesktopDevice.mockReturnValue(true);
+    const printCharacterSheet = vi.fn();
+    const openPreviewPage = vi.fn();
+    const { openIoModal } = useAppModals({
+      dataManager: {},
+      loadCharacterById: vi.fn(),
+      saveCharacterToDrive: vi.fn(),
+      handleSignInClick: vi.fn(),
+      handleSignOutClick: vi.fn(),
+      refreshHubList: vi.fn(),
+      saveNewCharacter: vi.fn(),
+      saveData: vi.fn(),
+      handleFileUpload: vi.fn(),
+      outputToCocofolia: vi.fn(),
+      printCharacterSheet,
+      openPreviewPage,
+      promptForDriveFolder: vi.fn(),
+      copyEditCallback: vi.fn(),
+    });
+    await openIoModal();
+    const args = useModal.mock.results[0].value.showModal.mock.calls[0][0];
+    expect(args.on.print).toBe(printCharacterSheet);
+  });
+
+  test("mobile uses preview page", async () => {
+    isDesktopDevice.mockReturnValue(false);
+    const printCharacterSheet = vi.fn();
+    const openPreviewPage = vi.fn();
+    const { openIoModal } = useAppModals({
+      dataManager: {},
+      loadCharacterById: vi.fn(),
+      saveCharacterToDrive: vi.fn(),
+      handleSignInClick: vi.fn(),
+      handleSignOutClick: vi.fn(),
+      refreshHubList: vi.fn(),
+      saveNewCharacter: vi.fn(),
+      saveData: vi.fn(),
+      handleFileUpload: vi.fn(),
+      outputToCocofolia: vi.fn(),
+      printCharacterSheet,
+      openPreviewPage,
+      promptForDriveFolder: vi.fn(),
+      copyEditCallback: vi.fn(),
+    });
+    await openIoModal();
+    const args = useModal.mock.results[0].value.showModal.mock.calls[0][0];
+    expect(args.on.print).toBe(openPreviewPage);
+  });
+});


### PR DESCRIPTION
## Summary
- add device detection utility
- reuse device detection in help composable
- switch print behavior in modals depending on device
- expose preview function to App.vue
- test `useAppModals` for print on desktop and mobile

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_685649b7ce8c8326bbe09bf67b23defd