### PR TITLE
Add configurable Drive folder path settings

### DIFF
--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -7,7 +7,7 @@ module.exports = defineConfig({
     baseURL: 'http://localhost:4173/AioniaCS/',
   },
   webServer: {
-    command: 'npx vite --port 4173 --strictPort',
+    command: 'cross-env VITE_USE_MOCK_DRIVE=true npx vite --port 4173 --strictPort',
     port: 4173,
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,

--- a/src/components/ui/CharacterHub.vue
+++ b/src/components/ui/CharacterHub.vue
@@ -1,43 +1,33 @@
 <template>
   <div class="character-hub">
-    <div class="character-hub--config">
-      <label class="character-hub--label" for="drive_folder_path">保存先フォルダ</label>
-      <input
-        id="drive_folder_path"
-        class="character-hub--input"
-        type="text"
-        v-model="folderPathInput"
-        :disabled="!uiStore.isSignedIn"
-        placeholder="慈悲なきアイオニア"
-        @blur="commitFolderPath"
-        @keyup.enter.prevent="commitFolderPath"
-      />
-    </div>
     <template v-if="uiStore.isSignedIn">
       <div class="character-hub--actions">
+        <div class="character-hub--config">
+          <label class="character-hub--label" for="drive_folder_path">保存先フォルダ</label>
+          <input
+            id="drive_folder_path"
+            class="character-hub--input"
+            type="text"
+            v-model="folderPathInput"
+            :disabled="!uiStore.isSignedIn"
+            placeholder="慈悲なきアイオニア"
+            @blur="commitFolderPath"
+            @keyup.enter.prevent="commitFolderPath"
+          />
+        </div>
         <button class="button-base character-hub--button" :disabled="!isDriveReady" @click="loadCharacterFromDrive">
           Driveから読み込む
         </button>
         <button class="button-base character-hub--button" :disabled="!isDriveReady" @click="saveNewCharacter">
           新しい冒険者として保存
         </button>
-        <button
-          class="button-base character-hub--button"
-          :disabled="!isOverwriteEnabled"
-          @click="saveOverwrite"
-        >
-          上書き保存
-        </button>
-        <button class="button-base character-hub--button" @click="emitSignOut">
-          ログアウト
-        </button>
+        <button class="button-base character-hub--button" :disabled="!isOverwriteEnabled" @click="saveOverwrite">上書き保存</button>
+        <button class="button-base character-hub--button" @click="emitSignOut">ログアウト</button>
       </div>
     </template>
     <template v-else>
       <div class="character-hub--actions">
-        <button class="button-base character-hub--button" :disabled="!canSignIn" @click="emitSignIn">
-          Googleにログイン
-        </button>
+        <button class="button-base character-hub--button" :disabled="!canSignIn" @click="emitSignIn">Googleにログイン</button>
       </div>
     </template>
   </div>
@@ -128,7 +118,6 @@ async function commitFolderPath() {
   flex-direction: column;
   gap: 6px;
   width: 100%;
-  margin-bottom: 16px;
 }
 
 .character-hub--label {

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -67,6 +67,15 @@ export const messages = {
       title: 'Google Drive',
       message: '初期化が完了するまでお待ちください',
     }),
+    config: {
+      loadError: () => ({ title: '設定読み込み失敗', message: '保存先フォルダの取得に失敗しました' }),
+      requiresSignIn: () => ({ title: 'Google Drive', message: 'Googleにサインインしてください' }),
+      updateSuccess: () => ({ title: '設定更新', message: '保存先フォルダを更新しました' }),
+      updateError: (err) => ({
+        title: '設定更新失敗',
+        message: err?.message || '保存先フォルダの更新に失敗しました',
+      }),
+    },
   },
   share: {
     copied: (link) => ({ title: '共有リンクをコピーしました', message: link }),

--- a/src/services/dataManager.js
+++ b/src/services/dataManager.js
@@ -298,8 +298,16 @@ export class DataManager {
       ),
     };
 
-    if (currentFileId) {
-      return this.googleDriveManager.updateCharacterFile(currentFileId, dataToSave);
+    let targetFileId = currentFileId;
+    if (targetFileId) {
+      const isInConfiguredFolder = await this.googleDriveManager.isFileInConfiguredFolder(targetFileId);
+      if (!isInConfiguredFolder) {
+        targetFileId = null;
+      }
+    }
+
+    if (targetFileId) {
+      return this.googleDriveManager.updateCharacterFile(targetFileId, dataToSave);
     }
 
     return this.googleDriveManager.createCharacterFile(dataToSave);

--- a/src/stores/uiStore.js
+++ b/src/stores/uiStore.js
@@ -8,8 +8,7 @@ export const useUiStore = defineStore('ui', {
     isGapiInitialized: false,
     isGisInitialized: false,
     isLoading: false,
-    driveFolderId: null,
-    driveFolderName: '',
+    driveFolderPath: '慈悲なきアイオニア',
     currentDriveFileId: null,
     isViewingShared: false,
     pendingDriveSaves: {},
@@ -26,7 +25,7 @@ export const useUiStore = defineStore('ui', {
       return state.isGapiInitialized && state.isGisInitialized && !state.isSignedIn;
     },
     canOperateDrive(state) {
-      return state.isSignedIn && state.driveFolderId;
+      return state.isSignedIn;
     },
   },
   actions: {
@@ -38,6 +37,9 @@ export const useUiStore = defineStore('ui', {
     },
     clearCurrentDriveFileId() {
       this.currentDriveFileId = null;
+    },
+    setDriveFolderPath(path) {
+      this.driveFolderPath = path;
     },
     registerPendingDriveSave(id) {
       this.pendingDriveSaves[id] = { canceled: false };

--- a/tests/e2e/index.test.cjs
+++ b/tests/e2e/index.test.cjs
@@ -169,9 +169,6 @@ test.describe('Character Sheet E2E Tests', () => {
     const modal = page.locator('.modal');
     await modal.waitFor({ state: 'visible' });
 
-    const folderInput = page.locator('#drive_folder_path');
-    await expect(folderInput).toHaveValue('慈悲なきアイオニア');
-
     const signInButton = page.locator('button:has-text("Googleにログイン")');
     await signInButton.waitFor({ state: 'visible' });
     await expect(signInButton).toBeEnabled({ timeout: 10000 });
@@ -180,6 +177,9 @@ test.describe('Character Sheet E2E Tests', () => {
     const saveNewButton = page.locator('button:has-text("新しい冒険者として保存")');
     await expect(saveNewButton).toBeVisible({ timeout: 10000 });
     await expect(saveNewButton).toBeEnabled({ timeout: 10000 });
+
+    const folderInput = page.locator('#drive_folder_path');
+    await expect(folderInput).toHaveValue('慈悲なきアイオニア');
 
     const desiredPath = '慈悲なきアイオニア\\PC/第一キャンペーン';
     await folderInput.fill(desiredPath);

--- a/tests/e2e/index.test.cjs
+++ b/tests/e2e/index.test.cjs
@@ -158,4 +158,63 @@ test.describe('Character Sheet E2E Tests', () => {
       await expect(imageCountDisplay).toHaveText('1 / 1'); // Assuming one image in the test zip
     });
   });
+
+  test('updates Drive folder path and saves using configured hierarchy', async ({ page }) => {
+    await page.evaluate(() => localStorage.clear());
+
+    const characterNameInput = page.locator('#name');
+    await characterNameInput.fill('MockE2E');
+
+    await page.locator('.icon-button').first().click();
+    const modal = page.locator('.modal');
+    await modal.waitFor({ state: 'visible' });
+
+    const folderInput = page.locator('#drive_folder_path');
+    await expect(folderInput).toHaveValue('慈悲なきアイオニア');
+
+    const signInButton = page.locator('button:has-text("Googleにログイン")');
+    await signInButton.waitFor({ state: 'visible' });
+    await expect(signInButton).toBeEnabled({ timeout: 10000 });
+    await signInButton.click();
+
+    const saveNewButton = page.locator('button:has-text("新しい冒険者として保存")');
+    await expect(saveNewButton).toBeVisible({ timeout: 10000 });
+    await expect(saveNewButton).toBeEnabled({ timeout: 10000 });
+
+    const desiredPath = '慈悲なきアイオニア\\PC/第一キャンペーン';
+    await folderInput.fill(desiredPath);
+    await folderInput.blur();
+    await expect(folderInput).toHaveValue('慈悲なきアイオニア/PC/第一キャンペーン');
+
+    await saveNewButton.click();
+
+    await page.waitForFunction(() => {
+      const stateRaw = localStorage.getItem('mockGoogleDriveData');
+      if (!stateRaw) return false;
+      try {
+        const state = JSON.parse(stateRaw);
+        return Object.values(state.files || {}).some((file) => file.name === 'MockE2E.json');
+      } catch (e) {
+        return false;
+      }
+    });
+
+    const driveState = await page.evaluate(() => JSON.parse(localStorage.getItem('mockGoogleDriveData')));
+    expect(driveState.config.characterFolderPath).toBe('慈悲なきアイオニア/PC/第一キャンペーン');
+
+    const savedFile = Object.values(driveState.files).find((file) => file.name === 'MockE2E.json');
+    expect(savedFile).toBeTruthy();
+
+    const buildPath = (folderId) => {
+      const segments = [];
+      let current = driveState.folders[folderId];
+      while (current) {
+        segments.unshift(current.name);
+        current = driveState.folders[current.parentId];
+      }
+      return segments.join('/');
+    };
+
+    expect(buildPath(savedFile.parentId)).toBe('慈悲なきアイオニア/PC/第一キャンペーン');
+  });
 });

--- a/tests/unit/dataManager.test.js
+++ b/tests/unit/dataManager.test.js
@@ -277,6 +277,8 @@ describe('DataManager', () => {
       dm.googleDriveManager = {
         createCharacterFile: vi.fn().mockResolvedValue({ id: '1', name: 'c.json' }),
         updateCharacterFile: vi.fn().mockResolvedValue({ id: '1', name: 'c.json' }),
+        findOrCreateAioniaCSFolder: vi.fn().mockResolvedValue('folder-id'),
+        isFileInConfiguredFolder: vi.fn().mockResolvedValue(true),
       };
     });
 
@@ -289,6 +291,16 @@ describe('DataManager', () => {
     test('updates file when id exists', async () => {
       await dm.saveDataToAppData(mockCharacter, mockSkills, mockSpecialSkills, mockEquipments, mockHistories, '1');
       expect(dm.googleDriveManager.updateCharacterFile).toHaveBeenCalledWith('1', expect.any(Object));
+    });
+
+    test('creates new file when existing file is outside configured folder', async () => {
+      dm.googleDriveManager.isFileInConfiguredFolder.mockResolvedValue(false);
+
+      await dm.saveDataToAppData(mockCharacter, mockSkills, mockSpecialSkills, mockEquipments, mockHistories, '1');
+
+      expect(dm.googleDriveManager.isFileInConfiguredFolder).toHaveBeenCalledWith('1');
+      expect(dm.googleDriveManager.updateCharacterFile).not.toHaveBeenCalled();
+      expect(dm.googleDriveManager.createCharacterFile).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary
- add aioniacs.cfg handling to GoogleDriveManager to persist folder paths and build nested Drive directories
- surface a Drive folder path input in CharacterHub backed by new store state and updateDriveFolderPath helper
- extend data/mocks and tests, including a Playwright check, to cover the new folder relocation logic

## Testing
- npm run lint
- npm test
- npm run e2e *(fails: missing system dependencies for browser launch)*

------
https://chatgpt.com/codex/tasks/task_e_68dbbaca19f083268bd3b9b359d967e8