### PR TITLE
Implement Cloudflare R2-backed character image handling

### DIFF
--- a/netlify/functions/delete-character-image.js
+++ b/netlify/functions/delete-character-image.js
@@ -1,0 +1,82 @@
+import { DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { verifyToken } from './utils/auth.js';
+import { getBucketName, getR2Client, extractKeyFromUrl, ensureImageOwnership } from './utils/r2.js';
+
+const client = getR2Client();
+const bucket = getBucketName();
+
+export const handler = async (event) => {
+  if (event.httpMethod !== 'DELETE') {
+    return {
+      statusCode: 405,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Method Not Allowed' }),
+    };
+  }
+
+  const auth = await verifyToken(event);
+  if (auth.statusCode !== 200) {
+    return auth;
+  }
+
+  if (!event.body) {
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Request body is required' }),
+    };
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(event.body);
+  } catch (error) {
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Invalid JSON body' }),
+    };
+  }
+
+  const { url } = payload;
+  if (!url) {
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: '画像URLが必要です。' }),
+    };
+  }
+
+  let key;
+  try {
+    key = extractKeyFromUrl(url);
+    ensureImageOwnership(auth.userId, key);
+  } catch (error) {
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: error.message || 'Invalid image reference' }),
+    };
+  }
+
+  try {
+    const command = new DeleteObjectCommand({
+      Bucket: bucket,
+      Key: key,
+    });
+    await client.send(command);
+
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: 'Image deleted', url }),
+    };
+  } catch (error) {
+    console.error('Failed to delete image:', error);
+    return {
+      statusCode: 500,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: '画像の削除に失敗しました。' }),
+    };
+  }
+};

--- a/netlify/functions/upload-character-image.js
+++ b/netlify/functions/upload-character-image.js
@@ -1,0 +1,92 @@
+import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { verifyToken } from './utils/auth.js';
+import { getBucketName, getR2Client, generateImageKey, buildPublicUrl } from './utils/r2.js';
+import { parseMultipartForm } from './utils/form.js';
+import { IMAGE_SETTINGS } from '../../src/config/imageSettings.js';
+
+const client = getR2Client();
+const bucket = getBucketName();
+
+function resolveExtension(file) {
+  const nameExtension = file.filename?.split('.').pop();
+  if (nameExtension) {
+    return nameExtension;
+  }
+  const mimeExtension = file.mimeType?.split('/').pop();
+  if (mimeExtension === 'jpeg') {
+    return 'jpg';
+  }
+  return mimeExtension || 'png';
+}
+
+export const handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Method Not Allowed' }),
+    };
+  }
+
+  const auth = await verifyToken(event);
+  if (auth.statusCode !== 200) {
+    return auth;
+  }
+
+  let form;
+  try {
+    form = await parseMultipartForm(event, {
+      limits: { fileSize: IMAGE_SETTINGS.MAX_FILE_SIZE_BYTES },
+    });
+  } catch (error) {
+    console.error('Failed to parse multipart form:', error);
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: error.message || 'Invalid upload payload' }),
+    };
+  }
+
+  const file = form.files.find((f) => f.fieldname === 'image');
+  if (!file) {
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: '画像ファイルが見つかりません。' }),
+    };
+  }
+
+  if (!IMAGE_SETTINGS.ALLOWED_TYPES.includes(file.mimeType)) {
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: '対応していない画像形式です。' }),
+    };
+  }
+
+  const extension = resolveExtension(file);
+  const key = generateImageKey(auth.userId, extension);
+
+  try {
+    const command = new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: file.buffer,
+      ContentType: file.mimeType,
+    });
+    await client.send(command);
+
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url: buildPublicUrl(key), key }),
+    };
+  } catch (error) {
+    console.error('Failed to upload image:', error);
+    return {
+      statusCode: 500,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: '画像のアップロードに失敗しました。' }),
+    };
+  }
+};

