### PR TITLE
Add Vitest Auth0 mock and preinstall Playwright dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "vitest run",
     "test:ui": "vitest --ui",
     "e2e": "playwright test",
-    "pree2e": "playwright install --with-deps",
+    "pree2e": "playwright install",
     "prepare": "husky",
     "format": "prettier --write ."
   },

--- a/setup.bash
+++ b/setup.bash
@@ -1,2 +1,87 @@
+#!/usr/bin/env bash
+
+# Playwright for Linux dependencies installation
+apt-get update && apt-get install -y --no-install-recommends \
+    libasound2t64 \
+    libatk-bridge2.0-0t64 \
+    libatk1.0-0t64 \
+    libatspi2.0-0t64 \
+    libcairo2 \
+    libcups2t64 \
+    libdbus-1-3 \
+    libdrm2 \
+    libgbm1 \
+    libglib2.0-0t64 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libx11-6 \
+    libxcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxkbcommon0 \
+    libxrandr2 \
+    libcairo-gobject2 \
+    libfontconfig1 \
+    libfreetype6 \
+    libgdk-pixbuf-2.0-0 \
+    libgtk-3-0t64 \
+    libpangocairo-1.0-0 \
+    libx11-xcb1 \
+    libxcb-shm0 \
+    libxcursor1 \
+    libxi6 \
+    libxrender1 \
+    gstreamer1.0-libav \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    libicu74 \
+    libatomic1 \
+    libenchant-2-2 \
+    libepoxy0 \
+    libevent-2.1-7t64 \
+    libflite1 \
+    libgles2 \
+    libgstreamer-gl1.0-0 \
+    libgstreamer-plugins-bad1.0-0 \
+    libgstreamer-plugins-base1.0-0 \
+    libgstreamer1.0-0 \
+    libgtk-4-1 \
+    libharfbuzz-icu0 \
+    libharfbuzz0b \
+    libhyphen0 \
+    libjpeg-turbo8 \
+    liblcms2-2 \
+    libmanette-0.2-0 \
+    libopus0 \
+    libpng16-16t64 \
+    libsecret-1-0 \
+    libvpx9 \
+    libwayland-client0 \
+    libwayland-egl1 \
+    libwayland-server0 \
+    libwebp7 \
+    libwebpdemux2 \
+    libwoff1 \
+    libxml2 \
+    libxslt1.1 \
+    libx264-164 \
+    libavif16 \
+    xvfb \
+    fonts-noto-color-emoji \
+    fonts-unifont \
+    xfonts-cyrillic \
+    xfonts-scalable \
+    fonts-liberation \
+    fonts-ipafont-gothic \
+    fonts-wqy-zenhei \
+    fonts-tlwg-loma-otf \
+    fonts-freefont-ttf
+
+apt-get clean && rm -rf /var/lib/apt/lists/*
+
 git submodule update --remote
 npm install

--- a/tests/__mocks__/auth0-vue.js
+++ b/tests/__mocks__/auth0-vue.js
@@ -1,0 +1,16 @@
+const defaultAuth0Mock = {
+  isAuthenticated: { value: false },
+  isLoading: { value: false },
+  user: { value: null },
+  getAccessTokenSilently: async () => 'mock-token',
+  loginWithRedirect: () => {},
+  logout: () => {},
+};
+
+export const useAuth0 = () => {
+  return globalThis.__auth0Mock ?? defaultAuth0Mock;
+};
+
+export default {
+  useAuth0,
+};

--- a/tests/vitest.setup.js
+++ b/tests/vitest.setup.js
@@ -1,0 +1,26 @@
+import './unit/setup.js';
+import { vi } from 'vitest';
+import { ref } from 'vue';
+
+const auth0Mock = {
+  isAuthenticated: ref(true),
+  isLoading: ref(false),
+  user: ref({
+    name: 'Test User',
+    email: 'test@example.com',
+    sub: 'auth0|test-user',
+  }),
+  getAccessTokenSilently: vi.fn().mockResolvedValue('mock-token'),
+  loginWithRedirect: vi.fn(),
+  logout: vi.fn(),
+};
+
+vi.mock(
+  '@auth0/auth0-vue',
+  () => ({
+    useAuth0: () => auth0Mock,
+  }),
+  { virtual: true },
+);
+
+globalThis.__auth0Mock = auth0Mock;

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import { resolve } from 'path';
 import { visualizer } from 'rollup-plugin-visualizer';
 
 export default defineConfig({
-  base: './', 
+  base: './',
   plugins: [vue(), visualizer({ open: true })],
   resolve: {
     alias: {
@@ -20,12 +20,13 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    setupFiles: './tests/unit/setup.js',
+    setupFiles: './tests/vitest.setup.js',
     include: ['tests/unit/**/*.test.js', 'tests/integrity/**/*.test.js'],
     exclude: ['tests/e2e/**', 'src/libs/sabalessshare/**', 'node_modules/**'],
     alias: {
       '\\?raw$': resolve(__dirname, 'tests/unit/__mocks__/raw.js'),
       '@sabalessshare': resolve(__dirname, 'src/libs/sabalessshare/src'),
+      '@auth0/auth0-vue': resolve(__dirname, 'tests/__mocks__/auth0-vue.js'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- add a global Vitest setup file that mocks `@auth0/auth0-vue` and expose a reusable mock instance
- point Vitest configuration at the new setup file and alias `@auth0/auth0-vue` to the mock module for tests
- move Playwright OS dependency installation into `setup.bash` and drop the `--with-deps` flag from the `pree2e` script

## Testing
- npm run lint
- npm run test
- npm run e2e

------
https://chatgpt.com/codex/tasks/task_e_68d8fe1b3ea48326aaa4c8f14b4250b0