### PR TITLE
Remove redundant style import from App component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -148,7 +148,6 @@ onMounted(initialize);
   You can either @import your main CSS file here or manage it
   in your main.js/main.ts entry file.
 */
-@import './assets/css/style.css';
 
 /* Additional component-specific styles can go here */
 .hidden {


### PR DESCRIPTION
## Summary
- remove the redundant scoped import of the shared stylesheet from App.vue so it is only loaded once

## Testing
- npm run lint
- npm run test
- npm run e2e *(fails: host system is missing dependencies to run Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68e367c926808326a396f4a1ed9f15c8