### PR TITLE
feat: add R2-backed character image uploads

### DIFF
--- a/docs/character-image-uploads.md
+++ b/docs/character-image-uploads.md
@@ -1,0 +1,75 @@
+# キャラクター画像アップロード機能
+
+キャラクター画像は Cloudflare R2 に保存され、Netlify Functions を経由してアップロードおよび削除されます。本ドキュメントでは追加されたエンドポイントと利用方法、必要な環境変数について説明します。
+
+## 環境変数
+
+| 変数名 | 用途 |
+| --- | --- |
+| `R2_ACCOUNT_ID` | Cloudflare R2 アカウント ID |
+| `R2_ACCESS_KEY_ID` | R2 アクセスキー |
+| `R2_SECRET_ACCESS_KEY` | R2 シークレットキー |
+| `R2_BUCKET_NAME` | 画像を保存するバケット名 |
+| `R2_PUBLIC_BASE_URL` | 画像へアクセスするための公開ベース URL (例: `https://static.example.com/character-images`) |
+
+`R2_PUBLIC_BASE_URL` は末尾にスラッシュを付けずに設定してください。
+
+## エンドポイント
+
+### `POST /.netlify/functions/upload-character-image`
+
+| フィールド | 型 | 必須 | 説明 |
+| --- | --- | --- | --- |
+| `imageFolderId` | `string` | ✅ | キャラクターごとに一意なフォルダー ID。クライアントが保持します。 |
+| `data` | `string` | ✅ | Base64 形式の画像データ (プレフィックスなし) |
+| `contentType` | `string` | ✅ | 画像の MIME タイプ (`image/jpeg` など) |
+| `fileName` | `string` | ❌ | 元のファイル名。返却値にも含まれます。 |
+
+レスポンス:
+
+```json
+{
+  "id": "<生成された画像ID>",
+  "key": "<R2 オブジェクトキー>",
+  "url": "<公開URL>",
+  "contentType": "image/png",
+  "fileName": "original.png"
+}
+```
+
+制限事項:
+
+* 画像フォルダーごとに最大 4 枚まで保存できます。超過時は 400 エラーを返します。
+* アップロード可能な形式は `image/jpeg`, `image/png`, `image/gif`, `image/webp` です。
+
+### `POST /.netlify/functions/delete-character-image`
+
+| フィールド | 型 | 必須 | 説明 |
+| --- | --- | --- | --- |
+| `imageFolderId` | `string` | ✅ | キャラクターのフォルダー ID |
+| `key` | `string` | ✅ | 削除対象の R2 オブジェクトキー |
+
+レスポンス:
+
+```json
+{
+  "key": "user-id/images/imgfld-xxx/uuid.jpg"
+}
+```
+
+フォルダー ID とユーザー ID が一致しないキーを渡した場合は 403 エラーとなります。
+
+## クライアント側での利用フロー
+
+1. キャラクター作成時に `imageFolderId` を生成し、キャラクターデータに保持します。
+2. アップロード時は以下を順に実行します。
+   1. 画像の枚数と MIME タイプを検証。
+   2. `browser-image-compression` で最大 1024x1024 に圧縮。
+   3. `FileReader` で Base64 文字列に変換し、Netlify Function に送信。
+3. レスポンスとして返る `id`, `key`, `url` をキャラクターデータに保存します。
+4. 削除時は `imageFolderId` と `key` を Function に渡して削除します。
+
+## 既存データとの互換性
+
+* これまで Base64 文字列として保存されていた画像は、そのまま読み込み・エクスポートできます。
+* エクスポート処理は URL 形式の画像を取得して ZIP に含めるよう更新されています。取得に失敗した画像は ZIP には含まれませんが、処理全体は継続します。