--- a/netlify/functions/utils/form.js
+++ b/netlify/functions/utils/form.js
@@ -1,0 +1,42 @@
+import Busboy from 'busboy';
+
+export function parseMultipartForm(event, options = {}) {
+  return new Promise((resolve, reject) => {
+    const headers = event.headers || {};
+    const contentType = headers['content-type'] || headers['Content-Type'];
+
+    if (!contentType) {
+      reject(new Error('Content-Type header is required.'));
+      return;
+    }
+
+    const busboy = Busboy({ headers: { 'content-type': contentType }, limits: options.limits });
+    const files = [];
+    const fields = {};
+
+    busboy.on('file', (name, file, info) => {
+      const chunks = [];
+      file.on('data', (data) => chunks.push(data));
+      file.on('limit', () => reject(new Error('アップロード可能なサイズを超えています。')));
+      file.on('end', () => {
+        files.push({
+          fieldname: name,
+          filename: info.filename,
+          mimeType: info.mimeType,
+          encoding: info.encoding,
+          buffer: Buffer.concat(chunks),
+        });
+      });
+    });
+
+    busboy.on('field', (name, value) => {
+      fields[name] = value;
+    });
+
+    busboy.once('error', reject);
+    busboy.once('finish', () => resolve({ files, fields }));
+
+    const body = event.isBase64Encoded ? Buffer.from(event.body, 'base64') : event.body;
+    busboy.end(body);
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@vue/test-utils": "^2.4.6",
         "aws4fetch": "^1.0.20",
         "browser-image-compression": "^2.0.2",
+        "busboy": "^1.6.0",
         "dompurify": "^3.2.6",
         "jose": "^6.1.0",
         "jsdom": "^24.0.0",
@@ -5426,6 +5427,17 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/cac": {
@@ -23406,6 +23418,14 @@
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@vue/test-utils": "^2.4.6",
     "aws4fetch": "^1.0.20",
     "browser-image-compression": "^2.0.2",
+    "busboy": "^1.6.0",
     "dompurify": "^3.2.6",
     "jose": "^6.1.0",
     "jsdom": "^24.0.0",

--- a/src/composables/useCharacterImageManager.js
+++ b/src/composables/useCharacterImageManager.js
@@ -1,0 +1,108 @@
+import { ref } from 'vue';
+import { useAuth0 } from '@auth0/auth0-vue';
+import { CloudStorageService } from '../services/cloudStorageService.js';
+import { ImageManager } from '../services/imageManager.js';
+import { useNotifications } from './useNotifications.js';
+import { messages } from '../locales/ja.js';
+
+let cachedService = null;
+
+function ensureService(getAccessTokenSilently) {
+  if (!cachedService) {
+    cachedService = new CloudStorageService(getAccessTokenSilently);
+  }
+  return cachedService;
+}
+
+export function useCharacterImageManager() {
+  const { isAuthenticated, getAccessTokenSilently } = useAuth0();
+  const { showToast, showAsyncToast } = useNotifications();
+  const isUploading = ref(false);
+  const isDeleting = ref(false);
+
+  function ensureSignedIn() {
+    if (!isAuthenticated.value) {
+      showToast({ type: 'error', ...messages.image.signInRequired() });
+      return false;
+    }
+    return true;
+  }
+
+  async function uploadImage(file) {
+    if (!file) {
+      return null;
+    }
+
+    if (!ensureSignedIn()) {
+      return null;
+    }
+
+    let preparedFile;
+    try {
+      preparedFile = await ImageManager.prepareForUpload(file);
+    } catch (error) {
+      showToast({ type: 'error', ...messages.image.upload.error(error) });
+      return null;
+    }
+
+    isUploading.value = true;
+    const service = ensureService(getAccessTokenSilently);
+    const uploadPromise = service.uploadCharacterImage(preparedFile);
+
+    showAsyncToast(uploadPromise, {
+      loading: messages.image.upload.loading(),
+      success: messages.image.upload.success(),
+      error: (err) => messages.image.upload.error(err),
+    });
+
+    try {
+      const result = await uploadPromise;
+      if (!result?.url) {
+        throw new Error('画像URLの取得に失敗しました。');
+      }
+      return result.url;
+    } catch (error) {
+      console.error('Character image upload failed:', error);
+      return null;
+    } finally {
+      isUploading.value = false;
+    }
+  }
+
+  async function deleteImage(url) {
+    if (!url) {
+      return false;
+    }
+
+    if (!ensureSignedIn()) {
+      return false;
+    }
+
+    isDeleting.value = true;
+    const service = ensureService(getAccessTokenSilently);
+    const deletePromise = service.deleteCharacterImage(url);
+
+    showAsyncToast(deletePromise, {
+      loading: messages.image.delete.loading(),
+      success: messages.image.delete.success(),
+      error: (err) => messages.image.delete.error(err),
+    });
+
+    try {
+      await deletePromise;
+      return true;
+    } catch (error) {
+      console.error('Character image delete failed:', error);
+      return false;
+    } finally {
+      isDeleting.value = false;
+    }
+  }
+
+  return {
+    uploadImage,
+    deleteImage,
+    isUploading,
+    isDeleting,
+  };
+}

--- a/src/composables/useImages.js
+++ b/src/composables/useImages.js
@@ -1,9 +1,12 @@
 import { ref, computed } from 'vue';
-import { ImageManager } from '../services/imageManager.js';
+import { IMAGE_SETTINGS } from '../config/imageSettings.js';
+import { messages } from '../locales/ja.js';
+import { useCharacterImageManager } from './useCharacterImageManager.js';
 
 // 画像関連のロジックを提供するコンポーザブル関数
 export function useImages(character, showCustomAlert) {
   const currentImageIndex = ref(0);
+  const { uploadImage, deleteImage, isUploading, isDeleting } = useCharacterImageManager();
 
   const currentImageSrc = computed(() => {
     if (character.value?.images?.length > 0 && currentImageIndex.value < character.value.images.length) {
@@ -14,19 +17,26 @@ export function useImages(character, showCustomAlert) {
 
   async function handleImageUpload(event) {
     const file = event.target.files[0];
+    event.target.value = null;
     if (!file) return;
 
+    if (!character.value.images) {
+      character.value.images = [];
+    }
+
+    if (character.value.images.length >= IMAGE_SETTINGS.MAX_COUNT) {
+      showCustomAlert(messages.image.limitNotice(IMAGE_SETTINGS.MAX_COUNT));
+      return;
+    }
+
     try {
-      const imageData = await ImageManager.loadImage(file);
-      if (!character.value.images) {
-        character.value.images = [];
+      const imageUrl = await uploadImage(file);
+      if (imageUrl) {
+        character.value.images.push(imageUrl);
+        currentImageIndex.value = character.value.images.length - 1;
       }
-      character.value.images.push(imageData);
-      currentImageIndex.value = character.value.images.length - 1;
     } catch (error) {
       showCustomAlert(`画像の読み込みに失敗しました：${error.message}`);
-    } finally {
-      if (event.target) event.target.value = null;
     }
   }
 
@@ -42,8 +52,14 @@ export function useImages(character, showCustomAlert) {
     }
   }
 
-  function removeCurrentImage() {
+  async function removeCurrentImage() {
     if (character.value?.images?.length > 0 && currentImageIndex.value >= 0) {
+      const targetUrl = character.value.images[currentImageIndex.value];
+      const success = await deleteImage(targetUrl);
+      if (!success) {
+        return;
+      }
+
       character.value.images.splice(currentImageIndex.value, 1);
       if (character.value.images.length === 0) {
         currentImageIndex.value = -1;
@@ -60,5 +76,7 @@ export function useImages(character, showCustomAlert) {
     nextImage,
     previousImage,
     removeCurrentImage,
+    isUploading,
+    isDeleting,
   };
 }

--- a/src/config/imageSettings.js
+++ b/src/config/imageSettings.js
@@ -1,0 +1,7 @@
+export const IMAGE_SETTINGS = Object.freeze({
+  MAX_COUNT: 4,
+  MAX_DIMENSION: 1024,
+  COMPRESSION_QUALITY: 0.85,
+  MAX_FILE_SIZE_BYTES: 10 * 1024 * 1024,
+  ALLOWED_TYPES: Object.freeze(['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml']),
+});

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -133,6 +133,32 @@ export const messages = {
   },
   image: {
     loadError: (err) => ({ title: '画像読み込み失敗', message: err.message }),
+    upload: {
+      loading: () => ({ title: '画像アップロード', message: 'アップロードしています...' }),
+      success: () => ({ title: '画像アップロード', message: '画像を保存しました。' }),
+      error: (err) => ({
+        title: '画像アップロード失敗',
+        message: err?.message || '画像のアップロードに失敗しました。',
+      }),
+      inProgress: 'アップロード中...',
+    },
+    delete: {
+      loading: () => ({ title: '画像削除', message: '画像を削除しています...' }),
+      success: () => ({ title: '画像削除', message: '画像を削除しました。' }),
+      error: (err) => ({
+        title: '画像削除失敗',
+        message: err?.message || '画像の削除に失敗しました。',
+      }),
+    },
+    signInRequired: () => ({
+      title: '画像操作',
+      message: '画像を操作するにはログインしてください。',
+    }),
+    limitReached: (max) => ({
+      title: '画像の上限',
+      message: `画像は最大${max}枚まで追加できます。`,
+    }),
+    limitNotice: (max) => `画像は最大${max}枚まで追加できます。`,
   },
   dataExport: {
     loadError: (msg) => ({ title: '読み込み失敗', message: msg }),

--- a/src/services/apiManager.js
+++ b/src/services/apiManager.js
@@ -68,10 +68,16 @@ export class ApiManager {
     const fetchOptions = { method, headers };
 
     if (options.body !== undefined) {
-      if (!headers.has('Content-Type')) {
-        headers.set('Content-Type', 'application/json');
+      const isFormData = typeof FormData !== 'undefined' && options.body instanceof FormData;
+      if (isFormData) {
+        headers.delete('Content-Type');
+        fetchOptions.body = options.body;
+      } else {
+        if (!headers.has('Content-Type')) {
+          headers.set('Content-Type', 'application/json');
+        }
+        fetchOptions.body = typeof options.body === 'string' ? options.body : JSON.stringify(options.body);
       }
-      fetchOptions.body = typeof options.body === 'string' ? options.body : JSON.stringify(options.body);
     }
 
     const response = await fetch(url, fetchOptions);
@@ -108,6 +114,20 @@ export class ApiManager {
       throw new Error('Character ID is required.');
     }
     return this.request('delete-character', { method: 'DELETE', params: { id } });
+  }
+
+  uploadCharacterImage(formData) {
+    if (!(typeof FormData !== 'undefined' && formData instanceof FormData)) {
+      throw new Error('FormData payload is required for image upload.');
+    }
+    return this.request('upload-character-image', { method: 'POST', body: formData });
+  }
+
+  deleteCharacterImage(url) {
+    if (!url) {
+      throw new Error('Image URL is required.');
+    }
+    return this.request('delete-character-image', { method: 'DELETE', body: { url } });
   }
 
   _ensureAuth() {

--- a/src/services/cloudStorageService.js
+++ b/src/services/cloudStorageService.js
@@ -154,4 +154,33 @@ export class CloudStorageService {
       throw error;
     }
   }
+
+  async uploadCharacterImage(file) {
+    if (!(file instanceof File)) {
+      throw new Error('有効な画像ファイルが必要です。');
+    }
+
+    const formData = new FormData();
+    formData.append('image', file, file.name);
+
+    try {
+      return await this.apiManager.uploadCharacterImage(formData);
+    } catch (error) {
+      console.error('Failed to upload character image:', error);
+      throw error;
+    }
+  }
+
+  async deleteCharacterImage(url) {
+    if (!url) {
+      throw new Error('画像URLが必要です。');
+    }
+
+    try {
+      return await this.apiManager.deleteCharacterImage(url);
+    } catch (error) {
+      console.error('Failed to delete character image:', error);
+      throw error;
+    }
+  }
 }

--- a/tests/unit/imageManager.test.js
+++ b/tests/unit/imageManager.test.js
@@ -1,98 +1,67 @@
-// tests/unit/imageManager.test.js
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { vi } from 'vitest';
-// Mocking FileReader
-global.FileReader = class {
-  constructor() {
-    this.onload = null;
-    this.onerror = null;
-  }
+vi.mock('browser-image-compression', () => ({
+  default: vi.fn(async (file) => new File([file], `compressed-${file.name}`, { type: file.type })),
+}));
 
-  readAsDataURL(file) {
-    if (file && file.name === 'error.png') {
-      // Simulate an error
-      if (this.onerror) {
-        this.onerror(new Error('Simulated FileReader error'));
-      }
-    } else if (file) {
-      // Simulate a successful read
-      if (this.onload) {
-        this.onload({
-          target: {
-            result: `data:image/png;base64,mock_base64_data_for_${file.name}`,
-          },
-        });
-      }
-    } else {
-      if (this.onerror) {
-        this.onerror(new Error('No file provided to FileReader mock'));
-      }
-    }
-  }
-};
-
-// Assuming imageManager.js attaches ImageManager to window
-// If not, you might need to require/import it and handle its global availability.
-// For this example, let's assume src/imageManager.js has been loaded or is mocked
-// such that window.ImageManager is available.
-
-// If src/imageManager.js is not automatically available in the test runner,
-// you might need to manually load it or mock its structure:
-if (typeof window.ImageManager === 'undefined') {
-  window.ImageManager = {
-    loadImage: vi.fn((file) => {
-      return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = (e) => resolve(e.target.result);
-        reader.onerror = (e) => reject(e);
-        if (file) {
-          reader.readAsDataURL(file);
-        } else {
-          reject(new Error('No file provided.'));
-        }
-      });
-    }),
-    // removeImage can be mocked if needed, but the subtask says to skip its tests
-  };
-}
+const imageCompression = (await import('browser-image-compression')).default;
+const { ImageManager } = await import('../../src/services/imageManager.js');
+const { IMAGE_SETTINGS } = await import('../../src/config/imageSettings.js');
 
 describe('ImageManager', () => {
-  describe('loadImage', () => {
-    it('should resolve with a base64 data URL for a valid file', async () => {
-      const mockFile = { name: 'sample.png', type: 'image/png' };
-      // Use the actual ImageManager.loadImage if available and properly set up,
-      // otherwise the mock defined above will be used.
-      const imageData = await window.ImageManager.loadImage(mockFile);
-      expect(imageData).toMatch(/^data:image\/png;base64,/);
-      expect(imageData).toContain('mock_base64_data_for_sample.png');
-    });
-
-    it('should reject if no file is provided', async () => {
-      await expect(window.ImageManager.loadImage(null)).rejects.toThrow('No file provided.');
-    });
-
-    it('should reject if FileReader encounters an error', async () => {
-      const mockErrorFile = { name: 'error.png', type: 'image/png' };
-      await expect(window.ImageManager.loadImage(mockErrorFile)).rejects.toThrow('Simulated FileReader error');
-    });
-
-    // Example of how you might test with a real instance if imageManager.js was loaded
-    // This requires a proper JSDOM setup where src/imageManager.js can execute.
-    it('should process file using mocked FileReader successfully (alternative)', () => {
-      // This test assumes ImageManager is the actual implementation from src/imageManager.js
-      // and that imageManager.js has been loaded into the test environment (e.g., by JSDOM)
-      // For this to work, the ImageManager mock above should be conditional or removed if
-      // the actual script is loaded.
-
-      // const actualImageManager = require('../../src/imageManager'); // This won't work directly due to window
-      // For now, we rely on the global window.ImageManager which might be the mock or the real one.
-
-      const mockFile = { name: 'another.jpeg', type: 'image/jpeg' };
-      return window.ImageManager.loadImage(mockFile).then((data) => {
-        expect(data).toBe(`data:image/png;base64,mock_base64_data_for_${mockFile.name}`);
-      });
-    });
+  beforeEach(() => {
+    imageCompression.mockClear();
   });
 
-  // Tests for removeImage would go here if needed
+  it('validates supported file types and size', () => {
+    const file = new File([new Uint8Array([1, 2, 3])], 'hero.png', { type: 'image/png' });
+    expect(() => ImageManager.validateFile(file)).not.toThrow();
+  });
+
+  it('throws when file is not provided', () => {
+    expect(() => ImageManager.validateFile(null)).toThrow('画像ファイルを選択してください。');
+  });
+
+  it('throws when file type is not supported', () => {
+    const file = new File([new Uint8Array([1])], 'hero.bmp', { type: 'image/bmp' });
+    expect(() => ImageManager.validateFile(file)).toThrow('対応していない画像形式です。');
+  });
+
+  it('throws when file is larger than limit', () => {
+    const largeArray = new Uint8Array(IMAGE_SETTINGS.MAX_FILE_SIZE_BYTES + 1);
+    const file = new File([largeArray], 'huge.png', { type: 'image/png' });
+    expect(() => ImageManager.validateFile(file)).toThrow('ファイルサイズが大きすぎます。');
+  });
+
+  it('compresses raster images before upload', async () => {
+    const file = new File([new Uint8Array([1, 2, 3])], 'portrait.jpg', { type: 'image/jpeg' });
+    const compressed = await ImageManager.prepareForUpload(file);
+
+    expect(imageCompression).toHaveBeenCalledTimes(1);
+    expect(imageCompression).toHaveBeenCalledWith(
+      file,
+      expect.objectContaining({
+        maxWidthOrHeight: IMAGE_SETTINGS.MAX_DIMENSION,
+        initialQuality: IMAGE_SETTINGS.COMPRESSION_QUALITY,
+      }),
+    );
+    expect(compressed).toBeInstanceOf(File);
+    expect(compressed.name).toBe('compressed-portrait.jpg');
+  });
+
+  it('returns original SVG file without compression', async () => {
+    const file = new File([new TextEncoder().encode('<svg></svg>')], 'icon.svg', { type: 'image/svg+xml' });
+    const result = await ImageManager.prepareForUpload(file);
+    expect(imageCompression).not.toHaveBeenCalled();
+    expect(result).toBeInstanceOf(File);
+    expect(result.name).toBe('icon.svg');
+  });
+
+  it('rethrows compression errors with friendly message', async () => {
+    imageCompression.mockImplementationOnce(async () => {
+      throw new Error('Unexpected failure');
+    });
+    const file = new File([new Uint8Array([1])], 'portrait.png', { type: 'image/png' });
+    await expect(ImageManager.prepareForUpload(file)).rejects.toThrow('画像の圧縮に失敗しました。');
+  });
 });


### PR DESCRIPTION
## Summary
- add Cloudflare R2 upload and deletion functions with multipart parsing utilities
- migrate character image UI and services to compress, upload, and manage remote image URLs with shared settings
- refresh tests and locale messaging to reflect URL-based storage and signed-in upload requirements

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: Playwright browsers require system dependencies in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9271e70f88326a7a8e8188b67f120