### PR TITLE
Remove unused ListManager utility

### DIFF
--- a/src/utils/listManager.js
+++ b/src/utils/listManager.js
@@ -1,5 +1,0 @@
-export const ListManager = {
-  manage() {
-    // 実装内容
-  },
-};


### PR DESCRIPTION
## Summary
- remove the unused placeholder ListManager utility since it has no remaining references

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dd3913f29c83268f6c14c2ad55bda2