### PR TITLE
feat: store Drive sheets in visible folder

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -36,11 +36,13 @@ const { printCharacterSheet, openPreviewPage } = usePrint();
 
 const {
   canSignInToGoogle,
+  canOverwrite,
   handleSignInClick,
   handleSignOutClick,
-  promptForDriveFolder,
-  saveCharacterToDrive,
-  saveOrUpdateCurrentCharacterInDrive,
+  openDriveFile,
+  saveFile,
+  saveAsNewFile,
+  overwriteFile,
 } = useGoogleDrive(dataManager);
 
 const { helpState, isHelpVisible, handleHelpIconMouseOver, handleHelpIconMouseLeave, handleHelpIconClick, closeHelpPanel } = useHelp(
@@ -57,7 +59,7 @@ function refreshHubList() {
 }
 
 async function saveNewCharacter() {
-  await saveCharacterToDrive(null);
+  await saveAsNewFile();
 }
 
 async function loadCharacterById(id, characterName) {
@@ -81,17 +83,14 @@ async function loadCharacterById(id, characterName) {
 const { openHub, openIoModal, openShareModal } = useAppModals({
   dataManager,
   loadCharacterById,
-  saveCharacterToDrive,
   handleSignInClick,
   handleSignOutClick,
   refreshHubList,
   saveNewCharacter,
-  saveData,
-  handleFileUpload,
-  outputToCocofolia,
-  printCharacterSheet,
-  openPreviewPage,
-  promptForDriveFolder,
+  openDriveFile,
+  saveAsNewFile,
+  overwriteFile,
+  canOverwrite: () => canOverwrite.value,
   copyEditCallback: () => {
     uiStore.isViewingShared = false;
   },
@@ -172,7 +171,7 @@ onMounted(initialize);
     :save-local="saveData"
     :handle-file-upload="handleFileUpload"
     :open-hub="openHub"
-    :save-to-drive="saveOrUpdateCurrentCharacterInDrive"
+    :save-to-drive="saveFile"
     :experience-label="messages.ui.footer.experience"
     :io-label="messages.ui.footer.io"
     :share-label="messages.ui.footer.share"

--- a/src/components/modals/contents/IoModal.vue
+++ b/src/components/modals/contents/IoModal.vue
@@ -1,71 +1,86 @@
 <template>
   <div class="io-modal">
-    <button class="button-base" @click="$emit('save-local')">
-      {{ saveLocalLabel }}
-    </button>
-    <label class="button-base">
-      {{ loadLocalLabel }}
-      <input type="file" class="hidden" @change="(e) => $emit('load-local', e)" accept=".json,.txt,.zip" />
-    </label>
-    <AnimatedButton
-      class="button-base"
-      :trigger="triggerKey"
-      :default-label="outputLabels.default"
-      :animating-label="outputLabels.animating"
-      :success-label="outputLabels.success"
-      :timings="outputTimings"
-      @click="$emit('output-cocofolia')"
-    />
-    <button class="button-base" @click="$emit('print')">
-      {{ printLabel }}
-    </button>
-    <button class="button-base" v-if="signedIn" @click="$emit('drive-folder')">
-      {{ driveFolderLabel }}
-    </button>
+    <template v-if="!signedIn">
+      <p class="io-modal__description">
+        {{ description }}
+      </p>
+      <button class="button-base io-modal__primary" @click="$emit('login')">
+        {{ loginLabel }}
+      </button>
+    </template>
+    <template v-else>
+      <p class="io-modal__folder-info">{{ folderMessage }}</p>
+      <div class="io-modal__actions">
+        <button class="button-base" @click="$emit('open')">
+          {{ openLabel }}
+        </button>
+        <button class="button-base" @click="$emit('save-new')">
+          {{ saveNewLabel }}
+        </button>
+        <button class="button-base" :disabled="!canOverwrite" @click="$emit('overwrite')">
+          {{ overwriteLabel }}
+        </button>
+        <button class="button-base button-secondary" @click="$emit('logout')">
+          {{ logoutLabel }}
+        </button>
+      </div>
+    </template>
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted } from 'vue';
-import AnimatedButton from '../../common/AnimatedButton.vue';
+import { computed } from 'vue';
 
-defineProps({
+const props = defineProps({
   signedIn: Boolean,
-  saveLocalLabel: String,
-  loadLocalLabel: String,
-  outputLabels: Object,
-  outputTimings: Object,
-  printLabel: String,
-  driveFolderLabel: String,
+  canOverwrite: Boolean,
+  description: String,
+  folderName: String,
+  loginLabel: String,
+  openLabel: String,
+  saveNewLabel: String,
+  overwriteLabel: String,
+  logoutLabel: String,
 });
 
-defineEmits(['save-local', 'load-local', 'output-cocofolia', 'print', 'drive-folder']);
+defineEmits(['login', 'open', 'save-new', 'overwrite', 'logout']);
 
-const triggerKey = ref(0);
-function triggerAnimation() {
-  triggerKey.value += 1;
-}
-
-function handleCopySuccess(event) {
-  if (event.detail.type === 'cocofolia') {
-    triggerAnimation();
-  }
-}
-
-onMounted(() => {
-  document.removeEventListener('aionia-copy-success', handleCopySuccess);
-  document.addEventListener('aionia-copy-success', handleCopySuccess);
-});
-
-onUnmounted(() => {
-  document.removeEventListener('aionia-copy-success', handleCopySuccess);
-});
+const folderMessage = computed(() => `${props.folderName} にキャラクターシートを保存します。`);
 </script>
 
 <style scoped>
 .io-modal {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 16px;
+}
+
+.io-modal__description {
+  margin: 0;
+  line-height: 1.6;
+  text-align: center;
+}
+
+.io-modal__primary {
+  align-self: center;
+  min-width: 220px;
+}
+
+.io-modal__folder-info {
+  margin: 0;
+  font-size: 0.95rem;
+  opacity: 0.8;
+  text-align: center;
+}
+
+.io-modal__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.io-modal__actions .button-base[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 </style>

--- a/src/composables/useDataExport.js
+++ b/src/composables/useDataExport.js
@@ -5,9 +5,11 @@ import { useCharacterStore } from '../stores/characterStore.js';
 import { useNotifications } from './useNotifications.js';
 import { messages } from '../locales/ja.js';
 import { copyText } from '../utils/clipboard.js';
+import { useUiStore } from '../stores/uiStore.js';
 
 export function useDataExport() {
   const characterStore = useCharacterStore();
+  const uiStore = useUiStore();
   const dataManager = new DataManager(AioniaGameData);
   const cocofoliaExporter = new CocofoliaExporter();
   const { showToast } = useNotifications();
@@ -31,6 +33,7 @@ export function useDataExport() {
         characterStore.specialSkills.splice(0, characterStore.specialSkills.length, ...parsedData.specialSkills);
         Object.assign(characterStore.equipments, parsedData.equipments);
         characterStore.histories.splice(0, characterStore.histories.length, ...parsedData.histories);
+        uiStore.currentDriveFileId = null;
       },
       (errorMessage) =>
         showToast({

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -154,12 +154,14 @@ export const messages = {
       shareFailed: '共有リンク生成失敗',
       io: {
         title: '入出力',
-        buttons: {
-          saveLocal: '端末保存',
-          loadLocal: '端末読込',
-          output: '駒出力',
-          print: '印刷',
-          driveFolder: 'フォルダ変更',
+        google: {
+          description: (folderName) =>
+            `Google Driveにサインインするとマイドライブ直下に${folderName}フォルダが自動で作成され、キャラクターシートを保存できます。`,
+          login: 'Googleでログイン',
+          open: 'ファイルを開く',
+          saveNew: '新規保存',
+          overwrite: '上書き保存',
+          logout: 'ログアウト',
         },
       },
     },

--- a/src/services/googleDriveManager.js
+++ b/src/services/googleDriveManager.js
@@ -1,16 +1,19 @@
 /**
  * Manages interactions with Google Drive and Google Sign-In.
  */
+export const DRIVE_FOLDER_NAME = 'AioniaCS';
+
 export class GoogleDriveManager {
   constructor(apiKey, clientId) {
     this.apiKey = apiKey;
     this.clientId = clientId;
     this.discoveryDocs = ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'];
-    this.scope = 'https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive.file';
+    this.scope = 'https://www.googleapis.com/auth/drive.file';
     this.gapiLoadedCallback = null;
     this.gisLoadedCallback = null;
     this.tokenClient = null;
     this.pickerApiLoaded = false;
+    this.appFolderId = null;
 
     // Bind methods
     this.handleSignIn = this.handleSignIn.bind(this);
@@ -142,7 +145,7 @@ export class GoogleDriveManager {
    * @param {string} folderName - The name for the new folder.
    * @returns {Promise<string|null>} The ID of the created folder, or null on error.
    */
-  async createFolder(folderName) {
+  async createFolder(folderName, parentId = 'root') {
     if (!gapi.client || !gapi.client.drive) {
       console.error('GAPI client or Drive API not loaded.');
       return null;
@@ -152,6 +155,7 @@ export class GoogleDriveManager {
         resource: {
           name: folderName,
           mimeType: 'application/vnd.google-apps.folder',
+          parents: parentId ? [parentId] : undefined,
         },
         fields: 'id, name',
       });
@@ -168,14 +172,14 @@ export class GoogleDriveManager {
    * @param {string} folderName - The name of the folder to find.
    * @returns {Promise<string|null>} The ID of the folder if found, otherwise null.
    */
-  async findFolder(folderName) {
+  async findFolder(folderName, parentId = 'root') {
     if (!gapi.client || !gapi.client.drive) {
       console.error('GAPI client or Drive API not loaded.');
       return null;
     }
     try {
       const response = await gapi.client.drive.files.list({
-        q: `mimeType='application/vnd.google-apps.folder' and name='${folderName}' and trashed=false`,
+        q: `mimeType='application/vnd.google-apps.folder' and name='${folderName}' and '${parentId}' in parents and trashed=false`,
         fields: 'files(id, name)',
         spaces: 'drive',
       });
@@ -198,20 +202,31 @@ export class GoogleDriveManager {
    * @param {string} appFolderName - The name of the folder.
    * @returns {Promise<string|null>} The folder ID, or null on error.
    */
-  async getOrCreateAppFolder(appFolderName) {
+  async ensureAppFolder() {
+    if (this.appFolderId) {
+      return this.appFolderId;
+    }
+
     if (!gapi.client || !gapi.client.drive) {
-      console.error('GAPI client or Drive API not loaded for getOrCreateAppFolder.');
+      console.error('GAPI client or Drive API not loaded for ensureAppFolder.');
       return null;
     }
+
     try {
-      let folderId = await this.findFolder(appFolderName);
-      if (!folderId) {
-        console.log(`Folder "${appFolderName}" not found, creating it.`);
-        folderId = await this.createFolder(appFolderName);
+      const existingFolder = await this.findFolder(DRIVE_FOLDER_NAME);
+      if (existingFolder && existingFolder.id) {
+        this.appFolderId = existingFolder.id;
+        return this.appFolderId;
       }
-      return folderId;
+      const createdFolder = await this.createFolder(DRIVE_FOLDER_NAME);
+      if (createdFolder && createdFolder.id) {
+        this.appFolderId = createdFolder.id;
+        return this.appFolderId;
+      }
+      console.error('Failed to create Drive folder.');
+      return null;
     } catch (error) {
-      console.error(`Error in getOrCreateAppFolder for "${appFolderName}":`, error);
+      console.error('Error ensuring Drive folder:', error);
       return null;
     }
   }
@@ -222,16 +237,19 @@ export class GoogleDriveManager {
    * @param {string} mimeType - The MIME type of files to list.
    * @returns {Promise<Array<{id: string, name: string}>>} A list of files, or empty array on error.
    */
-  async listFiles(folderId, mimeType = 'application/json') {
+  async listFiles(folderId = null, mimeType = 'application/json') {
     if (!gapi.client || !gapi.client.drive) {
       console.error('GAPI client or Drive API not loaded for listFiles.');
       return [];
     }
     try {
+      const targetFolderId = folderId || (await this.ensureAppFolder());
+      if (!targetFolderId) return [];
       const response = await gapi.client.drive.files.list({
-        q: `'${folderId}' in parents and mimeType='${mimeType}' and trashed=false`,
-        fields: 'files(id, name)',
+        q: `'${targetFolderId}' in parents and mimeType='${mimeType}' and trashed=false`,
+        fields: 'files(id, name, modifiedTime)',
         spaces: 'drive',
+        orderBy: 'modifiedTime desc',
       });
       return response.result.files || [];
     } catch (error) {
@@ -253,6 +271,8 @@ export class GoogleDriveManager {
       console.error('GAPI client or Drive API not loaded for saveFile.');
       return null;
     }
+
+    const targetFolderId = fileId ? null : folderId || (await this.ensureAppFolder());
 
     if (fileId) {
       try {
@@ -306,9 +326,11 @@ export class GoogleDriveManager {
       const contentType = 'application/json';
       const metadata = {
         name: fileName,
-        parents: [folderId],
         mimeType: contentType,
       };
+      if (targetFolderId) {
+        metadata.parents = [targetFolderId];
+      }
 
       const multipartRequestBody =
         delimiter +
@@ -514,89 +536,6 @@ export class GoogleDriveManager {
    * Ensures the character index file exists in appDataFolder.
    * @returns {Promise<{id:string,name:string}|null>} index file info
    */
-  async ensureIndexFile() {
-    const fileList =
-      (
-        await gapi.client.drive.files.list({
-          q: "name='character_index.json' and trashed=false",
-          spaces: 'appDataFolder',
-          fields: 'files(id,name)',
-        })
-      ).result.files || [];
-
-    if (fileList.length > 0) {
-      this.indexFileId = fileList[0].id;
-      return fileList[0];
-    }
-
-    const created = await this.saveFile('appDataFolder', 'character_index.json', '[]');
-    if (created) this.indexFileId = created.id;
-    return created;
-  }
-
-  /**
-   * Reads and parses the character index file.
-   * @returns {Promise<Array>}
-   */
-  async readIndexFile() {
-    const info = await this.ensureIndexFile();
-    if (!info) return [];
-    const content = await this.loadFileContent(info.id);
-    try {
-      return JSON.parse(content || '[]');
-    } catch {
-      return [];
-    }
-  }
-
-  /**
-   * Writes the given index array back to the index file.
-   * @param {Array} indexData
-   */
-  async writeIndexFile(indexData) {
-    const info = await this.ensureIndexFile();
-    if (!info) return null;
-    return this.saveFile('appDataFolder', 'character_index.json', JSON.stringify(indexData, null, 2), info.id);
-  }
-
-  async addIndexEntry(entry) {
-    const index = await this.readIndexFile();
-    index.push({ ...entry, updatedAt: new Date().toISOString() });
-    await this.writeIndexFile(index);
-  }
-
-  async renameIndexEntry(id, newName) {
-    const index = await this.readIndexFile();
-    index.forEach((e) => {
-      if (e.id === id) {
-        e.characterName = newName;
-        e.updatedAt = new Date().toISOString();
-      }
-    });
-    await this.writeIndexFile(index);
-  }
-
-  async removeIndexEntry(id) {
-    const index = await this.readIndexFile();
-    const filtered = index.filter((e) => e.id !== id);
-    await this.writeIndexFile(filtered);
-  }
-
-  /**
-   * Creates a character data file in appDataFolder.
-   * @param {object} data character JSON object
-   * @param {string} name file name
-   */
-  async createCharacterFile(data) {
-    const fileName = `${(data.character?.name || '名もなき冒険者').replace(/[\\/:*?"<>|]/g, '_')}.json`;
-    return this.saveFile('appDataFolder', fileName, JSON.stringify(data, null, 2));
-  }
-
-  async updateCharacterFile(id, data) {
-    const fileName = `${(data.character?.name || '名もなき冒険者').replace(/[\\/:*?"<>|]/g, '_')}.json`;
-    return this.saveFile('appDataFolder', fileName, JSON.stringify(data, null, 2), id);
-  }
-
   async loadCharacterFile(id) {
     const content = await this.loadFileContent(id);
     return content ? JSON.parse(content) : null;
@@ -605,7 +544,6 @@ export class GoogleDriveManager {
   async deleteCharacterFile(id) {
     if (!gapi.client || !gapi.client.drive) return null;
     await gapi.client.drive.files.delete({ fileId: id });
-    await this.removeIndexEntry(id);
   }
 }
 

--- a/src/stores/uiStore.js
+++ b/src/stores/uiStore.js
@@ -36,31 +36,12 @@ export const useUiStore = defineStore('ui', {
     },
     async refreshDriveCharacters(gdm) {
       if (!gdm) return;
-      const temps = this.driveCharacters.filter((c) => c.id.startsWith('temp-'));
-      const serverList = await gdm.readIndexFile();
-      const serverIds = new Set(serverList.map((c) => c.id));
-
-      // Keep local entries that still exist on server
-      let merged = this.driveCharacters.filter((c) => c.id.startsWith('temp-') || serverIds.has(c.id));
-
-      // Add or update server entries
-      serverList.forEach((srv) => {
-        const idx = merged.findIndex((c) => c.id === srv.id);
-        if (idx !== -1) {
-          merged[idx] = { ...merged[idx], ...srv };
-        } else {
-          merged.push(srv);
-        }
-      });
-
-      // Ensure temps remain
-      temps.forEach((t) => {
-        if (!merged.some((c) => c.id === t.id)) {
-          merged.push(t);
-        }
-      });
-
-      this.driveCharacters = merged;
+      const files = await gdm.listFiles();
+      this.driveCharacters = files.map((file) => ({
+        id: file.id,
+        characterName: file.name.replace(/\.json$/i, ''),
+        updatedAt: file.modifiedTime,
+      }));
     },
     clearDriveCharacters() {
       this.driveCharacters = [];

--- a/tests/unit/dataManager.test.js
+++ b/tests/unit/dataManager.test.js
@@ -274,28 +274,22 @@ describe('DataManager', () => {
   describe('saveDataToAppData', () => {
     beforeEach(() => {
       dm.googleDriveManager = {
-        createCharacterFile: vi.fn().mockResolvedValue({ id: '1', name: 'c.json' }),
-        updateCharacterFile: vi.fn().mockResolvedValue({ id: '1', name: 'c.json' }),
-        addIndexEntry: vi.fn().mockResolvedValue(),
-        renameIndexEntry: vi.fn().mockResolvedValue(),
+        ensureAppFolder: vi.fn().mockResolvedValue('folder-1'),
+        saveFile: vi.fn().mockResolvedValue({ id: '1', name: 'c.json' }),
       };
     });
 
-    test('creates new file and adds index when no id', async () => {
+    test('creates new file when no id', async () => {
       const res = await dm.saveDataToAppData(mockCharacter, mockSkills, mockSpecialSkills, mockEquipments, mockHistories, null);
-      expect(dm.googleDriveManager.createCharacterFile).toHaveBeenCalled();
-      expect(dm.googleDriveManager.addIndexEntry).toHaveBeenCalledWith({
-        id: '1',
-        characterName: 'TestChar',
-      });
+      expect(dm.googleDriveManager.ensureAppFolder).toHaveBeenCalled();
+      expect(dm.googleDriveManager.saveFile).toHaveBeenCalledWith('folder-1', 'TestChar.json', expect.any(String), null);
       expect(res.id).toBe('1');
     });
 
-    test('updates file when id exists and renames index', async () => {
+    test('updates file when id exists', async () => {
       await dm.saveDataToAppData(mockCharacter, mockSkills, mockSpecialSkills, mockEquipments, mockHistories, '1');
-      expect(dm.googleDriveManager.updateCharacterFile).toHaveBeenCalledWith('1', expect.any(Object));
-      expect(dm.googleDriveManager.renameIndexEntry).toHaveBeenCalledWith('1', 'TestChar');
-      expect(dm.googleDriveManager.addIndexEntry).not.toHaveBeenCalled();
+      expect(dm.googleDriveManager.ensureAppFolder).toHaveBeenCalled();
+      expect(dm.googleDriveManager.saveFile).toHaveBeenCalledWith('folder-1', 'TestChar.json', expect.any(String), '1');
     });
   });
 });

--- a/tests/unit/googleDriveAuth.test.js
+++ b/tests/unit/googleDriveAuth.test.js
@@ -26,7 +26,7 @@ describe('GoogleDriveManager auth', () => {
     await gdm.onGisLoad();
     expect(google.accounts.oauth2.initTokenClient).toHaveBeenCalledWith({
       client_id: 'c',
-      scope: 'https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive.file',
+      scope: 'https://www.googleapis.com/auth/drive.file',
       callback: '',
     });
   });

--- a/tests/unit/stores/uiStoreCharacters.test.js
+++ b/tests/unit/stores/uiStoreCharacters.test.js
@@ -6,17 +6,13 @@ describe('uiStore character cache', () => {
     setActivePinia(createPinia());
   });
 
-  test('refreshDriveCharacters merges lists', async () => {
+  test('refreshDriveCharacters loads files from Drive', async () => {
     const store = useUiStore();
-    store.driveCharacters = [
-      { id: '2', characterName: 'B' },
-      { id: 'temp-1', characterName: 'Temp' },
-    ];
-    const gdm = { readIndexFile: vi.fn().mockResolvedValue([{ id: '1' }]) };
+    const gdm = {
+      listFiles: vi.fn().mockResolvedValue([{ id: '1', name: 'Hero.json', modifiedTime: '2024-01-01T00:00:00Z' }]),
+    };
     await store.refreshDriveCharacters(gdm);
-    expect(store.driveCharacters).toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: '1' }), expect.objectContaining({ id: 'temp-1', characterName: 'Temp' })]),
-    );
+    expect(store.driveCharacters).toEqual([{ id: '1', characterName: 'Hero', updatedAt: '2024-01-01T00:00:00Z' }]);
   });
 
   test('clearDriveCharacters empties cache', () => {


### PR DESCRIPTION
## Summary
- change Google Drive integration to create and reuse an AioniaCS folder in My Drive with drive.file scope
- refresh Drive IO composable and modal to support open/save/new flows with stored file id state
- simplify Drive character list loading, update data manager and related tests to reflect folder-based storage

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db436cccc08326bc83aed3b2ea21da

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Revamped Google Drive integration with a login-first IO modal showing folder info and actions: Open, Save as New, and Overwrite (disabled when unavailable), plus Logout.
  - Added overwrite capability with clear state when a file can be updated.
  - Drive files now saved as JSON in a dedicated app folder; file list displays name and last updated time.
  - Reduced Google Drive permission scope to “drive.file” for a simpler authorization prompt.
  - Updated Japanese localization for the new Drive flow and labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->