--- a/netlify/functions/delete-character-image.js
+++ b/netlify/functions/delete-character-image.js
@@ -1,0 +1,84 @@
+import { DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { verifyToken } from './utils/auth.js';
+import { buildCharacterImagePrefix, getBucketName, getR2Client } from './utils/r2.js';
+
+const client = getR2Client();
+const bucket = getBucketName();
+
+export const handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Method Not Allowed' }),
+    };
+  }
+
+  const auth = await verifyToken(event);
+  if (auth.statusCode !== 200) {
+    return auth;
+  }
+
+  if (!event.body) {
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Request body is required' }),
+    };
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(event.body);
+  } catch (error) {
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Invalid JSON body' }),
+    };
+  }
+
+  const { imageFolderId, key } = payload;
+
+  if (!imageFolderId || typeof imageFolderId !== 'string') {
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'imageFolderId is required' }),
+    };
+  }
+
+  if (!key || typeof key !== 'string') {
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'key is required' }),
+    };
+  }
+
+  const expectedPrefix = buildCharacterImagePrefix(auth.userId, imageFolderId);
+  if (!key.startsWith(expectedPrefix)) {
+    return {
+      statusCode: 403,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Forbidden' }),
+    };
+  }
+
+  try {
+    const command = new DeleteObjectCommand({ Bucket: bucket, Key: key });
+    await client.send(command);
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key }),
+    };
+  } catch (error) {
+    console.error('Failed to delete character image:', error);
+    return {
+      statusCode: 500,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Failed to delete image' }),
+    };
+  }
+};

--- a/netlify/functions/upload-character-image.js
+++ b/netlify/functions/upload-character-image.js
@@ -1,0 +1,156 @@
+import { PutObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3';
+import { randomUUID } from 'crypto';
+import { verifyToken } from './utils/auth.js';
+import { buildCharacterImageKey, buildCharacterImagePrefix, buildPublicImageUrl, getBucketName, getR2Client } from './utils/r2.js';
+
+const client = getR2Client();
+const bucket = getBucketName();
+const MAX_IMAGES_PER_CHARACTER = 4;
+const ALLOWED_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
+
+function resolveExtension(contentType) {
+  switch (contentType) {
+    case 'image/jpeg':
+      return 'jpg';
+    case 'image/png':
+      return 'png';
+    case 'image/gif':
+      return 'gif';
+    case 'image/webp':
+      return 'webp';
+    default:
+      throw new Error('Unsupported content type');
+  }
+}
+
+export const handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Method Not Allowed' }),
+    };
+  }
+
+  const auth = await verifyToken(event);
+  if (auth.statusCode !== 200) {
+    return auth;
+  }
+
+  if (!event.body) {
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Request body is required' }),
+    };
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(event.body);
+  } catch (error) {
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Invalid JSON body' }),
+    };
+  }
+
+  const { imageFolderId, data, contentType, fileName } = payload;
+
+  if (!imageFolderId || typeof imageFolderId !== 'string') {
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'imageFolderId is required' }),
+    };
+  }
+
+  const normalizedType = typeof contentType === 'string' ? contentType.toLowerCase() : '';
+  if (!ALLOWED_TYPES.has(normalizedType)) {
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Unsupported content type' }),
+    };
+  }
+
+  if (!data || typeof data !== 'string') {
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Image data is required' }),
+    };
+  }
+
+  const prefix = buildCharacterImagePrefix(auth.userId, imageFolderId);
+
+  try {
+    const listCommand = new ListObjectsV2Command({
+      Bucket: bucket,
+      Prefix: prefix,
+      MaxKeys: MAX_IMAGES_PER_CHARACTER + 1,
+    });
+    const existing = await client.send(listCommand);
+    const count = existing?.Contents?.length || 0;
+    if (count >= MAX_IMAGES_PER_CHARACTER) {
+      return {
+        statusCode: 400,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ error: 'Image limit reached' }),
+      };
+    }
+  } catch (error) {
+    console.error('Failed to list existing images:', error);
+    return {
+      statusCode: 500,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Failed to validate existing images' }),
+    };
+  }
+
+  let buffer;
+  try {
+    buffer = Buffer.from(data, 'base64');
+  } catch (error) {
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Invalid image data' }),
+    };
+  }
+
+  try {
+    const imageId = randomUUID();
+    const extension = resolveExtension(normalizedType);
+    const objectFileName = `${imageId}.${extension}`;
+    const key = buildCharacterImageKey(auth.userId, imageFolderId, objectFileName);
+    const putCommand = new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: buffer,
+      ContentType: normalizedType,
+      CacheControl: 'public, max-age=31536000',
+    });
+    await client.send(putCommand);
+
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: imageId,
+        key,
+        url: buildPublicImageUrl(key),
+        contentType: normalizedType,
+        fileName: fileName || objectFileName,
+      }),
+    };
+  } catch (error) {
+    console.error('Failed to upload character image:', error);
+    return {
+      statusCode: 500,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Failed to upload image' }),
+    };
+  }
+};

