### PR TITLE
Implement keyboard-aware footer

### DIFF
--- a/src/assets/css/_layout.css
+++ b/src/assets/css/_layout.css
@@ -135,10 +135,15 @@
   box-shadow: 0 -3px 8px rgb(0 0 0 / 50%);
   flex-wrap: nowrap;
   overflow-x: auto;
+  transition: bottom 0.2s ease-in-out;
   gap: 15px;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: thin;
   scrollbar-color: var(--color-border-normal) var(--color-background);
+}
+
+body.keyboard-visible .main-footer {
+  bottom: var(--keyboard-height, 0);
 }
 
 .main-footer::-webkit-scrollbar {

--- a/src/assets/css/_layout.css
+++ b/src/assets/css/_layout.css
@@ -84,6 +84,11 @@
   display: none !important;
 }
 
+/* キーボード表示中は、コンテンツ下の余白を減らしてフッターとの距離を詰める */
+body.keyboard-visible .main-content {
+  padding-bottom: 15px;
+}
+
 /* フォーム行レイアウト */
 .info-row {
   display: flex;

--- a/src/composables/useKeyboardHandling.js
+++ b/src/composables/useKeyboardHandling.js
@@ -23,38 +23,12 @@ export function useKeyboardHandling() {
     }
   }
 
-  function onFocus(event) {
-    if (event.target.matches("input, textarea")) {
-      setTimeout(handleViewportResize, 200);
-    }
-  }
-
-  function onFocusOut(event) {
-    if (event.target.matches("input, textarea")) {
-      setTimeout(() => {
-        body.classList.remove("keyboard-visible");
-        root.style.removeProperty("--keyboard-height");
-        keyboardVisible = false;
-      }, 200);
-    }
-  }
-
   onMounted(() => {
-    document.addEventListener("focusin", onFocus);
-    document.addEventListener("focusout", onFocusOut);
     window.visualViewport.addEventListener("resize", handleViewportResize);
-    if (
-      document.activeElement &&
-      (document.activeElement.matches("input") ||
-        document.activeElement.matches("textarea"))
-    ) {
-      setTimeout(handleViewportResize, 200);
-    }
+    handleViewportResize();
   });
 
   onBeforeUnmount(() => {
-    document.removeEventListener("focusin", onFocus);
-    document.removeEventListener("focusout", onFocusOut);
     window.visualViewport.removeEventListener("resize", handleViewportResize);
     body.classList.remove("keyboard-visible");
     root.style.removeProperty("--keyboard-height");


### PR DESCRIPTION
## Summary
- update keyboard detection composable to use Visual Viewport API
- animate footer bottom position and apply keyboard height

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68575e55570883268fe05f383bfed31f