### PR TITLE
Implement computed scar value from adventure log increments

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -107,21 +107,11 @@ const experienceStatusClass = computed(() => uiStore.experienceStatusClass);
 // --- Watchers (formerly `watch`) ---
 
 watch(
-  () => characterStore.character.initialScar,
-  (newVal) => {
-    if (characterStore.character.linkCurrentToInitialScar) {
-      characterStore.character.currentScar = newVal;
-    }
+  () => characterStore.calculatedScar,
+  (currentScar) => {
+    characterStore.character.currentScar = currentScar;
   },
-);
-
-watch(
-  () => characterStore.character.linkCurrentToInitialScar,
-  (isLinked) => {
-    if (isLinked) {
-      characterStore.character.currentScar = characterStore.character.initialScar;
-    }
-  },
+  { immediate: true },
 );
 
 watch(

--- a/src/components/sections/AdventureLogSection.vue
+++ b/src/components/sections/AdventureLogSection.vue
@@ -8,16 +8,17 @@
           <div class="history-item-inputs">
             <div class="flex-history-name"><label>シナリオ名</label></div>
             <div class="flex-history-exp"><label>経験点</label></div>
+            <div class="flex-history-scar"><label>増加傷痕</label></div>
             <div class="flex-history-memo"><label>メモ</label></div>
           </div>
         </div>
       </div>
       <ul id="histories" class="list-reset">
         <BaseListItem
-          v-for="(history, index) in characterStore.histories"
+          v-for="(history, index) in characterStore.adventureLog"
           :key="index"
           :show-delete-button="!uiStore.isViewingShared"
-          :can-delete="!(characterStore.histories.length <= 1 && !hasHistoryContent(history))"
+          :can-delete="!(characterStore.adventureLog.length <= 1 && !hasHistoryContent(history))"
           @delete-item="characterStore.removeHistoryItem(index)"
         >
           <div class="flex-grow">
@@ -36,6 +37,14 @@
                   min="0"
                   :model-value="history.gotExperiments"
                   @update:model-value="(v) => characterStore.updateHistoryItem(index, 'gotExperiments', v)"
+                  :disabled="uiStore.isViewingShared"
+                />
+              </div>
+              <div class="flex-history-scar">
+                <BaseInput
+                  type="number"
+                  min="0"
+                  v-model.number="history.increasedScar"
                   :disabled="uiStore.isViewingShared"
                 />
               </div>
@@ -75,7 +84,12 @@ const characterStore = useCharacterStore();
 const uiStore = useUiStore();
 
 function hasHistoryContent(h) {
-  return !!(h.sessionName || (h.gotExperiments !== null && h.gotExperiments !== '') || h.memo);
+  return !!(
+    h.sessionName ||
+    (h.gotExperiments !== null && h.gotExperiments !== '') ||
+    Number(h.increasedScar) > 0 ||
+    h.memo
+  );
 }
 </script>
 
@@ -94,6 +108,10 @@ function hasHistoryContent(h) {
 
 .flex-history-exp {
   flex: 0 1 80px;
+}
+
+.flex-history-scar {
+  flex: 0 1 100px;
 }
 
 .flex-history-memo {

--- a/src/components/sections/ScarWeaknessSection.vue
+++ b/src/components/sections/ScarWeaknessSection.vue
@@ -6,26 +6,14 @@
         <div class="sub-box-title sub-box-title--scar">傷痕</div>
         <div class="info-row">
           <div class="info-item info-item--double">
-            <div class="link-checkbox-container">
-              <label for="current_scar" class="link-checkbox-main-label">現在値</label>
-              <input
-                type="checkbox"
-                id="link_current_to_initial_scar_checkbox"
-                v-model="characterStore.character.linkCurrentToInitialScar"
-                class="link-checkbox"
-                :disabled="uiStore.isViewingShared"
-              />
-              <label for="link_current_to_initial_scar_checkbox" class="link-checkbox-label">連動</label>
-            </div>
+            <label for="current_scar" class="link-checkbox-main-label">現在値</label>
             <input
               type="number"
               id="current_scar"
-              v-model.number="characterStore.character.currentScar"
-              @input="handleCurrentScarInput"
-              :class="{ 'greyed-out': characterStore.character.linkCurrentToInitialScar }"
+              :value="calculatedScar"
               min="0"
-              class="scar-section__current-input"
-              :disabled="uiStore.isViewingShared"
+              class="scar-section__current-input scar-section__current-input--readonly"
+              disabled
             />
           </div>
           <div class="info-item info-item--double">
@@ -75,14 +63,7 @@ import { useUiStore } from '../../stores/uiStore.js';
 const characterStore = useCharacterStore();
 const uiStore = useUiStore();
 const sessionNames = computed(() => characterStore.sessionNamesForWeaknessDropdown);
-
-function handleCurrentScarInput(event) {
-  const enteredValue = parseInt(event.target.value, 10);
-  if (Number.isNaN(enteredValue)) return;
-  if (characterStore.character.linkCurrentToInitialScar && enteredValue !== characterStore.character.initialScar) {
-    characterStore.character.linkCurrentToInitialScar = false;
-  }
-}
+const calculatedScar = computed(() => characterStore.calculatedScar);
 </script>
 
 <style scoped>
@@ -94,29 +75,13 @@ function handleCurrentScarInput(event) {
   margin-bottom: 25px;
 }
 
-.link-checkbox-container {
-  display: flex;
-  align-items: center;
-}
-
 .link-checkbox-main-label {
   margin-right: 8px;
 }
 
-.link-checkbox {
-  margin-right: 4px;
-  margin-bottom: 2px;
-  accent-color: var(--color-accent);
-  transform: scale(1.1);
-  width: auto;
-}
-
-.link-checkbox-label {
-  font-size: 0.9em;
-  color: var(--color-text-muted);
-  font-weight: normal;
-  user-select: none;
-  margin-bottom: 0;
+.scar-section__current-input--readonly {
+  background-color: var(--color-surface-muted);
+  color: var(--color-text);
 }
 
 .sub-box-title--weakness {

--- a/src/composables/core/useCharacterData.js
+++ b/src/composables/core/useCharacterData.js
@@ -21,7 +21,7 @@ export function useCharacterData() {
     weapon2: { group: '', name: '' },
     armor: { group: '', name: '' },
   });
-  const histories = reactive([{ sessionName: '', gotExperiments: null, memo: '' }]);
+  const histories = reactive([{ sessionName: '', gotExperiments: null, memo: '', increasedScar: 0 }]);
 
   function resetCharacter() {
     Object.assign(character, createCharacter());
@@ -55,6 +55,7 @@ export function useCharacterData() {
       sessionName: '',
       gotExperiments: null,
       memo: '',
+      increasedScar: 0,
     });
   }
 

--- a/src/composables/usePrint.js
+++ b/src/composables/usePrint.js
@@ -38,7 +38,6 @@ export function usePrint() {
   async function buildHtml() {
     const { default: printTemplate } = await import('/src/assets/print/print-template.html?raw');
     const { default: printStyles } = await import('/src/assets/print/print-styles.css?raw');
-    const characterStore = useCharacterStore();
     const ch = characterStore.character;
     let html = printTemplate;
 
@@ -60,7 +59,7 @@ export function usePrint() {
     replace('origin', ch.origin || '');
     replace('occupation', ch.occupation || '');
     replace('faith', ch.faith || '');
-    replace('current-scar-value', String(ch.currentScar ?? ''));
+    replace('current-scar-value', String(characterStore.calculatedScar ?? ''));
     replace('current-experience-value', String(characterStore.currentExperiencePoints + '/' + characterStore.maxExperiencePoints));
 
     // --- 弱点の置換 ---
@@ -97,7 +96,7 @@ export function usePrint() {
     replace('background-content', ch.memo || '');
 
     for (let i = 0; i < 7; i++) {
-      const h = characterStore.histories[i] || {};
+      const h = characterStore.adventureLog[i] || {};
       replace(`adventure-scenario-${i}`, h.sessionName || '');
       replace(`adventure-memo-${i}`, h.memo || '');
       replace(`adventure-experience-${i}`, h.gotExperiments != null ? String(h.gotExperiments) : '');

--- a/src/services/dataManager.js
+++ b/src/services/dataManager.js
@@ -45,7 +45,9 @@ export class DataManager {
       })),
       specialSkills: specialSkills.filter((ss) => ss.group && ss.name),
       equipments: equipments,
-      histories: histories.filter((h) => h.sessionName || (h.gotExperiments !== null && h.gotExperiments !== '') || h.memo),
+      histories: histories.filter(
+        (h) => h.sessionName || (h.gotExperiments !== null && h.gotExperiments !== '') || Number(h.increasedScar) > 0 || h.memo,
+      ),
     };
 
     const jsonData = JSON.stringify(dataToSave, null, 2);
@@ -238,7 +240,9 @@ export class DataManager {
       })),
       specialSkills: specialSkills.filter((ss) => ss.group && ss.name),
       equipments: equipments,
-      histories: histories.filter((h) => h.sessionName || (h.gotExperiments !== null && h.gotExperiments !== '') || h.memo),
+      histories: histories.filter(
+        (h) => h.sessionName || (h.gotExperiments !== null && h.gotExperiments !== '') || Number(h.increasedScar) > 0 || h.memo,
+      ),
     };
 
     const jsonData = JSON.stringify(dataToSave, null, 2);
@@ -273,7 +277,9 @@ export class DataManager {
       })),
       specialSkills: specialSkills.filter((ss) => ss.group && ss.name),
       equipments: equipments,
-      histories: histories.filter((h) => h.sessionName || (h.gotExperiments !== null && h.gotExperiments !== '') || h.memo),
+      histories: histories.filter(
+        (h) => h.sessionName || (h.gotExperiments !== null && h.gotExperiments !== '') || Number(h.increasedScar) > 0 || h.memo,
+      ),
     };
 
     if (currentFileId) {
@@ -566,6 +572,7 @@ export class DataManager {
         gotExperiments: h.experiments ? parseInt(h.experiments, 10) : null,
         // Use 'memo' if present (from this tool's older format), otherwise 'stress' (from bright-trpg)
         memo: h.memo || h.stress || '',
+        increasedScar: h.increasedScar ? parseInt(h.increasedScar, 10) : 0,
       }));
     }
     // If no history, it will remain an empty array from initialization