--- a/netlify/functions/utils/r2.js
+++ b/netlify/functions/utils/r2.js
@@ -1,6 +1,6 @@
 import { S3Client } from '@aws-sdk/client-s3';
 
-const { R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET_NAME } = process.env;
+const { R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET_NAME, R2_PUBLIC_BASE_URL } = process.env;
 
 let client;
 
@@ -38,6 +38,36 @@ export function buildCharacterKey(userId, characterId) {
     throw new Error('Character ID is required');
   }
   return `${userId}/${characterId}.json`;
+}
+
+export function buildCharacterImagePrefix(userId, imageFolderId) {
+  if (!userId) {
+    throw new Error('User ID is required');
+  }
+  if (!imageFolderId) {
+    throw new Error('Image folder ID is required');
+  }
+  return `${userId}/images/${imageFolderId}/`;
+}
+
+export function buildCharacterImageKey(userId, imageFolderId, fileName) {
+  if (!fileName) {
+    throw new Error('Image file name is required');
+  }
+  return `${buildCharacterImagePrefix(userId, imageFolderId)}${fileName}`;
+}
+
+export function getPublicBaseUrl() {
+  return ensureEnv(R2_PUBLIC_BASE_URL, 'R2_PUBLIC_BASE_URL');
+}
+
+export function buildPublicImageUrl(key) {
+  const baseUrl = getPublicBaseUrl().replace(/\/$/, '');
+  const encodedKey = key
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+  return `${baseUrl}/${encodedKey}`;
 }
 
 export async function streamToString(stream) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@vue/compiler-sfc": "^3.5.16",
         "@vue/test-utils": "^2.4.6",
         "aws4fetch": "^1.0.20",
+        "browser-image-compression": "^2.0.2",
         "dompurify": "^3.2.6",
         "jose": "^6.1.0",
         "jsdom": "^24.0.0",
@@ -5352,6 +5353,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browser-tabs-lock": {
@@ -24267,6 +24277,12 @@
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.3.6",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@vue/compiler-sfc": "^3.5.16",
     "@vue/test-utils": "^2.4.6",
     "aws4fetch": "^1.0.20",
+    "browser-image-compression": "^2.0.2",
     "dompurify": "^3.2.6",
     "jose": "^6.1.0",
     "jsdom": "^24.0.0",

