### PR TITLE
Implement automatic scar calculation from adventure log

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -107,21 +107,11 @@ const experienceStatusClass = computed(() => uiStore.experienceStatusClass);
 // --- Watchers (formerly `watch`) ---
 
 watch(
-  () => characterStore.character.initialScar,
+  () => characterStore.calculatedScar,
   (newVal) => {
-    if (characterStore.character.linkCurrentToInitialScar) {
-      characterStore.character.currentScar = newVal;
-    }
+    characterStore.character.currentScar = newVal;
   },
-);
-
-watch(
-  () => characterStore.character.linkCurrentToInitialScar,
-  (isLinked) => {
-    if (isLinked) {
-      characterStore.character.currentScar = characterStore.character.initialScar;
-    }
-  },
+  { immediate: true },
 );
 
 watch(

--- a/src/components/sections/AdventureLogSection.vue
+++ b/src/components/sections/AdventureLogSection.vue
@@ -8,16 +8,17 @@
           <div class="history-item-inputs">
             <div class="flex-history-name"><label>シナリオ名</label></div>
             <div class="flex-history-exp"><label>経験点</label></div>
+            <div class="flex-history-scar"><label>増加傷痕</label></div>
             <div class="flex-history-memo"><label>メモ</label></div>
           </div>
         </div>
       </div>
       <ul id="histories" class="list-reset">
         <BaseListItem
-          v-for="(history, index) in characterStore.histories"
+          v-for="(history, index) in characterStore.adventureLog"
           :key="index"
           :show-delete-button="!uiStore.isViewingShared"
-          :can-delete="!(characterStore.histories.length <= 1 && !hasHistoryContent(history))"
+          :can-delete="!(characterStore.adventureLog.length <= 1 && !hasHistoryContent(history))"
           @delete-item="characterStore.removeHistoryItem(index)"
         >
           <div class="flex-grow">
@@ -36,6 +37,15 @@
                   min="0"
                   :model-value="history.gotExperiments"
                   @update:model-value="(v) => characterStore.updateHistoryItem(index, 'gotExperiments', v)"
+                  :disabled="uiStore.isViewingShared"
+                />
+              </div>
+              <div class="flex-history-scar">
+                <BaseInput
+                  type="number"
+                  min="0"
+                  :model-value="history.increasedScar"
+                  @update:model-value="(v) => characterStore.updateHistoryItem(index, 'increasedScar', v)"
                   :disabled="uiStore.isViewingShared"
                 />
               </div>
@@ -75,7 +85,12 @@ const characterStore = useCharacterStore();
 const uiStore = useUiStore();
 
 function hasHistoryContent(h) {
-  return !!(h.sessionName || (h.gotExperiments !== null && h.gotExperiments !== '') || h.memo);
+  return !!(
+    h.sessionName ||
+    (h.gotExperiments !== null && h.gotExperiments !== '') ||
+    (h.increasedScar !== null && h.increasedScar !== undefined && h.increasedScar !== 0) ||
+    h.memo
+  );
 }
 </script>
 
@@ -94,6 +109,10 @@ function hasHistoryContent(h) {
 
 .flex-history-exp {
   flex: 0 1 80px;
+}
+
+.flex-history-scar {
+  flex: 0 1 100px;
 }
 
 .flex-history-memo {

--- a/src/components/sections/ScarWeaknessSection.vue
+++ b/src/components/sections/ScarWeaknessSection.vue
@@ -6,27 +6,8 @@
         <div class="sub-box-title sub-box-title--scar">傷痕</div>
         <div class="info-row">
           <div class="info-item info-item--double">
-            <div class="link-checkbox-container">
-              <label for="current_scar" class="link-checkbox-main-label">現在値</label>
-              <input
-                type="checkbox"
-                id="link_current_to_initial_scar_checkbox"
-                v-model="characterStore.character.linkCurrentToInitialScar"
-                class="link-checkbox"
-                :disabled="uiStore.isViewingShared"
-              />
-              <label for="link_current_to_initial_scar_checkbox" class="link-checkbox-label">連動</label>
-            </div>
-            <input
-              type="number"
-              id="current_scar"
-              v-model.number="characterStore.character.currentScar"
-              @input="handleCurrentScarInput"
-              :class="{ 'greyed-out': characterStore.character.linkCurrentToInitialScar }"
-              min="0"
-              class="scar-section__current-input"
-              :disabled="uiStore.isViewingShared"
-            />
+            <label for="current_scar">現在値</label>
+            <span id="current_scar" class="scar-section__current-value">{{ characterStore.calculatedScar }}</span>
           </div>
           <div class="info-item info-item--double">
             <label for="initial_scar">初期値</label>
@@ -75,14 +56,6 @@ import { useUiStore } from '../../stores/uiStore.js';
 const characterStore = useCharacterStore();
 const uiStore = useUiStore();
 const sessionNames = computed(() => characterStore.sessionNamesForWeaknessDropdown);
-
-function handleCurrentScarInput(event) {
-  const enteredValue = parseInt(event.target.value, 10);
-  if (Number.isNaN(enteredValue)) return;
-  if (characterStore.character.linkCurrentToInitialScar && enteredValue !== characterStore.character.initialScar) {
-    characterStore.character.linkCurrentToInitialScar = false;
-  }
-}
 </script>
 
 <style scoped>
@@ -94,29 +67,16 @@ function handleCurrentScarInput(event) {
   margin-bottom: 25px;
 }
 
-.link-checkbox-container {
-  display: flex;
+.scar-section__current-value {
+  display: inline-flex;
   align-items: center;
-}
-
-.link-checkbox-main-label {
-  margin-right: 8px;
-}
-
-.link-checkbox {
-  margin-right: 4px;
-  margin-bottom: 2px;
-  accent-color: var(--color-accent);
-  transform: scale(1.1);
-  width: auto;
-}
-
-.link-checkbox-label {
-  font-size: 0.9em;
-  color: var(--color-text-muted);
-  font-weight: normal;
-  user-select: none;
-  margin-bottom: 0;
+  min-height: 36px;
+  padding: 6px 10px;
+  border: 1px solid var(--color-border-normal);
+  border-radius: 4px;
+  background: var(--color-surface-elevated);
+  color: var(--color-text-normal);
+  font-variant-numeric: tabular-nums;
 }
 
 .sub-box-title--weakness {

--- a/src/stores/characterStore.js
+++ b/src/stores/characterStore.js
@@ -28,7 +28,7 @@ function baseEquipments() {
 }
 
 function baseHistories() {
-  return [{ sessionName: '', gotExperiments: null, memo: '' }];
+  return [{ sessionName: '', gotExperiments: null, memo: '', increasedScar: 0 }];
 }
 
 export const useCharacterStore = defineStore('character', {
@@ -40,6 +40,9 @@ export const useCharacterStore = defineStore('character', {
     histories: baseHistories(),
   }),
   getters: {
+    adventureLog(state) {
+      return state.histories;
+    },
     maxExperiencePoints(state) {
       const initialScarExp = Number(state.character.initialScar) || 0;
       const creationWeaknessExp = state.character.weaknesses.reduce(
@@ -82,6 +85,11 @@ export const useCharacterStore = defineStore('character', {
       weight += weaponWeights[state.equipments.weapon2.group] || 0;
       weight += armorWeights[state.equipments.armor.group] || 0;
       return weight;
+    },
+    calculatedScar(state) {
+      const initialScar = Number(state.character.initialScar) || 0;
+      const adventureScar = state.histories.reduce((sum, history) => sum + (Number(history?.increasedScar) || 0), 0);
+      return initialScar + adventureScar;
     },
     sessionNamesForWeaknessDropdown(state) {
       const defaultOptions = [...AioniaGameData.weaknessAcquisitionOptions];
@@ -147,6 +155,7 @@ export const useCharacterStore = defineStore('character', {
           sessionName: '',
           gotExperiments: null,
           memo: '',
+          increasedScar: 0,
         }),
       });
     },
@@ -159,8 +168,15 @@ export const useCharacterStore = defineStore('character', {
           sessionName: '',
           gotExperiments: null,
           memo: '',
+          increasedScar: 0,
         }),
-        hasContentChecker: (h) => !!(h.sessionName || (h.gotExperiments !== null && h.gotExperiments !== '') || h.memo),
+        hasContentChecker: (h) =>
+          !!(
+            h.sessionName ||
+            (h.gotExperiments !== null && h.gotExperiments !== '') ||
+            (h.increasedScar !== null && h.increasedScar !== undefined && h.increasedScar !== 0) ||
+            h.memo
+          ),
       });
     },
     addExpert(skillId) {
@@ -187,7 +203,13 @@ export const useCharacterStore = defineStore('character', {
     },
     updateHistoryItem(index, field, value) {
       if (this.histories[index]) {
-        this.histories[index][field] = field === 'gotExperiments' && value !== '' && value !== null ? Number(value) : value;
+        if (field === 'gotExperiments') {
+          this.histories[index][field] = value !== '' && value !== null ? Number(value) : value;
+        } else if (field === 'increasedScar') {
+          this.histories[index][field] = value !== '' && value !== null ? Number(value) : null;
+        } else {
+          this.histories[index][field] = value;
+        }
       }
     },
     handleSpeciesChange() {

--- a/tests/unit/stores/characterStore.test.js
+++ b/tests/unit/stores/characterStore.test.js
@@ -48,4 +48,28 @@ describe('characterStore', () => {
     expect(skill.experts.length).toBe(1);
     expect(skill.experts[0].value).toBe('');
   });
+
+  test('calculatedScar reflects initial value when no increments are present', () => {
+    const store = useCharacterStore();
+    store.character.initialScar = 7;
+    expect(store.calculatedScar).toBe(7);
+  });
+
+  test('calculatedScar includes positive scar increases from adventure log', () => {
+    const store = useCharacterStore();
+    store.character.initialScar = 3;
+    store.adventureLog[0].increasedScar = 4;
+    expect(store.calculatedScar).toBe(7);
+  });
+
+  test('calculatedScar sums multiple scar increases including zeros', () => {
+    const store = useCharacterStore();
+    store.character.initialScar = 2;
+    store.adventureLog[0].increasedScar = 0;
+    store.addHistoryItem();
+    store.adventureLog[1].increasedScar = 5;
+    store.addHistoryItem();
+    store.adventureLog[2].increasedScar = 3;
+    expect(store.calculatedScar).toBe(10);
+  });
 });


### PR DESCRIPTION
## Summary
- add an `increasedScar` field to adventure log entries and compute a `calculatedScar` total in the character store
- expose the new field in the Adventure Log UI and render the current scar as a read-only calculated value
- cover the new scar calculation logic with unit tests

## Testing
- npm run lint
- npm test -- tests/unit/stores/characterStore.test.js
- npm run e2e *(fails: missing system dependencies for Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68db4bf6d97c8326b13e8614015dae7c