### PR TITLE
Implement secure character image proxy delivery

### DIFF
--- a/netlify/functions/delete-character-image.js
+++ b/netlify/functions/delete-character-image.js
@@ -1,6 +1,6 @@
 import { DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { verifyToken } from './utils/auth.js';
-import { getBucketName, getR2Client, extractKeyFromUrl, ensureImageOwnership } from './utils/r2.js';
+import { getBucketName, getR2Client, ensureImageOwnership } from './utils/r2.js';
 
 const client = getR2Client();
 const bucket = getBucketName();
@@ -38,18 +38,17 @@ export const handler = async (event) => {
     };
   }
 
-  const { url } = payload;
-  if (!url) {
+  const rawKey = payload.key;
+  const key = typeof rawKey === 'string' ? rawKey.trim() : '';
+  if (!key) {
     return {
       statusCode: 400,
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ error: '画像URLが必要です。' }),
+      body: JSON.stringify({ error: '画像キーが必要です。' }),
     };
   }
 
-  let key;
   try {
-    key = extractKeyFromUrl(url);
     ensureImageOwnership(auth.userId, key);
   } catch (error) {
     return {
@@ -69,7 +68,7 @@ export const handler = async (event) => {
     return {
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ message: 'Image deleted', url }),
+      body: JSON.stringify({ message: 'Image deleted', key }),
     };
   } catch (error) {
     console.error('Failed to delete image:', error);

--- a/netlify/functions/get-character-image.js
+++ b/netlify/functions/get-character-image.js
@@ -1,0 +1,73 @@
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { verifyToken } from './utils/auth.js';
+import { getBucketName, getR2Client, ensureImageOwnership, streamToBuffer } from './utils/r2.js';
+
+const client = getR2Client();
+const bucket = getBucketName();
+
+function jsonResponse(statusCode, error) {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ error }),
+  };
+}
+
+export const handler = async (event) => {
+  if (event.httpMethod !== 'GET') {
+    return jsonResponse(405, 'Method Not Allowed');
+  }
+
+  const auth = await verifyToken(event);
+  if (auth.statusCode !== 200) {
+    return auth;
+  }
+
+  const rawKey = event.queryStringParameters?.key;
+  const key = typeof rawKey === 'string' ? rawKey.trim() : '';
+  if (!key) {
+    return jsonResponse(400, '画像キーが必要です。');
+  }
+
+  try {
+    ensureImageOwnership(auth.userId, key);
+  } catch (error) {
+    return jsonResponse(403, error.message || 'Invalid image reference');
+  }
+
+  try {
+    const command = new GetObjectCommand({
+      Bucket: bucket,
+      Key: key,
+    });
+    const result = await client.send(command);
+
+    const buffer = await streamToBuffer(result.Body);
+    const contentType = result.ContentType || 'application/octet-stream';
+    const headers = {
+      'Content-Type': contentType,
+      'Cache-Control': result.CacheControl || 'public, max-age=3600, immutable',
+    };
+
+    if (result.ETag) {
+      headers.ETag = result.ETag.replace(/"/g, '');
+    }
+    if (result.LastModified) {
+      headers['Last-Modified'] = new Date(result.LastModified).toUTCString();
+    }
+
+    return {
+      statusCode: 200,
+      headers,
+      body: buffer.toString('base64'),
+      isBase64Encoded: true,
+    };
+  } catch (error) {
+    console.error('Failed to fetch image from R2:', error);
+    const status = error.$metadata?.httpStatusCode || 500;
+    if (status === 404) {
+      return jsonResponse(404, '指定された画像が見つかりません。');
+    }
+    return jsonResponse(500, '画像の取得に失敗しました。');
+  }
+};

--- a/netlify/functions/upload-character-image.js
+++ b/netlify/functions/upload-character-image.js
@@ -1,6 +1,6 @@
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { verifyToken } from './utils/auth.js';
-import { getBucketName, getR2Client, generateImageKey, buildPublicUrl } from './utils/r2.js';
+import { getBucketName, getR2Client, generateImageKey } from './utils/r2.js';
 import { parseMultipartForm } from './utils/form.js';
 import { IMAGE_SETTINGS } from '../../src/config/imageSettings.js';
 
@@ -79,7 +79,7 @@ export const handler = async (event) => {
     return {
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ url: buildPublicUrl(key), key }),
+      body: JSON.stringify({ key }),
     };
   } catch (error) {
     console.error('Failed to upload image:', error);

--- a/src/composables/useCharacterImageManager.js
+++ b/src/composables/useCharacterImageManager.js
@@ -57,10 +57,10 @@ export function useCharacterImageManager() {
 
     try {
       const result = await uploadPromise;
-      if (!result?.url) {
-        throw new Error('画像URLの取得に失敗しました。');
+      if (!result?.key) {
+        throw new Error('画像キーの取得に失敗しました。');
       }
-      return result.url;
+      return result.key;
     } catch (error) {
       console.error('Character image upload failed:', error);
       return null;
@@ -69,8 +69,8 @@ export function useCharacterImageManager() {
     }
   }
 
-  async function deleteImage(url) {
-    if (!url) {
+  async function deleteImage(key) {
+    if (!key) {
       return false;
     }
 
@@ -80,7 +80,7 @@ export function useCharacterImageManager() {
 
     isDeleting.value = true;
     const service = ensureService(getAccessTokenSilently);
-    const deletePromise = service.deleteCharacterImage(url);
+    const deletePromise = service.deleteCharacterImage(key);
 
     showAsyncToast(deletePromise, {
       loading: messages.image.delete.loading(),

--- a/src/services/apiManager.js
+++ b/src/services/apiManager.js
@@ -123,11 +123,11 @@ export class ApiManager {
     return this.request('upload-character-image', { method: 'POST', body: formData });
   }
 
-  deleteCharacterImage(url) {
-    if (!url) {
-      throw new Error('Image URL is required.');
+  deleteCharacterImage(key) {
+    if (!key) {
+      throw new Error('Image key is required.');
     }
-    return this.request('delete-character-image', { method: 'DELETE', body: { url } });
+    return this.request('delete-character-image', { method: 'DELETE', body: { key } });
   }
 
   _ensureAuth() {

--- a/src/services/cloudStorageService.js
+++ b/src/services/cloudStorageService.js
@@ -171,13 +171,13 @@ export class CloudStorageService {
     }
   }
 
-  async deleteCharacterImage(url) {
-    if (!url) {
-      throw new Error('画像URLが必要です。');
+  async deleteCharacterImage(key) {
+    if (!key) {
+      throw new Error('画像キーが必要です。');
     }
 
     try {
-      return await this.apiManager.deleteCharacterImage(url);
+      return await this.apiManager.deleteCharacterImage(key);
     } catch (error) {
       console.error('Failed to delete character image:', error);
       throw error;


### PR DESCRIPTION
## Summary
- add a Netlify function that proxies character image requests from the private R2 bucket with caching headers
- update image upload and delete functions plus shared R2 utilities to operate on object keys instead of public URLs
- adjust Vue image management UI and services to persist object keys and request images through the proxy endpoint

## Testing
- npm run lint
- npm test
- npm run e2e *(fails: missing browser system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d9411c17008326a8291a7b31176a6b