@@ -714,10 +721,11 @@ export class DataManager {
             ? null // Keep null as null
             : Number(h.gotExperiments), // Convert valid numbers
         memo: h.memo || '',
+        increasedScar: h.increasedScar === null || h.increasedScar === undefined || h.increasedScar === '' ? 0 : Number(h.increasedScar),
       }));
     }
     // No historyData or empty array, return a single default history item
-    return [{ sessionName: '', gotExperiments: null, memo: '' }];
+    return [{ sessionName: '', gotExperiments: null, memo: '', increasedScar: 0 }];
   }
 }
 

--- a/src/stores/characterStore.js
+++ b/src/stores/characterStore.js
@@ -27,8 +27,12 @@ function baseEquipments() {
   };
 }
 
+function baseAdventureLogEntry() {
+  return { sessionName: '', gotExperiments: null, memo: '', increasedScar: 0 };
+}
+
 function baseHistories() {
-  return [{ sessionName: '', gotExperiments: null, memo: '' }];
+  return [baseAdventureLogEntry()];
 }
 
 export const useCharacterStore = defineStore('character', {
@@ -40,6 +44,9 @@ export const useCharacterStore = defineStore('character', {
     histories: baseHistories(),
   }),
   getters: {
+    adventureLog(state) {
+      return state.histories;
+    },
     maxExperiencePoints(state) {
       const initialScarExp = Number(state.character.initialScar) || 0;
       const creationWeaknessExp = state.character.weaknesses.reduce(
@@ -53,6 +60,11 @@ export const useCharacterStore = defineStore('character', {
       const combinedInitialBonus = Math.min(initialScarExp + creationWeaknessExp, AioniaGameData.experiencePointValues.maxInitialBonus);
       const historyExp = state.histories.reduce((sum, h) => sum + (Number(h.gotExperiments) || 0), 0);
       return AioniaGameData.experiencePointValues.basePoints + combinedInitialBonus + historyExp;
+    },
+    calculatedScar(state) {
+      const initialScar = Number(state.character.initialScar) || 0;
+      const adventureScar = state.histories.reduce((sum, entry) => sum + (Number(entry.increasedScar) || 0), 0);
+      return initialScar + adventureScar;
     },
     currentExperiencePoints(state) {
       const skillExp = state.skills.reduce((sum, s) => sum + (s.checked ? AioniaGameData.experiencePointValues.skillBase : 0), 0);
@@ -143,11 +155,7 @@ export const useCharacterStore = defineStore('character', {
       this._manageListItem({
         list: this.histories,
         action: 'add',
-        newItemFactory: () => ({
-          sessionName: '',
-          gotExperiments: null,
-          memo: '',
-        }),
+        newItemFactory: () => baseAdventureLogEntry(),
       });
     },
     removeHistoryItem(index) {
@@ -155,12 +163,11 @@ export const useCharacterStore = defineStore('character', {
         list: this.histories,
         action: 'remove',
         index,
-        newItemFactory: () => ({
-          sessionName: '',
-          gotExperiments: null,
-          memo: '',
-        }),
-        hasContentChecker: (h) => !!(h.sessionName || (h.gotExperiments !== null && h.gotExperiments !== '') || h.memo),
+        newItemFactory: () => baseAdventureLogEntry(),
+        hasContentChecker: (h) => {
+          const hasScarIncrease = Number(h.increasedScar) > 0;
+          return !!(h.sessionName || (h.gotExperiments !== null && h.gotExperiments !== '') || hasScarIncrease || h.memo);
+        },
       });
     },
     addExpert(skillId) {
@@ -187,7 +194,13 @@ export const useCharacterStore = defineStore('character', {
     },
     updateHistoryItem(index, field, value) {
       if (this.histories[index]) {
-        this.histories[index][field] = field === 'gotExperiments' && value !== '' && value !== null ? Number(value) : value;
+        if (field === 'gotExperiments') {
+          this.histories[index][field] = value !== '' && value !== null ? Number(value) : value;
+        } else if (field === 'increasedScar') {
+          this.histories[index][field] = value !== '' && value !== null ? Number(value) : 0;
+        } else {
+          this.histories[index][field] = value;
+        }
       }
     },
     handleSpeciesChange() {

--- a/tests/unit/dataManager.test.js
+++ b/tests/unit/dataManager.test.js
@@ -116,6 +116,7 @@ describe('DataManager', () => {
       sessionName: 'sess1',
       gotExperiments: 2,
       memo: 'note',
+      increasedScar: 0,
     });
     expect(internal.character.images).toEqual([]);
   });
@@ -125,13 +126,13 @@ describe('DataManager', () => {
     expect(result.character.weaknesses).toHaveLength(AioniaGameData.config.maxWeaknesses);
     result.character.weaknesses.forEach((w) => expect(w).toEqual({ text: '', acquired: '--' }));
     expect(result.skills).toHaveLength(AioniaGameData.baseSkills.length);
-    expect(result.histories).toEqual([{ sessionName: '', gotExperiments: null, memo: '' }]);
+    expect(result.histories).toEqual([{ sessionName: '', gotExperiments: null, memo: '', increasedScar: 0 }]);
     expect(result.character.linkCurrentToInitialScar).toBe(true);
     expect(result.character.images).toEqual([]);
   });
 
   test('_normalizeHistoryData returns default when empty', () => {
-    expect(dm._normalizeHistoryData([])).toEqual([{ sessionName: '', gotExperiments: null, memo: '' }]);
+    expect(dm._normalizeHistoryData([])).toEqual([{ sessionName: '', gotExperiments: null, memo: '', increasedScar: 0 }]);
   });
 
   describe('saveData', () => {

--- a/tests/unit/stores/characterStore.test.js
+++ b/tests/unit/stores/characterStore.test.js
@@ -48,4 +48,45 @@ describe('characterStore', () => {
     expect(skill.experts.length).toBe(1);
     expect(skill.experts[0].value).toBe('');
   });
+
+  describe('calculatedScar', () => {
+    test('sums increased scars with initial value', () => {
+      const store = useCharacterStore();
+      store.character.initialScar = 5;
+      store.adventureLog.splice(
+        0,
+        store.adventureLog.length,
+        ...[
+          { sessionName: 'Session 1', gotExperiments: 10, memo: '', increasedScar: 2 },
+          { sessionName: 'Session 2', gotExperiments: 5, memo: '', increasedScar: 3 },
+        ],
+      );
+
+      expect(store.calculatedScar).toBe(10);
+    });
+
+    test('handles zero values without NaN', () => {
+      const store = useCharacterStore();
+      store.character.initialScar = 0;
+      store.adventureLog[0].increasedScar = 0;
+
+      expect(store.calculatedScar).toBe(0);
+    });
+
+    test('ignores non-numeric values when summing', () => {
+      const store = useCharacterStore();
+      store.character.initialScar = 7;
+      store.adventureLog.splice(
+        0,
+        store.adventureLog.length,
+        ...[
+          { sessionName: 'Session 1', gotExperiments: 4, memo: '', increasedScar: 1 },
+          { sessionName: 'Session 2', gotExperiments: 4, memo: '', increasedScar: null },
+          { sessionName: 'Session 3', gotExperiments: 4, memo: '', increasedScar: '3' },
+        ],
+      );
+
+      expect(store.calculatedScar).toBe(11);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add an `increasedScar` field to each adventure log entry and compute the derived `calculatedScar` in the character store
- surface the new scar increase field in the adventure log UI and display the scar current value as a read-only computed number
- update data normalization/export routines and unit tests to support the new scar calculation flow

## Testing
- `npm run lint`
- `npx vitest run`
- `npm run e2e`
- `npx vitest run tests/unit/dataManager.test.js tests/unit/stores/characterStore.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68db4779bf7c8326820b13c6803cb054