### PR TITLE
feat: migrate drive workspace and refresh character hub

### DIFF
--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -1,5 +1,7 @@
 const { defineConfig } = require('@playwright/test');
 
+process.env.VITE_USE_MOCK_DRIVE = process.env.VITE_USE_MOCK_DRIVE || 'true';
+
 module.exports = defineConfig({
   testDir: './tests/e2e',
   use: {

--- a/src/components/ui/CharacterHubControls.vue
+++ b/src/components/ui/CharacterHubControls.vue
@@ -1,12 +1,33 @@
 <template>
-  <div class="character-hub--controls">
+  <div class="character-hub-controls">
     <template v-if="uiStore.isSignedIn">
-      <button class="button-base character-hub-button character-hub--signout" @click="$emit('sign-out')">ログアウト</button>
-      <button class="button-base character-hub-button character-hub--refresh" @click="$emit('refresh')">更新</button>
-      <button class="button-base character-hub-button character-hub--new" @click="$emit('new')">新規保存</button>
+      <button class="button-base character-hub-controls__button" @click="$emit('change-folder')">
+        {{ labels.changeFolder }}
+      </button>
+      <button class="button-base character-hub-controls__button" @click="$emit('refresh')">
+        {{ labels.refresh }}
+      </button>
+      <button class="button-base character-hub-controls__button" @click="$emit('open-picker')">
+        {{ labels.openPicker }}
+      </button>
+      <button class="button-base character-hub-controls__button" @click="$emit('save-new')">
+        {{ labels.saveNew }}
+      </button>
+      <button
+        class="button-base character-hub-controls__button"
+        :disabled="!uiStore.currentDriveFileId"
+        @click="$emit('save-current')"
+      >
+        {{ labels.saveOverwrite }}
+      </button>
+      <button class="button-base character-hub-controls__button" @click="$emit('sign-out')">
+        {{ labels.signOut }}
+      </button>
     </template>
     <template v-else>
-      <button class="button-base character-hub-button" @click="$emit('sign-in')">Googleにログイン</button>
+      <button class="button-base character-hub-controls__button" @click="$emit('sign-in')">
+        {{ labels.signIn }}
+      </button>
     </template>
   </div>
 </template>
@@ -14,22 +35,33 @@
 <script setup>
 import { useUiStore } from '../../stores/uiStore.js';
 
-const emit = defineEmits(['sign-in', 'sign-out', 'refresh', 'new']);
+defineProps({
+  labels: {
+    type: Object,
+    required: true,
+  },
+});
+
+defineEmits(['sign-in', 'sign-out', 'refresh', 'save-new', 'save-current', 'change-folder', 'open-picker']);
 const uiStore = useUiStore();
 </script>
 
 <style scoped>
-.character-hub--controls {
+.character-hub-controls {
   display: flex;
   flex-direction: row;
   justify-content: right;
   gap: 8px;
   margin-right: 10px;
 }
-.character-hub-button {
+.character-hub-controls__button {
   padding: 6px 8px;
   font-weight: 500;
   height: auto;
   width: auto;
+}
+.character-hub-controls__button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 </style>

--- a/src/composables/useAppModals.js
+++ b/src/composables/useAppModals.js
@@ -2,7 +2,6 @@ import { reactive, defineAsyncComponent } from 'vue';
 import { useModal } from './useModal.js';
 import { useUiStore } from '../stores/uiStore.js';
 const CharacterHub = defineAsyncComponent(() => import('../components/ui/CharacterHub.vue'));
-const CharacterHubControls = defineAsyncComponent(() => import('../components/ui/CharacterHubControls.vue'));
 const IoModal = defineAsyncComponent(() => import('../components/modals/contents/IoModal.vue'));
 const ShareOptions = defineAsyncComponent(() => import('../components/modals/contents/ShareOptions.vue'));
 
@@ -21,8 +20,6 @@ export function useAppModals(options) {
     saveCharacterToDrive,
     handleSignInClick,
     handleSignOutClick,
-    refreshHubList,
-    saveNewCharacter,
     saveData,
     handleFileUpload,
     outputToCocofolia,
@@ -41,14 +38,10 @@ export function useAppModals(options) {
         loadCharacter: loadCharacterById,
         saveToDrive: saveCharacterToDrive,
       },
-      globalActions: {
-        component: CharacterHubControls,
-        on: {
-          'sign-in': handleSignInClick,
-          'sign-out': handleSignOutClick,
-          refresh: refreshHubList,
-          new: saveNewCharacter,
-        },
+      on: {
+        'sign-in': handleSignInClick,
+        'sign-out': handleSignOutClick,
+        'change-folder': promptForDriveFolder,
       },
       buttons: [],
     });

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -23,11 +23,23 @@ export const messages = {
       success: () => ({ title: 'サインアウトしました', message: '' }),
     },
     folderPicker: {
+      loading: () => ({
+        title: 'Google Drive',
+        message: 'フォルダ情報を取得しています...',
+      }),
+      success: (name) => ({
+        title: 'フォルダ変更',
+        message: `${name} を使用します`,
+      }),
       error: (err) => ({
         title: 'Google Drive',
         message: err?.message || 'フォルダ選択をキャンセルしました',
       }),
     },
+    workspaceNotSelected: () => ({
+      title: 'Google Drive',
+      message: '保存先のフォルダを選択してください。',
+    }),
     save: {
       loading: () => ({ title: 'Google Drive', message: '保存中...' }),
       success: () => ({ title: '保存完了', message: '' }),
@@ -76,6 +88,31 @@ export const messages = {
     },
   },
   characterHub: {
+    fallbackName: '名もなき冒険者',
+    signedOutMessage: 'Google Driveと連携して、キャラクターを保存・共有できます。ベータ版のため、データの破損・消失の危険性があります。',
+    emptyMessage: '保存済みのキャラクターが見つかりません。',
+    defaultFolderName: 'AioniaCS',
+    workspaceLabel: (name) => `保存先フォルダ: ${name}`,
+    workspaceUnset: '保存先フォルダが未選択です。フォルダを選択してください。',
+    controls: {
+      signIn: 'Googleにログイン',
+      signOut: 'ログアウト',
+      refresh: '一覧更新',
+      saveNew: '新規保存',
+      saveOverwrite: '上書き保存',
+      changeFolder: 'フォルダ変更',
+      openPicker: 'Drive読込',
+    },
+    list: {
+      actions: {
+        overwrite: '上書き',
+        export: '端末保存',
+        remove: '削除',
+        cancel: 'キャンセル',
+      },
+      deletePrompt: 'このキャラクターを削除しますか？',
+      updatedAt: (text) => `更新: ${text}`,
+    },
     loadConfirm: (name) => ({
       title: '読込確認',
       message: `${name} を読み込みますか？`,

--- a/src/services/dataManager.js
+++ b/src/services/dataManager.js
@@ -254,13 +254,18 @@ export class DataManager {
   }
 
   /**
-   * Saves character data to the user's appDataFolder.
+   * Saves character data to the user's configured Google Drive workspace folder.
    * Adds an index entry when creating a new file.
    */
   async saveDataToAppData(character, skills, specialSkills, equipments, histories, currentFileId) {
     if (!this.googleDriveManager) {
       console.error('GoogleDriveManager not set in DataManager.');
       throw new Error('GoogleDriveManager not configured. Please sign in or initialize the Drive manager.');
+    }
+
+    const workspaceFolderId = this.googleDriveManager.getWorkspaceFolderId?.();
+    if (!workspaceFolderId) {
+      throw new Error('Google Drive folder is not selected. Please choose a destination folder.');
     }
 
     const dataToSave = {
@@ -329,6 +334,11 @@ export class DataManager {
     if (!this.googleDriveManager) {
       console.error('GoogleDriveManager not set in DataManager.');
       throw new Error('GoogleDriveManager not configured. Please sign in or initialize the Drive manager.');
+    }
+
+    const workspaceFolderId = this.googleDriveManager.getWorkspaceFolderId?.();
+    if (!workspaceFolderId) {
+      throw new Error('Google Drive folder is not selected. Please choose a destination folder.');
     }
 
     const index = await this.googleDriveManager.readIndexFile();

--- a/src/services/driveStorageAdapter.js
+++ b/src/services/driveStorageAdapter.js
@@ -7,7 +7,11 @@ export class DriveStorageAdapter {
 
   async create(data) {
     const content = this._serializeData(data);
-    const res = await this.gdm.saveFile('appDataFolder', `sls_${Date.now()}.json`, content);
+    const folderId = this.gdm.getWorkspaceFolderId?.();
+    if (!folderId) {
+      throw new Error('Workspace folder is not set.');
+    }
+    const res = await this.gdm.saveFile(folderId, `sls_${Date.now()}.json`, content);
     return res && res.id ? res.id : null;
   }
 
@@ -19,7 +23,11 @@ export class DriveStorageAdapter {
 
   async update(id, data) {
     const content = this._serializeData(data);
-    await this.gdm.saveFile('appDataFolder', `sls_${Date.now()}.json`, content, id);
+    const folderId = this.gdm.getWorkspaceFolderId?.();
+    if (!folderId) {
+      throw new Error('Workspace folder is not set.');
+    }
+    await this.gdm.saveFile(folderId, `sls_${Date.now()}.json`, content, id);
   }
 
   _serializeData(data) {

--- a/src/stores/uiStore.js
+++ b/src/stores/uiStore.js
@@ -34,6 +34,16 @@ export const useUiStore = defineStore('ui', {
     setLoading(flag) {
       this.isLoading = flag;
     },
+    setDriveFolder(folder) {
+      if (folder && folder.id) {
+        this.driveFolderId = folder.id;
+        this.driveFolderName = folder.name || '';
+      } else {
+        this.driveFolderId = null;
+        this.driveFolderName = '';
+        this.currentDriveFileId = null;
+      }
+    },
     async refreshDriveCharacters(gdm) {
       if (!gdm) return;
       const temps = this.driveCharacters.filter((c) => c.id.startsWith('temp-'));

--- a/tests/e2e/driveWorkspace.test.cjs
+++ b/tests/e2e/driveWorkspace.test.cjs
@@ -1,0 +1,35 @@
+const { test, expect } = require('@playwright/test');
+
+const INDEX_HTML_PATH = 'http://localhost:4173/AioniaCS/';
+
+test.describe('Google Drive workspace flow (mock)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(INDEX_HTML_PATH);
+  });
+
+  test('signs in and saves a character to the Drive workspace', async ({ page }) => {
+    await page.locator('#name').fill('E2E Hero');
+
+    await page.locator('button:has-text("Cloud Hub")').click();
+
+    const modal = page.locator('.modal');
+    await expect(modal).toBeVisible();
+
+    const signInButton = modal.locator('.character-hub-controls__button', { hasText: 'Googleにログイン' });
+    await signInButton.click();
+
+    await expect(modal.locator('.character-hub-controls__button', { hasText: 'ログアウト' })).toBeVisible();
+
+    await expect(modal.locator('.character-hub__folder-label')).toHaveText('保存先フォルダ: AioniaCS');
+
+    const saveNewButton = modal.locator('.character-hub-controls__button', { hasText: '新規保存' });
+    await saveNewButton.click();
+
+    const listItem = modal.locator('.character-hub__item').first();
+    await expect(listItem).toContainText('E2E Hero');
+    await expect(listItem).toHaveClass(/character-hub__item--active/);
+
+    const dateText = await listItem.locator('.character-hub__date').innerText();
+    expect(dateText).toMatch(/^更新: /);
+  });
+});

--- a/tests/integrity/data-resilience.test.js
+++ b/tests/integrity/data-resilience.test.js
@@ -7,10 +7,11 @@ describe('DataManager data integrity', () => {
   let dm;
   let gdm;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     gdm = new MockGoogleDriveManager('k', 'c');
     dm = new DataManager(AioniaGameData);
     dm.setGoogleDriveManager(gdm);
+    await gdm.ensureWorkspaceFolder();
   });
 
   it('should handle corrupted pointers gracefully without crashing', async () => {
@@ -29,6 +30,6 @@ describe('DataManager data integrity', () => {
     const list = await dm.loadCharacterListFromDrive();
     expect(list).toEqual([]);
     // ensure file exists but ignored
-    expect(gdm.appData[file.id]).toBeDefined();
+    expect(gdm.files[file.id]).toBeDefined();
   });
 });

--- a/tests/unit/dataManager.test.js
+++ b/tests/unit/dataManager.test.js
@@ -278,6 +278,7 @@ describe('DataManager', () => {
         updateCharacterFile: vi.fn().mockResolvedValue({ id: '1', name: 'c.json' }),
         addIndexEntry: vi.fn().mockResolvedValue(),
         renameIndexEntry: vi.fn().mockResolvedValue(),
+        getWorkspaceFolderId: vi.fn().mockReturnValue('folder-1'),
       };
     });
 

--- a/tests/unit/driveStorageAdapter.test.js
+++ b/tests/unit/driveStorageAdapter.test.js
@@ -9,6 +9,7 @@ describe('DriveStorageAdapter', () => {
     gdm = {
       saveFile: vi.fn().mockResolvedValue({ id: '1' }),
       loadFileContent: vi.fn().mockResolvedValue(''),
+      getWorkspaceFolderId: vi.fn().mockReturnValue('folder-1'),
     };
     adapter = new DriveStorageAdapter(gdm);
   });
@@ -32,6 +33,6 @@ describe('DriveStorageAdapter', () => {
 
   test('update calls saveFile with id', async () => {
     await adapter.update('u1', new Uint8Array(4));
-    expect(gdm.saveFile).toHaveBeenCalledWith('appDataFolder', expect.any(String), expect.any(String), 'u1');
+    expect(gdm.saveFile).toHaveBeenCalledWith('folder-1', expect.any(String), expect.any(String), 'u1');
   });
 });

--- a/tests/unit/googleDriveAuth.test.js
+++ b/tests/unit/googleDriveAuth.test.js
@@ -26,7 +26,7 @@ describe('GoogleDriveManager auth', () => {
     await gdm.onGisLoad();
     expect(google.accounts.oauth2.initTokenClient).toHaveBeenCalledWith({
       client_id: 'c',
-      scope: 'https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive.file',
+      scope: 'https://www.googleapis.com/auth/drive.file',
       callback: '',
     });
   });


### PR DESCRIPTION
## Summary
- switch Google Drive integration to manage a user-visible AioniaCS workspace folder, updating index maintenance, picker flows, and store state
- redesign the Character Hub experience around the new Drive workflow with localized labels and folder awareness
- ensure automated tests cover the workspace folder logic, including a new Playwright scenario using the mock Drive manager

## Testing
- npm run lint
- npm run test
- npm run e2e *(fails: missing Playwright system dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db512dd9648326b30191684d6187d8