### PR TITLE
feat: enhance special skills acquisition controls

### DIFF
--- a/src/composables/core/useExperienceCalculation.js
+++ b/src/composables/core/useExperienceCalculation.js
@@ -31,10 +31,12 @@ export function useExperienceCalculation(character, skills, specialSkills, histo
       }
       return sum;
     }, 0);
-    const specialSkillExp = specialSkills.reduce(
-      (sum, ss) => sum + (ss.name && ss.name.trim() !== '' ? AioniaGameData.experiencePointValues.specialSkill : 0),
-      0,
-    );
+    const specialSkillExp = specialSkills.reduce((sum, ss) => {
+      if (ss.excludeFromExp) {
+        return sum;
+      }
+      return sum + (ss.name && ss.name.trim() !== '' ? AioniaGameData.experiencePointValues.specialSkill : 0);
+    }, 0);
     return skillExp + expertExp + specialSkillExp;
   });
 

--- a/src/services/dataManager.js
+++ b/src/services/dataManager.js
@@ -670,6 +670,9 @@ export class DataManager {
           name: loadedSS.name || '',
           note: loadedSS.note || '',
           showNote: this.gameData.specialSkillsRequiringNote.includes(loadedSS.name || ''),
+          acquired:
+            Object.prototype.hasOwnProperty.call(loadedSS, 'acquired') && loadedSS.acquired !== undefined ? loadedSS.acquired : '作成時',
+          excludeFromExp: !!loadedSS.excludeFromExp,
         });
       } else {
         // Fill with empty special skill objects if loaded data is shorter
@@ -678,6 +681,8 @@ export class DataManager {
           name: '',
           note: '',
           showNote: false,
+          acquired: '作成時',
+          excludeFromExp: false,
         });
       }
     }

--- a/tests/unit/components/SpecialSkillsSection.test.js
+++ b/tests/unit/components/SpecialSkillsSection.test.js
@@ -15,9 +15,9 @@ describe('SpecialSkillsSection', () => {
     const store = useCharacterStore();
     const item = store.specialSkills[0];
 
-    const groupSelect = wrapper.findAll('select.flex-item-1')[0];
-    const nameSelect = wrapper.findAll('select.flex-item-2')[0];
-    const noteInput = wrapper.findAll('input.special-skill-note-input')[0];
+    const groupSelect = wrapper.find('.flex-special-type select');
+    const nameSelect = wrapper.find('.flex-special-name select');
+    const noteInput = wrapper.find('input.special-skill-note-input');
 
     await groupSelect.setValue('magic');
     await wrapper.vm.$nextTick();


### PR DESCRIPTION
## Summary
- extend character store special skill records with acquisition metadata and experience exclusion flags and expose dropdown options
- update the special skills section layout to add acquisition selectors, reward toggles, and a responsive header aligned with the inputs
- ensure data normalization, experience calculations, and unit tests reflect the new special skill fields

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68dd2422c7388326a8d22360016cb794