### PR TITLE
Implement unauthenticated character image proxy

### DIFF
--- a/netlify/functions/delete-character-image.js
+++ b/netlify/functions/delete-character-image.js
@@ -1,6 +1,6 @@
 import { DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { verifyToken } from './utils/auth.js';
-import { getBucketName, getR2Client, extractKeyFromUrl, ensureImageOwnership } from './utils/r2.js';
+import { getBucketName, getR2Client, assertValidImageKey, ensureImageOwnership } from './utils/r2.js';
 
 const client = getR2Client();
 const bucket = getBucketName();
@@ -38,18 +38,17 @@ export const handler = async (event) => {
     };
   }
 
-  const { url } = payload;
-  if (!url) {
+  const { key } = payload;
+  if (!key) {
     return {
       statusCode: 400,
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ error: '画像URLが必要です。' }),
+      body: JSON.stringify({ error: '画像キーが必要です。' }),
     };
   }
 
-  let key;
   try {
-    key = extractKeyFromUrl(url);
+    assertValidImageKey(key);
     ensureImageOwnership(auth.userId, key);
   } catch (error) {
     return {
@@ -69,7 +68,7 @@ export const handler = async (event) => {
     return {
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ message: 'Image deleted', url }),
+      body: JSON.stringify({ message: 'Image deleted', key }),
     };
   } catch (error) {
     console.error('Failed to delete image:', error);

--- a/netlify/functions/get-character-image.js
+++ b/netlify/functions/get-character-image.js
@@ -1,0 +1,66 @@
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { getBucketName, getR2Client, assertValidImageKey, streamToBuffer } from './utils/r2.js';
+
+const client = getR2Client();
+const bucket = getBucketName();
+
+function jsonResponse(statusCode, message) {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ error: message }),
+  };
+}
+
+export const handler = async (event) => {
+  if (event.httpMethod !== 'GET') {
+    return jsonResponse(405, 'Method Not Allowed');
+  }
+
+  const key = event.queryStringParameters?.key;
+  if (!key) {
+    return jsonResponse(400, '画像キーが必要です。');
+  }
+
+  try {
+    assertValidImageKey(key);
+  } catch (error) {
+    return jsonResponse(400, error.message || 'Invalid image key');
+  }
+
+  try {
+    const command = new GetObjectCommand({
+      Bucket: bucket,
+      Key: key,
+    });
+    const response = await client.send(command);
+    const buffer = await streamToBuffer(response.Body);
+    const headers = {
+      'Content-Type': response.ContentType || 'application/octet-stream',
+      'Cache-Control': response.CacheControl || 'public, max-age=31536000, immutable',
+      'Content-Length': buffer.length.toString(),
+    };
+
+    if (response.ETag) {
+      headers.ETag = response.ETag;
+    }
+
+    if (response.LastModified) {
+      headers['Last-Modified'] = new Date(response.LastModified).toUTCString();
+    }
+
+    return {
+      statusCode: 200,
+      headers,
+      body: buffer.toString('base64'),
+      isBase64Encoded: true,
+    };
+  } catch (error) {
+    if (error?.$metadata?.httpStatusCode === 404) {
+      return jsonResponse(404, '画像が見つかりませんでした。');
+    }
+
+    console.error('Failed to retrieve image from R2:', error);
+    return jsonResponse(500, '画像の取得に失敗しました。');
+  }
+};

--- a/netlify/functions/upload-character-image.js
+++ b/netlify/functions/upload-character-image.js
@@ -1,6 +1,6 @@
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { verifyToken } from './utils/auth.js';
-import { getBucketName, getR2Client, generateImageKey, buildPublicUrl } from './utils/r2.js';
+import { getBucketName, getR2Client, generateImageKey } from './utils/r2.js';
 import { parseMultipartForm } from './utils/form.js';
 import { IMAGE_SETTINGS } from '../../src/config/imageSettings.js';
 
