### PR TITLE
Mock Auth0 for Vitest

### DIFF
--- a/tests/vitest.setup.js
+++ b/tests/vitest.setup.js
@@ -1,0 +1,15 @@
+import { vi } from 'vitest';
+
+vi.mock('@auth0/auth0-vue', () => ({
+  useAuth0: () => ({
+    isAuthenticated: true,
+    isLoading: false,
+    user: {
+      name: 'Test User',
+      email: 'test@example.com',
+    },
+    getAccessTokenSilently: vi.fn().mockResolvedValue('mock-token'),
+    loginWithRedirect: vi.fn(),
+    logout: vi.fn(),
+  }),
+}));

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,18 @@
+import { resolve } from 'path';
+import { defineConfig } from 'vitest/config';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./tests/unit/setup.js', './tests/vitest.setup.js'],
+    include: ['tests/unit/**/*.test.js', 'tests/integrity/**/*.test.js'],
+    exclude: ['tests/e2e/**', 'src/libs/sabalessshare/**', 'node_modules/**'],
+    alias: {
+      '\\?raw$': resolve(__dirname, 'tests/unit/__mocks__/raw.js'),
+      '@sabalessshare': resolve(__dirname, 'src/libs/sabalessshare/src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a global Vitest setup that mocks @auth0/auth0-vue for unit tests
- mirror the previous Vite test configuration in a dedicated vitest.config.js and register the new setup file alongside the existing utilities

## Testing
- npm run lint
- npm run test
- npm run e2e *(fails: installing Playwright browsers pulls ~500MB of packages and was interrupted in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8c5326dc883269a0220f7847be5ca