--- a/src/data/gameData.js
+++ b/src/data/gameData.js
@@ -287,6 +287,7 @@ export const AioniaGameData = {
 
   // キャラクターの初期データ構造
   defaultCharacterData: {
+    imageFolderId: null,
     images: [],
     name: '',
     playerName: '',

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -111,6 +111,14 @@ export const messages = {
   },
   image: {
     loadError: (err) => ({ title: '画像読み込み失敗', message: err.message }),
+    validationError: (err) => ({ title: '画像の検証失敗', message: err.message }),
+    notSignedIn: () => ({ title: '画像をアップロードできません', message: '画像アップロードにはサインインが必要です。' }),
+    missingFolderId: () => ({
+      title: '画像フォルダー未設定',
+      message: '画像保存用のフォルダーIDが見つかりません。ページを再読み込みしてください。',
+    }),
+    uploadError: (err) => ({ title: '画像アップロード失敗', message: err.message || '画像のアップロードに失敗しました。' }),
+    deleteError: (err) => ({ title: '画像削除失敗', message: err.message || '画像の削除に失敗しました。' }),
   },
   dataExport: {
     loadError: (msg) => ({ title: '読み込み失敗', message: msg }),

--- a/src/services/characterImageService.js
+++ b/src/services/characterImageService.js
@@ -1,0 +1,21 @@
+import { ApiManager } from './apiManager.js';
+
+export class CharacterImageService {
+  constructor(getAccessTokenSilently) {
+    this.apiManager = new ApiManager(getAccessTokenSilently);
+  }
+
+  uploadImage(payload) {
+    return this.apiManager.request('upload-character-image', {
+      method: 'POST',
+      body: payload,
+    });
+  }
+
+  deleteImage(payload) {
+    return this.apiManager.request('delete-character-image', {
+      method: 'POST',
+      body: payload,
+    });
+  }
+}

--- a/src/stores/characterStore.js
+++ b/src/stores/characterStore.js
@@ -2,10 +2,14 @@ import { defineStore } from 'pinia';
 import { AioniaGameData } from '../data/gameData.js';
 import { messages } from '../locales/ja.js';
 import { deepClone, createWeaknessArray } from '../utils/utils.js';
+import { createRandomId } from '../utils/id.js';
 
 function createCharacter() {
   const base = deepClone(AioniaGameData.defaultCharacterData);
   base.weaknesses = createWeaknessArray(AioniaGameData.config.maxWeaknesses);
+  if (!base.imageFolderId) {
+    base.imageFolderId = createRandomId('imgfld');
+  }
   return base;
 }
 

--- a/src/utils/id.js
+++ b/src/utils/id.js
@@ -1,0 +1,7 @@
+export function createRandomId(prefix = 'id') {
+  const base =
+    typeof globalThis.crypto !== 'undefined' && typeof globalThis.crypto.randomUUID === 'function'
+      ? globalThis.crypto.randomUUID()
+      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  return prefix ? `${prefix}-${base}` : base;
+}

--- a/src/utils/imageProcessing.js
+++ b/src/utils/imageProcessing.js
@@ -1,0 +1,47 @@
+import imageCompression from 'browser-image-compression';
+
+export const MAX_IMAGE_DIMENSION = 1024;
+export const MAX_IMAGES_PER_CHARACTER = 4;
+export const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+
+export function validateImageLimit(currentCount, filesToAdd = 1, limit = MAX_IMAGES_PER_CHARACTER) {
+  if (currentCount + filesToAdd > limit) {
+    throw new Error(`画像は最大${limit}枚までです。`);
+  }
+}
+
+export function validateImageType(file, allowedTypes = ALLOWED_IMAGE_TYPES) {
+  if (!file) {
+    throw new Error('ファイルが選択されていません。');
+  }
+  if (!allowedTypes.includes(file.type)) {
+    throw new Error('対応していないファイル形式です。');
+  }
+}
+
+export async function compressImageFile(file, options = {}) {
+  if (!file) {
+    throw new Error('ファイルが選択されていません。');
+  }
+
+  const compressionOptions = {
+    maxWidthOrHeight: MAX_IMAGE_DIMENSION,
+    useWebWorker: true,
+    ...options,
+  };
+
+  return imageCompression(file, compressionOptions);
+}
+
+export function fileToDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    if (!file) {
+      reject(new Error('ファイルが選択されていません。'));
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = (error) => reject(error);
+    reader.readAsDataURL(file);
+  });
+}

--- a/tests/unit/dataManager.test.js
+++ b/tests/unit/dataManager.test.js
@@ -208,7 +208,7 @@ describe('DataManager', () => {
       // fileメソッドの呼び出しを検証
       expect(mockZipInstance.file).toHaveBeenCalledWith('character_data.json', expect.any(String));
       expect(mockZipInstance.file).toHaveBeenCalledWith('image_0.png', 'mockimgdata1', { base64: true });
-      expect(mockZipInstance.file).toHaveBeenCalledWith('image_1.jpeg', 'mockimgdata2', { base64: true });
+      expect(mockZipInstance.file).toHaveBeenCalledWith('image_1.jpg', 'mockimgdata2', { base64: true });
 
       const jsonDataCall = mockZipInstance.file.mock.calls.find((call) => call[0] === 'character_data.json');
       const jsonDataInZip = JSON.parse(jsonDataCall[1]);

--- a/tests/unit/stores/characterStore.test.js
+++ b/tests/unit/stores/characterStore.test.js
@@ -17,6 +17,12 @@ describe('characterStore', () => {
     expect(store.specialSkills.length).toBeLessThanOrEqual(max);
   });
 
+  test('creates a unique image folder id for characters', () => {
+    const store = useCharacterStore();
+    expect(typeof store.character.imageFolderId).toBe('string');
+    expect(store.character.imageFolderId).toMatch(/^imgfld-/);
+  });
+
   test('currentWeight calculates equipment weight', () => {
     const store = useCharacterStore();
     store.equipments.weapon1.group = 'combat_small';

--- a/tests/unit/utils/imageProcessing.test.js
+++ b/tests/unit/utils/imageProcessing.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('browser-image-compression', () => {
+  return {
+    default: vi.fn(async (file, options) => ({ ...file, options })),
+  };
+});
+
+import imageCompression from 'browser-image-compression';
+import {
+  MAX_IMAGE_DIMENSION,
+  MAX_IMAGES_PER_CHARACTER,
+  ALLOWED_IMAGE_TYPES,
+  compressImageFile,
+  validateImageLimit,
+  validateImageType,
+} from '../../../src/utils/imageProcessing.js';
+
+describe('imageProcessing utilities', () => {
+  beforeEach(() => {
+    imageCompression.mockClear();
+  });
+
+  describe('validateImageLimit', () => {
+    it('allows adding images when limit is not exceeded', () => {
+      expect(() => validateImageLimit(2, 1)).not.toThrow();
+    });
+
+    it('throws an error when limit would be exceeded', () => {
+      expect(() => validateImageLimit(MAX_IMAGES_PER_CHARACTER, 1)).toThrowError(/最大/);
+    });
+  });
+
+  describe('validateImageType', () => {
+    it('accepts allowed image types', () => {
+      const file = new File(['foo'], 'foo.png', { type: ALLOWED_IMAGE_TYPES[0] });
+      expect(() => validateImageType(file)).not.toThrow();
+    });
+
+    it('rejects unsupported image types', () => {
+      const file = new File(['foo'], 'foo.txt', { type: 'text/plain' });
+      expect(() => validateImageType(file)).toThrowError(/対応していない/);
+    });
+  });
+
+  describe('compressImageFile', () => {
+    it('compresses using configured dimensions', async () => {
+      const file = new File(['data'], 'image.png', { type: 'image/png' });
+      const compressed = await compressImageFile(file);
+      expect(imageCompression).toHaveBeenCalledWith(
+        file,
+        expect.objectContaining({
+          maxWidthOrHeight: MAX_IMAGE_DIMENSION,
+          useWebWorker: true,
+        }),
+      );
+      expect(compressed.options.maxWidthOrHeight).toBe(MAX_IMAGE_DIMENSION);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- compress and validate character images on the client while enforcing a 4-file limit
- wire the UI to authenticated Cloudflare R2 upload/delete Netlify functions and new service helpers
- update data export, store initialization, and add documentation for the new endpoints

## Testing
- npm test
- npm run lint
- npm run e2e *(fails: host missing Playwright browser dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d78c207e408326b294e1cccb674440