### PR TITLE
Fix scar readonly field colors using palette tokens

### DIFF
--- a/src/components/sections/ScarWeaknessSection.vue
+++ b/src/components/sections/ScarWeaknessSection.vue
@@ -80,8 +80,8 @@ const calculatedScar = computed(() => characterStore.calculatedScar);
 }
 
 .scar-section__current-input--readonly {
-  background-color: var(--color-surface-muted);
-  color: var(--color-text);
+  background-color: var(--color-input-disabled-bg);
+  color: var(--color-text-normal);
 }
 
 .sub-box-title--weakness {


### PR DESCRIPTION
## Summary
- update the readonly scar field to use existing palette tokens for its background and text colors

## Testing
- npm run lint
- npm run test
- npm run e2e *(fails: Playwright browsers require additional system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e367d5a8a88326a27906ee574dcdd2