### PR TITLE
Implement data manager refactor

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -51,14 +51,14 @@ const { showAsyncToast } = useNotifications();
 const { showModal } = useModal();
 
 function refreshHubList() {
-  uiStore.refreshDriveCharacters(dataManager.googleDriveManager);
+  uiStore.refreshDriveCharacters(dataManager);
 }
 
 async function saveNewCharacter() {
-  await saveCharacterToDrive(null, characterStore.character.name);
+  await saveCharacterToDrive(null);
 }
 
-async function loadCharacterById(id, name) {
+async function loadCharacterById(id) {
   const loadPromise = dataManager.loadDataFromDrive(id).then((parsedData) => {
     if (parsedData) {
       Object.assign(characterStore.character, parsedData.character);
@@ -67,12 +67,11 @@ async function loadCharacterById(id, name) {
       Object.assign(characterStore.equipments, parsedData.equipments);
       characterStore.histories.splice(0, characterStore.histories.length, ...parsedData.histories);
       uiStore.currentDriveFileId = id;
-      uiStore.currentDriveFileName = name;
     }
   });
   showAsyncToast(loadPromise, {
-    loading: messages.googleDrive.load.loading(name),
-    success: messages.googleDrive.load.success(name),
+    loading: messages.googleDrive.load.loading(''),
+    success: messages.googleDrive.load.success(''),
     error: (err) => messages.googleDrive.load.error(err),
   });
 }

--- a/src/services/mockGoogleDriveManager.js
+++ b/src/services/mockGoogleDriveManager.js
@@ -1,0 +1,120 @@
+export class MockGoogleDriveManager {
+  constructor() {
+    this.files = new Map();
+    this.indexContent = null; // if null, index file doesn't exist
+    this._idCounter = 1;
+  }
+
+  async _ensureIndexFile() {
+    if (this.indexContent === null) {
+      this.indexContent = '[]';
+      this.files.set('index', this.indexContent);
+    }
+    return { id: 'index', name: 'character_index.json' };
+  }
+
+  async _readIndexFile() {
+    await this._ensureIndexFile();
+    try {
+      return JSON.parse(this.indexContent || '[]');
+    } catch {
+      throw new SyntaxError('Invalid JSON');
+    }
+  }
+
+  async _writeIndexFile(data) {
+    await this._ensureIndexFile();
+    this.indexContent = JSON.stringify(data);
+    this.files.set('index', this.indexContent);
+    return { id: 'index', name: 'character_index.json' };
+  }
+
+  async _addIndexEntry(entry) {
+    const idx = await this._readIndexFile();
+    idx.push({ ...entry, updatedAt: new Date().toISOString() });
+    await this._writeIndexFile(idx);
+  }
+
+  async _renameIndexEntry(id, newName) {
+    const idx = await this._readIndexFile();
+    idx.forEach((e) => {
+      if (e.id === id) {
+        e.characterName = newName;
+        e.updatedAt = new Date().toISOString();
+      }
+    });
+    await this._writeIndexFile(idx);
+  }
+
+  async _removeIndexEntry(id) {
+    const idx = await this._readIndexFile();
+    await this._writeIndexFile(idx.filter((e) => e.id !== id));
+  }
+
+  async _saveFile(folderId, name, content, fileId = null) {
+    const id = fileId || `mock-${this._idCounter++}`;
+    this.files.set(id, content);
+    return { id, name };
+  }
+
+  async loadFileContent(id) {
+    return this.files.has(id) ? this.files.get(id) : null;
+  }
+
+  async _createCharacterFile(data, name) {
+    return this._saveFile('mock', name, JSON.stringify(data));
+  }
+
+  async _updateCharacterFile(id, data, name) {
+    return this._saveFile('mock', name, JSON.stringify(data), id);
+  }
+
+  async _loadCharacterFile(id) {
+    const text = await this.loadFileContent(id);
+    if (text === null) return null;
+    return JSON.parse(text);
+  }
+
+  async _deleteCharacterFile(id) {
+    this.files.delete(id);
+    await this._removeIndexEntry(id);
+  }
+
+  async listCharacters() {
+    try {
+      const info = await this._ensureIndexFile();
+      if (!info) return [];
+      const arr = await this._readIndexFile();
+      if (!Array.isArray(arr)) return [];
+      return arr
+        .filter((e) => e.id && e.characterName)
+        .map((e) => ({ fileId: e.id, characterName: e.characterName, lastModified: e.updatedAt }));
+    } catch (e) {
+      console.error(e);
+      return [];
+    }
+  }
+
+  async getCharacter(fileId) {
+    return this._loadCharacterFile(fileId);
+  }
+
+  async saveCharacter(characterData, fileId) {
+    const fileName = `${(characterData.name || 'character').replace(/[^\w.-]/g, '_')}.json`;
+    if (fileId) {
+      await this._updateCharacterFile(fileId, characterData, fileName);
+      await this._renameIndexEntry(fileId, characterData.name || '');
+    } else {
+      const created = await this._createCharacterFile(characterData, fileName);
+      fileId = created.id;
+      await this._addIndexEntry({ id: created.id, name: created.name, characterName: characterData.name || '' });
+    }
+    const index = await this._readIndexFile();
+    const entry = index.find((e) => e.id === fileId);
+    return { fileId, characterName: entry.characterName, lastModified: entry.updatedAt };
+  }
+
+  async deleteCharacter(fileId) {
+    await this._deleteCharacterFile(fileId);
+  }
+}

--- a/src/stores/uiStore.js
+++ b/src/stores/uiStore.js
@@ -35,33 +35,12 @@ export const useUiStore = defineStore('ui', {
     setLoading(flag) {
       this.isLoading = flag;
     },
-    async refreshDriveCharacters(gdm) {
-      if (!gdm) return;
-      const temps = this.driveCharacters.filter((c) => c.id.startsWith('temp-'));
-      const serverList = await gdm.readIndexFile();
-      const serverIds = new Set(serverList.map((c) => c.id));
-
-      // Keep local entries that still exist on server
-      let merged = this.driveCharacters.filter((c) => c.id.startsWith('temp-') || serverIds.has(c.id));
-
-      // Add or update server entries
-      serverList.forEach((srv) => {
-        const idx = merged.findIndex((c) => c.id === srv.id);
-        if (idx !== -1) {
-          merged[idx] = { ...merged[idx], ...srv };
-        } else {
-          merged.push(srv);
-        }
-      });
-
-      // Ensure temps remain
-      temps.forEach((t) => {
-        if (!merged.some((c) => c.id === t.id)) {
-          merged.push(t);
-        }
-      });
-
-      this.driveCharacters = merged;
+    async refreshDriveCharacters(dataManager) {
+      if (!dataManager) return;
+      const list = await dataManager.loadCharacterListFromDrive();
+      if (Array.isArray(list)) {
+        this.driveCharacters = list.filter((c) => c && c.fileId && c.characterName);
+      }
     },
     clearDriveCharacters() {
       this.driveCharacters = [];
@@ -70,7 +49,7 @@ export const useUiStore = defineStore('ui', {
       this.driveCharacters.push(ch);
     },
     updateDriveCharacter(id, updates) {
-      const idx = this.driveCharacters.findIndex((c) => c.id === id);
+      const idx = this.driveCharacters.findIndex((c) => c.fileId === id);
       if (idx !== -1) {
         this.driveCharacters[idx] = {
           ...this.driveCharacters[idx],
@@ -79,7 +58,7 @@ export const useUiStore = defineStore('ui', {
       }
     },
     removeDriveCharacter(id) {
-      this.driveCharacters = this.driveCharacters.filter((c) => c.id !== id);
+      this.driveCharacters = this.driveCharacters.filter((c) => c.fileId !== id);
     },
     registerPendingDriveSave(id) {
       this.pendingDriveSaves[id] = { canceled: false };

--- a/tests/unit/components/CharacterHub.test.js
+++ b/tests/unit/components/CharacterHub.test.js
@@ -1,0 +1,45 @@
+import * as Vue from 'vue';
+global.Vue = Vue;
+import { mount } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+import CharacterHub from '../../../src/components/ui/CharacterHub.vue';
+import { useUiStore } from '../../../src/stores/uiStore.js';
+
+vi.mock('../../../src/composables/useModal.js', () => ({
+  useModal: () => ({ showModal: vi.fn().mockResolvedValue({ value: 'delete' }) }),
+}));
+vi.mock('../../../src/composables/useNotifications.js', () => ({
+  useNotifications: () => ({ showToast: vi.fn(), showAsyncToast: vi.fn() }),
+}));
+
+describe('CharacterHub', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  test('delete button calls dataManager.deleteCharacter', async () => {
+    const dm = { deleteCharacter: vi.fn().mockResolvedValue(), loadDataFromDrive: vi.fn(), saveData: vi.fn() };
+    const wrapper = mount(CharacterHub, {
+      props: { dataManager: dm, loadCharacter: vi.fn(), saveToDrive: vi.fn() },
+    });
+    const store = useUiStore();
+    store.isSignedIn = true;
+    store.driveCharacters = [{ fileId: '1', characterName: 'A', updatedAt: 't' }];
+    await wrapper.vm.$nextTick();
+    const btn = wrapper.findAll('.button-base.button-compact')[2];
+    await btn.trigger('click');
+    await Vue.nextTick();
+    expect(dm.deleteCharacter).toHaveBeenCalledWith('1');
+  });
+
+  test('renders character list', async () => {
+    const wrapper = mount(CharacterHub, {
+      props: { dataManager: {}, loadCharacter: vi.fn(), saveToDrive: vi.fn() },
+    });
+    const store = useUiStore();
+    store.isSignedIn = true;
+    store.driveCharacters = [{ fileId: '1', characterName: 'A', updatedAt: 't' }];
+    await wrapper.vm.$nextTick();
+    expect(wrapper.text()).toContain('A');
+  });
+});

--- a/tests/unit/composables/useGoogleDrive.test.js
+++ b/tests/unit/composables/useGoogleDrive.test.js
@@ -10,7 +10,7 @@ describe('useGoogleDrive', () => {
 
   test('handleSaveToDriveClick calls saveDataToAppData with store data', async () => {
     const dataManager = {
-      saveDataToAppData: vi.fn().mockResolvedValue({ id: '1', name: 'c.json' }),
+      saveDataToAppData: vi.fn().mockResolvedValue({ fileId: '1' }),
       googleDriveManager: {},
     };
 
@@ -19,7 +19,6 @@ describe('useGoogleDrive', () => {
     const uiStore = useUiStore();
 
     uiStore.currentDriveFileId = null;
-    uiStore.currentDriveFileName = 'c';
     charStore.character.name = 'Hero';
 
     await handleSaveToDriveClick();
@@ -31,20 +30,19 @@ describe('useGoogleDrive', () => {
       charStore.equipments,
       charStore.histories,
       null,
-      'c',
     );
   });
 
-  test('saveCharacterToDrive uses provided id and name', async () => {
+  test('saveCharacterToDrive uses provided id', async () => {
     const dataManager = {
-      saveDataToAppData: vi.fn().mockResolvedValue({ id: '1', name: 'a.json' }),
+      saveDataToAppData: vi.fn().mockResolvedValue({ fileId: '1' }),
       googleDriveManager: {},
     };
     const { saveCharacterToDrive } = useGoogleDrive(dataManager);
     const charStore = useCharacterStore();
     charStore.character.name = 'Brave';
 
-    await saveCharacterToDrive('abc', 'foo');
+    await saveCharacterToDrive('abc');
 
     expect(dataManager.saveDataToAppData).toHaveBeenCalledWith(
       charStore.character,
@@ -53,20 +51,16 @@ describe('useGoogleDrive', () => {
       charStore.equipments,
       charStore.histories,
       'abc',
-      'foo',
     );
   });
 
   test('saveOrUpdateCurrentCharacterInDrive chooses create or update', async () => {
-    const createFile = vi.fn().mockResolvedValue({ id: '1' });
-    const updateFile = vi.fn().mockResolvedValue({ id: '2' });
+    const createFile = vi.fn().mockResolvedValue({});
+    const updateFile = vi.fn().mockResolvedValue({});
     const dataManager = {
-      googleDriveManager: {
-        createCharacterFile: createFile,
-        updateCharacterFile: updateFile,
-      },
-      saveDataToAppData: vi.fn((c, s, ss, e, h, id, name) => {
-        return id ? updateFile(id, {}, name) : createFile({}, name);
+      googleDriveManager: {},
+      saveDataToAppData: vi.fn((c, s, ss, e, h, id) => {
+        return id ? updateFile(id) : createFile();
       }),
     };
     const { saveOrUpdateCurrentCharacterInDrive } = useGoogleDrive(dataManager);
@@ -75,8 +69,7 @@ describe('useGoogleDrive', () => {
     await saveOrUpdateCurrentCharacterInDrive();
     expect(createFile).toHaveBeenCalled();
     uiStore.currentDriveFileId = 'abc';
-    uiStore.currentDriveFileName = 'c.json';
     await saveOrUpdateCurrentCharacterInDrive();
-    expect(updateFile).toHaveBeenCalledWith('abc', expect.any(Object), 'c.json');
+    expect(updateFile).toHaveBeenCalledWith('abc');
   });
 });

--- a/tests/unit/drivePersistence.test.js
+++ b/tests/unit/drivePersistence.test.js
@@ -1,0 +1,127 @@
+import { GoogleDriveManager } from '../../src/services/googleDriveManager.js';
+import { MockGoogleDriveManager } from '../../src/services/mockGoogleDriveManager.js';
+import { describe, beforeEach, test, expect, vi } from 'vitest';
+
+describe.each([
+  [
+    'GoogleDriveManager',
+    () => {
+      const real = new GoogleDriveManager('k', 'c');
+      const helper = new MockGoogleDriveManager();
+      real._ensureIndexFile = helper._ensureIndexFile.bind(helper);
+      real.loadFileContent = helper.loadFileContent.bind(helper);
+      real._saveFile = helper._saveFile.bind(helper);
+      real._readIndexFile = helper._readIndexFile.bind(helper);
+      real._writeIndexFile = helper._writeIndexFile.bind(helper);
+      real._addIndexEntry = helper._addIndexEntry.bind(helper);
+      real._renameIndexEntry = helper._renameIndexEntry.bind(helper);
+      real._removeIndexEntry = helper._removeIndexEntry.bind(helper);
+      real._createCharacterFile = helper._createCharacterFile.bind(helper);
+      real._updateCharacterFile = helper._updateCharacterFile.bind(helper);
+      real._loadCharacterFile = helper._loadCharacterFile.bind(helper);
+      real._deleteCharacterFile = helper._deleteCharacterFile.bind(helper);
+      return { manager: real, helper };
+    },
+  ],
+  [
+    'MockGoogleDriveManager',
+    () => {
+      const helper = new MockGoogleDriveManager();
+      return { manager: helper, helper };
+    },
+  ],
+])('%s API contract', (name, factory) => {
+  let mgr;
+  let helper;
+  beforeEach(() => {
+    const obj = factory();
+    mgr = obj.manager;
+    helper = obj.helper;
+  });
+
+  test('listCharacters returns metadata array', async () => {
+    await helper._writeIndexFile([{ id: '1', name: 'a.json', characterName: 'A', updatedAt: 't' }]);
+    const res = await mgr.listCharacters();
+    expect(res).toEqual([{ fileId: '1', characterName: 'A', lastModified: 't' }]);
+  });
+
+  test('listCharacters returns empty when missing file', async () => {
+    helper.indexContent = null;
+    const res = await mgr.listCharacters();
+    expect(res).toEqual([]);
+  });
+
+  test('listCharacters ignores invalid JSON', async () => {
+    helper.indexContent = 'invalid';
+    helper.files.set('index', 'invalid');
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const res = await mgr.listCharacters();
+    expect(res).toEqual([]);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  test('listCharacters filters invalid entries', async () => {
+    await helper._writeIndexFile([{ id: '1', characterName: 'A', updatedAt: 't' }, { characterName: 'B' }, { id: '2' }]);
+    const res = await mgr.listCharacters();
+    expect(res).toEqual([{ fileId: '1', characterName: 'A', lastModified: 't' }]);
+  });
+
+  test('getCharacter returns object when exists', async () => {
+    const meta = await mgr.saveCharacter({ id: 'c', name: 'A' }, null);
+    const data = await mgr.getCharacter(meta.fileId);
+    expect(data.name).toBe('A');
+  });
+
+  test('getCharacter returns null when file missing', async () => {
+    const data = await mgr.getCharacter('nope');
+    expect(data).toBeNull();
+  });
+
+  test('getCharacter throws on invalid JSON', async () => {
+    const { id } = await helper._saveFile('mock', 'bad.json', '');
+    await expect(mgr.getCharacter(id)).rejects.toThrow();
+  });
+
+  test('saveCharacter creates new entry and returns metadata', async () => {
+    const meta = await mgr.saveCharacter({ id: 'n1', name: 'New' }, null);
+    expect(meta.characterName).toBe('New');
+    const list = await mgr.listCharacters();
+    expect(list[0].fileId).toBe(meta.fileId);
+  });
+
+  test('saveCharacter updates existing entry', async () => {
+    const meta = await mgr.saveCharacter({ id: 'u1', name: 'Old' }, null);
+    const updated = await mgr.saveCharacter({ id: 'u1', name: 'Updated' }, meta.fileId);
+    expect(updated.characterName).toBe('Updated');
+    const list = await mgr.listCharacters();
+    expect(list[0].characterName).toBe('Updated');
+  });
+
+  test('deleteCharacter removes file and index', async () => {
+    const meta = await mgr.saveCharacter({ id: 'd1', name: 'Del' }, null);
+    await mgr.deleteCharacter(meta.fileId);
+    const list = await mgr.listCharacters();
+    expect(list).toEqual([]);
+  });
+
+  test('deleteCharacter with unknown id does not throw', async () => {
+    await expect(mgr.deleteCharacter('unknown')).resolves.not.toThrow();
+  });
+});
+
+describe('MockGoogleDriveManager specific', () => {
+  test('corrupted index string returns empty array', async () => {
+    const mgr = new MockGoogleDriveManager();
+    mgr.indexContent = '{';
+    const res = await mgr.listCharacters();
+    expect(res).toEqual([]);
+  });
+
+  test('index has entry but file missing returns null', async () => {
+    const mgr = new MockGoogleDriveManager();
+    await mgr._writeIndexFile([{ id: 'x', name: 'x.json', characterName: 'X', updatedAt: 't' }]);
+    const res = await mgr.getCharacter('x');
+    expect(res).toBeNull();
+  });
+});

--- a/tests/unit/googleDriveManager.test.js
+++ b/tests/unit/googleDriveManager.test.js
@@ -29,7 +29,7 @@ describe('GoogleDriveManager appDataFolder', () => {
     gapi.client.request.mockResolvedValue({
       result: { id: '1', name: 'character_index.json' },
     });
-    const info = await gdm.ensureIndexFile();
+    const info = await gdm._ensureIndexFile();
     expect(info.id).toBe('1');
     expect(gapi.client.request).toHaveBeenCalled();
   });
@@ -41,7 +41,7 @@ describe('GoogleDriveManager appDataFolder', () => {
     gapi.client.drive.files.get.mockResolvedValue({
       body: '[{"id":"a","name":"Alice"}]',
     });
-    const index = await gdm.readIndexFile();
+    const index = await gdm._readIndexFile();
     expect(index).toEqual([{ id: 'a', name: 'Alice' }]);
     expect(gapi.client.drive.files.get).toHaveBeenCalledWith({
       fileId: '10',
@@ -54,28 +54,28 @@ describe('GoogleDriveManager appDataFolder', () => {
       result: { id: 'c1', name: 'char.json' },
     });
     const data = { foo: 'bar' };
-    const res = await gdm.createCharacterFile(data, 'char.json');
+    const res = await gdm._createCharacterFile(data, 'char.json');
     expect(res.id).toBe('c1');
     expect(gapi.client.request).toHaveBeenCalled();
   });
 
   test('deleteCharacterFile removes file and index entry', async () => {
-    vi.spyOn(gdm, 'removeIndexEntry').mockResolvedValue();
+    vi.spyOn(gdm, '_removeIndexEntry').mockResolvedValue();
     gapi.client.drive.files.delete.mockResolvedValue({});
-    await gdm.deleteCharacterFile('d1');
+    await gdm._deleteCharacterFile('d1');
     expect(gapi.client.drive.files.delete).toHaveBeenCalledWith({
       fileId: 'd1',
     });
-    expect(gdm.removeIndexEntry).toHaveBeenCalledWith('d1');
+    expect(gdm._removeIndexEntry).toHaveBeenCalledWith('d1');
   });
 
   test('renameIndexEntry updates characterName and timestamp', async () => {
     const now = new Date('2024-01-01T00:00:00.000Z');
     vi.useFakeTimers().setSystemTime(now);
-    vi.spyOn(gdm, 'readIndexFile').mockResolvedValue([{ id: 'a', name: 'a.json', characterName: 'Old' }]);
-    vi.spyOn(gdm, 'writeIndexFile').mockResolvedValue();
-    await gdm.renameIndexEntry('a', 'New');
-    expect(gdm.writeIndexFile).toHaveBeenCalledWith([
+    vi.spyOn(gdm, '_readIndexFile').mockResolvedValue([{ id: 'a', name: 'a.json', characterName: 'Old' }]);
+    vi.spyOn(gdm, '_writeIndexFile').mockResolvedValue();
+    await gdm._renameIndexEntry('a', 'New');
+    expect(gdm._writeIndexFile).toHaveBeenCalledWith([
       {
         id: 'a',
         name: 'a.json',
@@ -89,10 +89,10 @@ describe('GoogleDriveManager appDataFolder', () => {
   test('addIndexEntry sets updatedAt', async () => {
     const now = new Date('2024-01-02T00:00:00.000Z');
     vi.useFakeTimers().setSystemTime(now);
-    vi.spyOn(gdm, 'readIndexFile').mockResolvedValue([]);
-    vi.spyOn(gdm, 'writeIndexFile').mockResolvedValue();
-    await gdm.addIndexEntry({ id: 'b', name: 'b.json', characterName: 'Bob' });
-    expect(gdm.writeIndexFile).toHaveBeenCalledWith([
+    vi.spyOn(gdm, '_readIndexFile').mockResolvedValue([]);
+    vi.spyOn(gdm, '_writeIndexFile').mockResolvedValue();
+    await gdm._addIndexEntry({ id: 'b', name: 'b.json', characterName: 'Bob' });
+    expect(gdm._writeIndexFile).toHaveBeenCalledWith([
       {
         id: 'b',
         name: 'b.json',

--- a/tests/unit/stores/uiStoreCharacters.test.js
+++ b/tests/unit/stores/uiStoreCharacters.test.js
@@ -6,29 +6,26 @@ describe('uiStore character cache', () => {
     setActivePinia(createPinia());
   });
 
-  test('refreshDriveCharacters merges lists', async () => {
+  test('refreshDriveCharacters loads list via dataManager', async () => {
     const store = useUiStore();
-    store.driveCharacters = [
-      { id: '2', name: 'b.json' },
-      { id: 'temp-1', name: 'temp.json' },
-    ];
-    const gdm = { readIndexFile: vi.fn().mockResolvedValue([{ id: '1' }]) };
-    await store.refreshDriveCharacters(gdm);
-    expect(store.driveCharacters).toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: '1' }), expect.objectContaining({ id: 'temp-1', name: 'temp.json' })]),
-    );
+    const dm = {
+      loadCharacterListFromDrive: vi.fn().mockResolvedValue([{ fileId: '1', characterName: 'A', lastModified: 't' }]),
+    };
+    await store.refreshDriveCharacters(dm);
+    expect(dm.loadCharacterListFromDrive).toHaveBeenCalled();
+    expect(store.driveCharacters).toEqual([{ fileId: '1', characterName: 'A', lastModified: 't' }]);
   });
 
   test('clearDriveCharacters empties cache', () => {
     const store = useUiStore();
-    store.driveCharacters = [{ id: '1' }];
+    store.driveCharacters = [{ fileId: '1' }];
     store.clearDriveCharacters();
     expect(store.driveCharacters).toEqual([]);
   });
 
   test('drive character add, update, remove', () => {
     const store = useUiStore();
-    store.addDriveCharacter({ id: 'a', name: 'a.json', characterName: 'A' });
+    store.addDriveCharacter({ fileId: 'a', name: 'a.json', characterName: 'A' });
     expect(store.driveCharacters).toHaveLength(1);
     store.updateDriveCharacter('a', { characterName: 'B' });
     expect(store.driveCharacters[0].characterName).toBe('B');


### PR DESCRIPTION
## Summary
- refreshDriveCharacters via DataManager
- update useGoogleDrive composable for new Drive API
- integrate DataManager calls in CharacterHub and App
- add component test for CharacterHub
- adjust unit tests for store and composable
- fix folder picker call through DataManager
- clean up character name display in hub

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859fc65f1ec832698c8351a6c46d072