### PR TITLE
chore: install playwright deps during setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "vitest run",
     "test:ui": "vitest --ui",
     "e2e": "playwright test",
-    "pree2e": "playwright install --with-deps",
+    "pree2e": "playwright install",
     "prepare": "husky",
     "format": "prettier --write ."
   },

--- a/setup.bash
+++ b/setup.bash
@@ -1,2 +1,85 @@
 git submodule update --remote
+
+# Playwright for Linux dependencies installation
+apt-get update && apt-get install -y \
+    libasound2t64 \
+    libatk-bridge2.0-0t64 \
+    libatk1.0-0t64 \
+    libatspi2.0-0t64 \
+    libcairo2 \
+    libcups2t64 \
+    libdbus-1-3 \
+    libdrm2 \
+    libgbm1 \
+    libglib2.0-0t64 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libx11-6 \
+    libxcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxkbcommon0 \
+    libxrandr2 \
+    libcairo-gobject2 \
+    libfontconfig1 \
+    libfreetype6 \
+    libgdk-pixbuf-2.0-0 \
+    libgtk-3-0t64 \
+    libpangocairo-1.0-0 \
+    libx11-xcb1 \
+    libxcb-shm0 \
+    libxcursor1 \
+    libxi6 \
+    libxrender1 \
+    gstreamer1.0-libav \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    libicu74 \
+    libatomic1 \
+    libenchant-2-2 \
+    libepoxy0 \
+    libevent-2.1-7t64 \
+    libflite1 \
+    libgles2 \
+    libgstreamer-gl1.0-0 \
+    libgstreamer-plugins-bad1.0-0 \
+    libgstreamer-plugins-base1.0-0 \
+    libgstreamer1.0-0 \
+    libgtk-4-1 \
+    libharfbuzz-icu0 \
+    libharfbuzz0b \
+    libhyphen0 \
+    libjpeg-turbo8 \
+    liblcms2-2 \
+    libmanette-0.2-0 \
+    libopus0 \
+    libpng16-16t64 \
+    libsecret-1-0 \
+    libvpx9 \
+    libwayland-client0 \
+    libwayland-egl1 \
+    libwayland-server0 \
+    libwebp7 \
+    libwebpdemux2 \
+    libwoff1 \
+    libxml2 \
+    libxslt1.1 \
+    libx264-164 \
+    libavif16 \
+    xvfb \
+    fonts-noto-color-emoji \
+    fonts-unifont \
+    xfonts-cyrillic \
+    xfonts-scalable \
+    fonts-liberation \
+    fonts-ipafont-gothic \
+    fonts-wqy-zenhei \
+    fonts-tlwg-loma-otf \
+    fonts-freefont-ttf \
+    --no-install-recommends
+
 npm install


### PR DESCRIPTION
## Summary
- install the Playwright OS dependencies once during setup to avoid repeated `--with-deps` installs
- simplify the `pree2e` script to call `playwright install` without the `--with-deps` flag

## Testing
- npm run e2e *(fails: existing download-related timeouts in Character Sheet E2E tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d8cc49427883269be674f28c55780e