### PR TITLE
Refactor drive file naming

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -57,10 +57,10 @@ function refreshHubList() {
 }
 
 async function saveNewCharacter() {
-  await saveCharacterToDrive(null, characterStore.character.name);
+  await saveCharacterToDrive(null);
 }
 
-async function loadCharacterById(id, name) {
+async function loadCharacterById(id, characterName) {
   const loadPromise = dataManager.loadDataFromDrive(id).then((parsedData) => {
     if (parsedData) {
       Object.assign(characterStore.character, parsedData.character);
@@ -69,12 +69,11 @@ async function loadCharacterById(id, name) {
       Object.assign(characterStore.equipments, parsedData.equipments);
       characterStore.histories.splice(0, characterStore.histories.length, ...parsedData.histories);
       uiStore.currentDriveFileId = id;
-      uiStore.currentDriveFileName = name;
     }
   });
   showAsyncToast(loadPromise, {
-    loading: messages.googleDrive.load.loading(name),
-    success: messages.googleDrive.load.success(name),
+    loading: messages.googleDrive.load.loading(characterName),
+    success: messages.googleDrive.load.success(characterName),
     error: (err) => messages.googleDrive.load.error(err),
   });
 }

--- a/src/components/ui/CharacterHub.vue
+++ b/src/components/ui/CharacterHub.vue
@@ -80,13 +80,13 @@ function refreshList() {
 
 async function saveNew() {
   if (props.saveToDrive) {
-    await props.saveToDrive(null, characterStore.character.name);
+    await props.saveToDrive(null);
   }
 }
 
 async function overwrite(ch) {
   if (props.saveToDrive) {
-    await props.saveToDrive(ch.id, ch.name);
+    await props.saveToDrive(ch.id);
   }
 }
 
@@ -96,9 +96,9 @@ function formatDate(date) {
 }
 
 async function confirmLoad(ch) {
-  const result = await showModal(messages.characterHub.loadConfirm(ch.characterName || ch.name));
+  const result = await showModal(messages.characterHub.loadConfirm(ch.characterName));
   if (result.value === 'load') {
-    await props.loadCharacter(ch.id, ch.name);
+    await props.loadCharacter(ch.id, ch.characterName);
   }
 }
 

--- a/src/composables/useGoogleDrive.js
+++ b/src/composables/useGoogleDrive.js
@@ -63,18 +63,17 @@ export function useGoogleDrive(dataManager) {
     });
   }
 
-  async function saveCharacterToDrive(fileId, fileName) {
+  async function saveCharacterToDrive(fileId) {
     if (!dataManager.googleDriveManager) return;
     uiStore.isCloudSaveSuccess = false;
 
-    const charName = characterStore.character.name || fileName;
+    const charName = characterStore.character.name || '名もなき冒険者';
     const now = new Date().toISOString();
 
     if (!fileId) {
       const tempId = `temp-${Date.now()}`;
       uiStore.addDriveCharacter({
         id: tempId,
-        name: fileName,
         characterName: charName,
         updatedAt: now,
       });
@@ -89,14 +88,12 @@ export function useGoogleDrive(dataManager) {
           characterStore.equipments,
           characterStore.histories,
           fileId,
-          fileName,
         )
         .then((result) => {
           if (!token.canceled && result) {
             uiStore.isCloudSaveSuccess = true;
             uiStore.updateDriveCharacter(tempId, {
               id: result.id,
-              name: result.name,
               updatedAt: now,
             });
           }
@@ -132,7 +129,6 @@ export function useGoogleDrive(dataManager) {
           characterStore.equipments,
           characterStore.histories,
           fileId,
-          fileName,
         )
         .then((result) => {
           if (result) {
@@ -156,14 +152,11 @@ export function useGoogleDrive(dataManager) {
   }
 
   function handleSaveToDriveClick() {
-    return saveCharacterToDrive(uiStore.currentDriveFileId, uiStore.currentDriveFileName);
+    return saveCharacterToDrive(uiStore.currentDriveFileId);
   }
 
   function saveOrUpdateCurrentCharacterInDrive() {
-    return saveCharacterToDrive(
-      uiStore.currentDriveFileId,
-      uiStore.currentDriveFileId ? uiStore.currentDriveFileName : characterStore.character.name,
-    );
+    return saveCharacterToDrive(uiStore.currentDriveFileId);
   }
 
   function initializeGoogleDrive() {

--- a/src/services/dataManager.js
+++ b/src/services/dataManager.js
@@ -222,7 +222,7 @@ export class DataManager {
    * @param {string} fileName - The desired name for the file.
    * @returns {Promise<object|null>} Result from GoogleDriveManager.saveFile or null on error.
    */
-  async exportDataToDriveFolder(character, skills, specialSkills, equipments, histories, targetFolderId, currentFileId, fileName) {
+  async exportDataToDriveFolder(character, skills, specialSkills, equipments, histories, targetFolderId, currentFileId) {
     if (!this.googleDriveManager) {
       console.error('GoogleDriveManager not set in DataManager.');
       throw new Error('GoogleDriveManager not configured. Please sign in or initialize the Drive manager.');
@@ -242,7 +242,7 @@ export class DataManager {
     };
 
     const jsonData = JSON.stringify(dataToSave, null, 2);
-    const sanitizedFileName = (fileName || character.name || '名もなき冒険者').replace(/[\\/:*?"<>|]/g, '_') + '.json';
+    const sanitizedFileName = (character.name || '名もなき冒険者').replace(/[\\/:*?"<>|]/g, '_') + '.json';
 
     try {
       const result = await this.googleDriveManager.saveFile(targetFolderId, sanitizedFileName, jsonData, currentFileId);
@@ -257,7 +257,7 @@ export class DataManager {
    * Saves character data to the user's appDataFolder.
    * Adds an index entry when creating a new file.
    */
-  async saveDataToAppData(character, skills, specialSkills, equipments, histories, currentFileId, fileName) {
+  async saveDataToAppData(character, skills, specialSkills, equipments, histories, currentFileId) {
     if (!this.googleDriveManager) {
       console.error('GoogleDriveManager not set in DataManager.');
       throw new Error('GoogleDriveManager not configured. Please sign in or initialize the Drive manager.');
@@ -276,19 +276,16 @@ export class DataManager {
       histories: histories.filter((h) => h.sessionName || (h.gotExperiments !== null && h.gotExperiments !== '') || h.memo),
     };
 
-    const sanitizedFileName = (fileName || character.name || '名もなき冒険者').replace(/[\\/:*?"<>|]/g, '_') + '.json';
-
     if (currentFileId) {
-      const res = await this.googleDriveManager.updateCharacterFile(currentFileId, dataToSave, sanitizedFileName);
+      const res = await this.googleDriveManager.updateCharacterFile(currentFileId, dataToSave);
       await this.googleDriveManager.renameIndexEntry(currentFileId, character.name || '名もなき冒険者');
       return res;
     }
 
-    const created = await this.googleDriveManager.createCharacterFile(dataToSave, sanitizedFileName);
+    const created = await this.googleDriveManager.createCharacterFile(dataToSave);
     if (created) {
       await this.googleDriveManager.addIndexEntry({
         id: created.id,
-        name: created.name,
         characterName: character.name || '名もなき冒険者',
       });
     }

--- a/src/services/googleDriveManager.js
+++ b/src/services/googleDriveManager.js
@@ -587,12 +587,14 @@ export class GoogleDriveManager {
    * @param {object} data character JSON object
    * @param {string} name file name
    */
-  async createCharacterFile(data, name) {
-    return this.saveFile('appDataFolder', name, JSON.stringify(data, null, 2));
+  async createCharacterFile(data) {
+    const fileName = `${(data.character?.name || '名もなき冒険者').replace(/[\\/:*?"<>|]/g, '_')}.json`;
+    return this.saveFile('appDataFolder', fileName, JSON.stringify(data, null, 2));
   }
 
-  async updateCharacterFile(id, data, name) {
-    return this.saveFile('appDataFolder', name, JSON.stringify(data, null, 2), id);
+  async updateCharacterFile(id, data) {
+    const fileName = `${(data.character?.name || '名もなき冒険者').replace(/[\\/:*?"<>|]/g, '_')}.json`;
+    return this.saveFile('appDataFolder', fileName, JSON.stringify(data, null, 2), id);
   }
 
   async loadCharacterFile(id) {

--- a/src/services/mockGoogleDriveManager.js
+++ b/src/services/mockGoogleDriveManager.js
@@ -2,8 +2,8 @@ export class MockGoogleDriveManager {
   constructor(apiKey, clientId) {
     this.apiKey = apiKey;
     this.clientId = clientId;
-    this.storageKey = "mockGoogleDriveData";
-    console.log("MockGoogleDriveManager is active and uses localStorage.");
+    this.storageKey = 'mockGoogleDriveData';
+    console.log('MockGoogleDriveManager is active and uses localStorage.');
     this._loadState();
   }
 
@@ -21,10 +21,7 @@ export class MockGoogleDriveManager {
         this._initState();
       }
     } catch (e) {
-      console.error(
-        "Failed to load mock state from localStorage, resetting.",
-        e,
-      );
+      console.error('Failed to load mock state from localStorage, resetting.', e);
       this._initState();
     }
     this.pickerApiLoaded = true;
@@ -71,9 +68,7 @@ export class MockGoogleDriveManager {
   }
 
   async createFolder(folderName) {
-    const existing = Object.values(this.folders).find(
-      (f) => f.name === folderName,
-    );
+    const existing = Object.values(this.folders).find((f) => f.name === folderName);
     if (existing) return existing;
     const id = `folder-${this.fileCounter++}`;
     const folder = { id, name: folderName };
@@ -83,9 +78,7 @@ export class MockGoogleDriveManager {
   }
 
   async findFolder(folderName) {
-    return (
-      Object.values(this.folders).find((f) => f.name === folderName) || null
-    );
+    return Object.values(this.folders).find((f) => f.name === folderName) || null;
   }
 
   async getOrCreateAppFolder(appFolderName) {
@@ -94,7 +87,7 @@ export class MockGoogleDriveManager {
     return folder;
   }
 
-  async listFiles(folderId, mimeType = "application/json") {
+  async listFiles(folderId, mimeType = 'application/json') {
     return Object.values(this.appData)
       .filter((f) => f.parentId === folderId)
       .map((f) => ({ id: f.id, name: f.name }));
@@ -118,23 +111,17 @@ export class MockGoogleDriveManager {
   }
 
   async uploadAndShareFile(fileContent, fileName, mimeType) {
-    const info = await this.saveFile("drive", fileName, fileContent);
+    const info = await this.saveFile('drive', fileName, fileContent);
     return info.id;
   }
 
-  showFilePicker(
-    callback,
-    parentFolderId = null,
-    mimeTypes = ["application/json"],
-  ) {
-    const files = Object.values(this.appData).filter(
-      (f) => !parentFolderId || f.parentId === parentFolderId,
-    );
+  showFilePicker(callback, parentFolderId = null, mimeTypes = ['application/json']) {
+    const files = Object.values(this.appData).filter((f) => !parentFolderId || f.parentId === parentFolderId);
     const first = files[0];
     if (first) {
       if (callback) callback(null, { id: first.id, name: first.name });
     } else if (callback) {
-      callback(new Error("No files available."));
+      callback(new Error('No files available.'));
     }
   }
 
@@ -143,27 +130,21 @@ export class MockGoogleDriveManager {
     if (first) {
       if (callback) callback(null, { id: first.id, name: first.name });
     } else if (callback) {
-      callback(new Error("No folders available."));
+      callback(new Error('No folders available.'));
     }
   }
 
   async ensureIndexFile() {
     if (this.indexFileId && this.appData[this.indexFileId]) {
-      return { id: this.indexFileId, name: "character_index.json" };
+      return { id: this.indexFileId, name: 'character_index.json' };
     }
-    const foundId = Object.keys(this.appData).find(
-      (id) => this.appData[id].name === "character_index.json",
-    );
+    const foundId = Object.keys(this.appData).find((id) => this.appData[id].name === 'character_index.json');
     if (foundId) {
       this.indexFileId = foundId;
       this._saveState();
-      return { id: foundId, name: "character_index.json" };
+      return { id: foundId, name: 'character_index.json' };
     }
-    const created = await this.saveFile(
-      "appDataFolder",
-      "character_index.json",
-      "[]",
-    );
+    const created = await this.saveFile('appDataFolder', 'character_index.json', '[]');
     this.indexFileId = created.id;
     this._saveState();
     return created;
@@ -173,7 +154,7 @@ export class MockGoogleDriveManager {
     const info = await this.ensureIndexFile();
     const content = await this.loadFileContent(info.id);
     try {
-      return JSON.parse(content || "[]");
+      return JSON.parse(content || '[]');
     } catch {
       return [];
     }
@@ -181,12 +162,7 @@ export class MockGoogleDriveManager {
 
   async writeIndexFile(indexData) {
     const info = await this.ensureIndexFile();
-    return this.saveFile(
-      "appDataFolder",
-      "character_index.json",
-      JSON.stringify(indexData, null, 2),
-      info.id,
-    );
+    return this.saveFile('appDataFolder', 'character_index.json', JSON.stringify(indexData, null, 2), info.id);
   }
 
   async addIndexEntry(entry) {
@@ -212,17 +188,14 @@ export class MockGoogleDriveManager {
     await this.writeIndexFile(filtered);
   }
 
-  async createCharacterFile(data, name) {
-    return this.saveFile("appDataFolder", name, JSON.stringify(data, null, 2));
+  async createCharacterFile(data) {
+    const fileName = `${(data.character?.name || '名もなき冒険者').replace(/[\\/:*?"<>|]/g, '_')}.json`;
+    return this.saveFile('appDataFolder', fileName, JSON.stringify(data, null, 2));
   }
 
-  async updateCharacterFile(id, data, name) {
-    return this.saveFile(
-      "appDataFolder",
-      name,
-      JSON.stringify(data, null, 2),
-      id,
-    );
+  async updateCharacterFile(id, data) {
+    const fileName = `${(data.character?.name || '名もなき冒険者').replace(/[\\/:*?"<>|]/g, '_')}.json`;
+    return this.saveFile('appDataFolder', fileName, JSON.stringify(data, null, 2), id);
   }
 
   async loadCharacterFile(id) {

--- a/src/stores/uiStore.js
+++ b/src/stores/uiStore.js
@@ -11,7 +11,6 @@ export const useUiStore = defineStore('ui', {
     driveFolderId: null,
     driveFolderName: '',
     currentDriveFileId: null,
-    currentDriveFileName: '',
     isViewingShared: false,
     driveCharacters: [],
     pendingDriveSaves: {},

--- a/tests/integrity/data-resilience.test.js
+++ b/tests/integrity/data-resilience.test.js
@@ -1,23 +1,21 @@
-import { describe, it, beforeEach, vi, expect } from "vitest";
-import { DataManager } from "../../src/services/dataManager.js";
-import { MockGoogleDriveManager } from "../../src/services/mockGoogleDriveManager.js";
-import { AioniaGameData } from "../../src/data/gameData.js";
+import { describe, it, beforeEach, vi, expect } from 'vitest';
+import { DataManager } from '../../src/services/dataManager.js';
+import { MockGoogleDriveManager } from '../../src/services/mockGoogleDriveManager.js';
+import { AioniaGameData } from '../../src/data/gameData.js';
 
-describe("DataManager data integrity", () => {
+describe('DataManager data integrity', () => {
   let dm;
   let gdm;
 
   beforeEach(() => {
-    gdm = new MockGoogleDriveManager("k", "c");
+    gdm = new MockGoogleDriveManager('k', 'c');
     dm = new DataManager(AioniaGameData);
     dm.setGoogleDriveManager(gdm);
   });
 
-  it("should handle corrupted pointers gracefully without crashing", async () => {
-    await gdm.writeIndexFile([
-      { id: "missing", name: "missing.json", characterName: "Missing" },
-    ]);
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  it('should handle corrupted pointers gracefully without crashing', async () => {
+    await gdm.writeIndexFile([{ id: 'missing', characterName: 'Missing' }]);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const list = await dm.loadCharacterListFromDrive();
     expect(Array.isArray(list)).toBe(true);
     expect(list.length).toBe(0);
@@ -25,11 +23,8 @@ describe("DataManager data integrity", () => {
     errorSpy.mockRestore();
   });
 
-  it("should ignore orphaned files not referenced in index", async () => {
-    const file = await gdm.createCharacterFile(
-      { character: { name: "Orphan" } },
-      "orphan.json",
-    );
+  it('should ignore orphaned files not referenced in index', async () => {
+    const file = await gdm.createCharacterFile({ character: { name: 'Orphan' } });
     await gdm.writeIndexFile([]);
     const list = await dm.loadCharacterListFromDrive();
     expect(list).toEqual([]);

--- a/tests/unit/composables/useGoogleDrive.test.js
+++ b/tests/unit/composables/useGoogleDrive.test.js
@@ -19,7 +19,6 @@ describe('useGoogleDrive', () => {
     const uiStore = useUiStore();
 
     uiStore.currentDriveFileId = null;
-    uiStore.currentDriveFileName = 'c';
     charStore.character.name = 'Hero';
 
     await handleSaveToDriveClick();
@@ -31,11 +30,10 @@ describe('useGoogleDrive', () => {
       charStore.equipments,
       charStore.histories,
       null,
-      'c',
     );
   });
 
-  test('saveCharacterToDrive uses provided id and name', async () => {
+  test('saveCharacterToDrive uses provided id', async () => {
     const dataManager = {
       saveDataToAppData: vi.fn().mockResolvedValue({ id: '1', name: 'a.json' }),
       googleDriveManager: {},
@@ -44,7 +42,7 @@ describe('useGoogleDrive', () => {
     const charStore = useCharacterStore();
     charStore.character.name = 'Brave';
 
-    await saveCharacterToDrive('abc', 'foo');
+    await saveCharacterToDrive('abc');
 
     expect(dataManager.saveDataToAppData).toHaveBeenCalledWith(
       charStore.character,
@@ -53,7 +51,6 @@ describe('useGoogleDrive', () => {
       charStore.equipments,
       charStore.histories,
       'abc',
-      'foo',
     );
   });
 
@@ -65,8 +62,8 @@ describe('useGoogleDrive', () => {
         createCharacterFile: createFile,
         updateCharacterFile: updateFile,
       },
-      saveDataToAppData: vi.fn((c, s, ss, e, h, id, name) => {
-        return id ? updateFile(id, {}, name) : createFile({}, name);
+      saveDataToAppData: vi.fn((c, s, ss, e, h, id) => {
+        return id ? updateFile(id, {}) : createFile({});
       }),
     };
     const { saveOrUpdateCurrentCharacterInDrive } = useGoogleDrive(dataManager);
@@ -75,8 +72,7 @@ describe('useGoogleDrive', () => {
     await saveOrUpdateCurrentCharacterInDrive();
     expect(createFile).toHaveBeenCalled();
     uiStore.currentDriveFileId = 'abc';
-    uiStore.currentDriveFileName = 'c.json';
     await saveOrUpdateCurrentCharacterInDrive();
-    expect(updateFile).toHaveBeenCalledWith('abc', expect.any(Object), 'c.json');
+    expect(updateFile).toHaveBeenCalledWith('abc', expect.any(Object));
   });
 });

--- a/tests/unit/dataManager.test.js
+++ b/tests/unit/dataManager.test.js
@@ -282,19 +282,18 @@ describe('DataManager', () => {
     });
 
     test('creates new file and adds index when no id', async () => {
-      const res = await dm.saveDataToAppData(mockCharacter, mockSkills, mockSpecialSkills, mockEquipments, mockHistories, null, 'c');
+      const res = await dm.saveDataToAppData(mockCharacter, mockSkills, mockSpecialSkills, mockEquipments, mockHistories, null);
       expect(dm.googleDriveManager.createCharacterFile).toHaveBeenCalled();
       expect(dm.googleDriveManager.addIndexEntry).toHaveBeenCalledWith({
         id: '1',
-        name: 'c.json',
         characterName: 'TestChar',
       });
       expect(res.id).toBe('1');
     });
 
     test('updates file when id exists and renames index', async () => {
-      await dm.saveDataToAppData(mockCharacter, mockSkills, mockSpecialSkills, mockEquipments, mockHistories, '1', 'c');
-      expect(dm.googleDriveManager.updateCharacterFile).toHaveBeenCalledWith('1', expect.any(Object), 'c.json');
+      await dm.saveDataToAppData(mockCharacter, mockSkills, mockSpecialSkills, mockEquipments, mockHistories, '1');
+      expect(dm.googleDriveManager.updateCharacterFile).toHaveBeenCalledWith('1', expect.any(Object));
       expect(dm.googleDriveManager.renameIndexEntry).toHaveBeenCalledWith('1', 'TestChar');
       expect(dm.googleDriveManager.addIndexEntry).not.toHaveBeenCalled();
     });

--- a/tests/unit/googleDriveManager.test.js
+++ b/tests/unit/googleDriveManager.test.js
@@ -39,10 +39,10 @@ describe('GoogleDriveManager appDataFolder', () => {
       result: { files: [{ id: '10', name: 'character_index.json' }] },
     });
     gapi.client.drive.files.get.mockResolvedValue({
-      body: '[{"id":"a","name":"Alice"}]',
+      body: '[{"id":"a","characterName":"Alice"}]',
     });
     const index = await gdm.readIndexFile();
-    expect(index).toEqual([{ id: 'a', name: 'Alice' }]);
+    expect(index).toEqual([{ id: 'a', characterName: 'Alice' }]);
     expect(gapi.client.drive.files.get).toHaveBeenCalledWith({
       fileId: '10',
       alt: 'media',
@@ -51,10 +51,10 @@ describe('GoogleDriveManager appDataFolder', () => {
 
   test('createCharacterFile uploads JSON to appDataFolder', async () => {
     gapi.client.request.mockResolvedValue({
-      result: { id: 'c1', name: 'char.json' },
+      result: { id: 'c1', name: 'Test.json' },
     });
-    const data = { foo: 'bar' };
-    const res = await gdm.createCharacterFile(data, 'char.json');
+    const data = { character: { name: 'Test' } };
+    const res = await gdm.createCharacterFile(data);
     expect(res.id).toBe('c1');
     expect(gapi.client.request).toHaveBeenCalled();
   });
@@ -72,13 +72,12 @@ describe('GoogleDriveManager appDataFolder', () => {
   test('renameIndexEntry updates characterName and timestamp', async () => {
     const now = new Date('2024-01-01T00:00:00.000Z');
     vi.useFakeTimers().setSystemTime(now);
-    vi.spyOn(gdm, 'readIndexFile').mockResolvedValue([{ id: 'a', name: 'a.json', characterName: 'Old' }]);
+    vi.spyOn(gdm, 'readIndexFile').mockResolvedValue([{ id: 'a', characterName: 'Old' }]);
     vi.spyOn(gdm, 'writeIndexFile').mockResolvedValue();
     await gdm.renameIndexEntry('a', 'New');
     expect(gdm.writeIndexFile).toHaveBeenCalledWith([
       {
         id: 'a',
-        name: 'a.json',
         characterName: 'New',
         updatedAt: now.toISOString(),
       },
@@ -91,11 +90,10 @@ describe('GoogleDriveManager appDataFolder', () => {
     vi.useFakeTimers().setSystemTime(now);
     vi.spyOn(gdm, 'readIndexFile').mockResolvedValue([]);
     vi.spyOn(gdm, 'writeIndexFile').mockResolvedValue();
-    await gdm.addIndexEntry({ id: 'b', name: 'b.json', characterName: 'Bob' });
+    await gdm.addIndexEntry({ id: 'b', characterName: 'Bob' });
     expect(gdm.writeIndexFile).toHaveBeenCalledWith([
       {
         id: 'b',
-        name: 'b.json',
         characterName: 'Bob',
         updatedAt: now.toISOString(),
       },

--- a/tests/unit/stores/uiStoreCharacters.test.js
+++ b/tests/unit/stores/uiStoreCharacters.test.js
@@ -9,13 +9,13 @@ describe('uiStore character cache', () => {
   test('refreshDriveCharacters merges lists', async () => {
     const store = useUiStore();
     store.driveCharacters = [
-      { id: '2', name: 'b.json' },
-      { id: 'temp-1', name: 'temp.json' },
+      { id: '2', characterName: 'B' },
+      { id: 'temp-1', characterName: 'Temp' },
     ];
     const gdm = { readIndexFile: vi.fn().mockResolvedValue([{ id: '1' }]) };
     await store.refreshDriveCharacters(gdm);
     expect(store.driveCharacters).toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: '1' }), expect.objectContaining({ id: 'temp-1', name: 'temp.json' })]),
+      expect.arrayContaining([expect.objectContaining({ id: '1' }), expect.objectContaining({ id: 'temp-1', characterName: 'Temp' })]),
     );
   });
 
@@ -28,7 +28,7 @@ describe('uiStore character cache', () => {
 
   test('drive character add, update, remove', () => {
     const store = useUiStore();
-    store.addDriveCharacter({ id: 'a', name: 'a.json', characterName: 'A' });
+    store.addDriveCharacter({ id: 'a', characterName: 'A' });
     expect(store.driveCharacters).toHaveLength(1);
     store.updateDriveCharacter('a', { characterName: 'B' });
     expect(store.driveCharacters[0].characterName).toBe('B');


### PR DESCRIPTION
## Summary
- simplify Drive index by dropping stored file name
- derive Drive file names from character data at save time
- remove currentDriveFileName from UI store and components
- update Drive composable and character hub logic
- adjust tests for new data flow

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_685ac4927e6c8326adb0f8a466fb3934