@@ -79,7 +79,7 @@ export const handler = async (event) => {
     return {
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ url: buildPublicUrl(key), key }),
+      body: JSON.stringify({ key }),
     };
   } catch (error) {
     console.error('Failed to upload image:', error);

--- a/src/components/ui/CharacterImageDisplay.vue
+++ b/src/components/ui/CharacterImageDisplay.vue
@@ -64,6 +64,7 @@ import { useNotifications } from '../../composables/useNotifications.js';
 import { messages } from '../../locales/ja.js';
 import { IMAGE_SETTINGS } from '../../config/imageSettings.js';
 import { useCharacterImageManager } from '../../composables/useCharacterImageManager.js';
+import { buildCharacterImageUrl } from '../../utils/imageProxy.js';
 
 const props = defineProps({
   images: {
@@ -105,7 +106,8 @@ const currentImageIndex = ref(imagesInternal.value.length > 0 ? 0 : -1);
 
 const currentImageSrc = computed(() => {
   if (imagesInternal.value.length > 0 && currentImageIndex.value >= 0 && currentImageIndex.value < imagesInternal.value.length) {
-    return imagesInternal.value[currentImageIndex.value];
+    const key = imagesInternal.value[currentImageIndex.value];
+    return buildCharacterImageUrl(key) || null;
   }
   return null;
 });
@@ -143,8 +145,8 @@ const removeCurrentImage = async () => {
     return;
   }
 
-  const targetUrl = imagesInternal.value[currentImageIndex.value];
-  const success = await deleteImage(targetUrl);
+  const targetKey = imagesInternal.value[currentImageIndex.value];
+  const success = await deleteImage(targetKey);
   if (!success) {
     return;
   }
@@ -167,9 +169,9 @@ const handleImageUpload = async (event) => {
     return;
   }
 
-  const uploadedUrl = await uploadImage(file);
-  if (uploadedUrl) {
-    imagesInternal.value.push(uploadedUrl);
+  const uploadedKey = await uploadImage(file);
+  if (uploadedKey) {
+    imagesInternal.value.push(uploadedKey);
     currentImageIndex.value = imagesInternal.value.length - 1;
   }
 };

--- a/src/composables/useImages.js
+++ b/src/composables/useImages.js
@@ -1,6 +1,7 @@
 import { ref, computed } from 'vue';
 import { IMAGE_SETTINGS } from '../config/imageSettings.js';
 import { messages } from '../locales/ja.js';
+import { buildCharacterImageUrl } from '../utils/imageProxy.js';
 import { useCharacterImageManager } from './useCharacterImageManager.js';
 
 // 画像関連のロジックを提供するコンポーザブル関数
@@ -10,7 +11,8 @@ export function useImages(character, showCustomAlert) {
 
   const currentImageSrc = computed(() => {
     if (character.value?.images?.length > 0 && currentImageIndex.value < character.value.images.length) {
-      return character.value.images[currentImageIndex.value];
+      const key = character.value.images[currentImageIndex.value];
+      return buildCharacterImageUrl(key) || null;
     }
     return null;
   });
@@ -30,9 +32,9 @@ export function useImages(character, showCustomAlert) {
     }
 
     try {
-      const imageUrl = await uploadImage(file);
-      if (imageUrl) {
-        character.value.images.push(imageUrl);
+      const imageKey = await uploadImage(file);
+      if (imageKey) {
+        character.value.images.push(imageKey);
         currentImageIndex.value = character.value.images.length - 1;
       }
     } catch (error) {
@@ -54,8 +56,8 @@ export function useImages(character, showCustomAlert) {
 
   async function removeCurrentImage() {
     if (character.value?.images?.length > 0 && currentImageIndex.value >= 0) {
-      const targetUrl = character.value.images[currentImageIndex.value];
-      const success = await deleteImage(targetUrl);
+      const targetKey = character.value.images[currentImageIndex.value];
+      const success = await deleteImage(targetKey);
       if (!success) {
         return;
       }

--- a/src/services/apiManager.js
+++ b/src/services/apiManager.js
@@ -123,11 +123,11 @@ export class ApiManager {
     return this.request('upload-character-image', { method: 'POST', body: formData });
   }
 
-  deleteCharacterImage(url) {
-    if (!url) {
-      throw new Error('Image URL is required.');
+  deleteCharacterImage(imageKey) {
+    if (!imageKey) {
+      throw new Error('Image key is required.');
     }
-    return this.request('delete-character-image', { method: 'DELETE', body: { url } });
+    return this.request('delete-character-image', { method: 'DELETE', body: { key: imageKey } });
   }
 
   _ensureAuth() {

--- a/src/services/cloudStorageService.js
+++ b/src/services/cloudStorageService.js
@@ -171,13 +171,13 @@ export class CloudStorageService {
     }
   }
 
-  async deleteCharacterImage(url) {
-    if (!url) {
-      throw new Error('画像URLが必要です。');
+  async deleteCharacterImage(imageKey) {
+    if (!imageKey) {
+      throw new Error('画像キーが必要です。');
     }
 
     try {
-      return await this.apiManager.deleteCharacterImage(url);
+      return await this.apiManager.deleteCharacterImage(imageKey);
     } catch (error) {
       console.error('Failed to delete character image:', error);
       throw error;

--- a/src/utils/imageProxy.js
+++ b/src/utils/imageProxy.js
@@ -1,0 +1,70 @@
+const FUNCTION_BASE_PATH = '/.netlify/functions/get-character-image';
+const ABSOLUTE_URL_PATTERN = /^(?:https?:)?\/\//i;
+
+function isFunctionUrl(value) {
+  return typeof value === 'string' && value.startsWith(FUNCTION_BASE_PATH);
+}
+
+function isDataUrl(value) {
+  return typeof value === 'string' && value.startsWith('data:');
+}
+
+export function buildCharacterImageUrl(key) {
+  if (!key) {
+    return '';
+  }
+
+  if (isDataUrl(key) || ABSOLUTE_URL_PATTERN.test(key) || isFunctionUrl(key)) {
+    return key;
+  }
+
+  return `${FUNCTION_BASE_PATH}?key=${encodeURIComponent(key)}`;
+}
+
+function decodePath(pathname = '') {
+  const trimmed = pathname.startsWith('/') ? pathname.slice(1) : pathname;
+  try {
+    return decodeURIComponent(trimmed);
+  } catch (error) {
+    console.warn('Failed to decode image path:', error);
+    return trimmed;
+  }
+}
+
+function toUrl(value) {
+  try {
+    return new URL(value, 'http://localhost');
+  } catch (error) {
+    console.warn('Failed to parse image URL:', error);
+    return null;
+  }
+}
+
+export function extractCharacterImageKey(reference) {
+  if (!reference) {
+    return '';
+  }
+
+  if (isDataUrl(reference)) {
+    return '';
+  }
+
+  if (!isFunctionUrl(reference) && ABSOLUTE_URL_PATTERN.test(reference)) {
+    const url = toUrl(reference);
+    if (!url) {
+      return '';
+    }
+    return decodePath(url.pathname);
+  }
+
+  if (isFunctionUrl(reference) || reference.startsWith(FUNCTION_BASE_PATH)) {
+    const url = toUrl(reference);
+    if (!url) {
+      return '';
+    }
+    const key = url.searchParams.get('key');
+    return key ? decodePath(key) : '';
+  }
+
+  return reference;
+}


### PR DESCRIPTION
## Summary
- add a public `get-character-image` Netlify Function that proxies private R2 objects with cache headers and strict key validation
- update the upload/delete functions and R2 helpers to operate solely on image keys while hardening validation utilities
- adjust the Vue image flows to store keys, build proxy URLs, and derive keys from legacy URLs before deleting

## Testing
- npm run lint *(warns about pre-existing unused variables)*
- npm test *(fails: Failed to resolve import "browser-image-compression" in tests/unit/imageManager.test.js)*
- npm run e2e *(fails: Playwright browsers require missing system dependencies and module resolution during dev server startup)*

------
https://chatgpt.com/codex/tasks/task_e_68d9461770c08326aaba15d5042c06bb