### PR TITLE
Fix load indicator base color token

### DIFF
--- a/src/components/ui/LoadIndicator.vue
+++ b/src/components/ui/LoadIndicator.vue
@@ -44,7 +44,7 @@ const stepClasses = computed(() => calculateStepClasses(loadValue.value));
   width: 10px;
   height: 16px;
   border-radius: 2px;
-  background-color: var(--color-ghost-normal);
+  background-color: var(--color-load-ghost-normal);
 }
 
 .load-indicator--step--on-normal {


### PR DESCRIPTION
## Summary
- update the load indicator base segment color to use the existing ghost load token so idle steps render with the muted shade

## Testing
- npm run lint
- npm run test
- npm run e2e *(fails: Playwright missing system dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e367e4cd508326aa905720fc326b6d