### PR TITLE
Handle Drive ZIP support for character data

### DIFF
--- a/src/composables/useAppInitialization.js
+++ b/src/composables/useAppInitialization.js
@@ -68,8 +68,9 @@ export function useAppInitialization(dataManager) {
         buffer = await receiveSharedData({
           location: window.location,
           downloadHandler: async (id) => {
-            const text = await dataManager.googleDriveManager.loadFileContent(id);
-            if (!text) throw new Error('no data');
+            const content = await dataManager.googleDriveManager.loadFileContent(id);
+            if (!content || content.body === undefined || content.body === null) throw new Error('no data');
+            const text = typeof content.body === 'string' ? content.body : JSON.stringify(content.body);
             const { ciphertext, iv } = JSON.parse(text);
             return {
               ciphertext: base64ToArrayBuffer(ciphertext),

--- a/src/services/characterDataFileHelpers.js
+++ b/src/services/characterDataFileHelpers.js
@@ -1,0 +1,154 @@
+import { deepClone } from '../utils/utils.js';
+
+function extractImagesArray(character) {
+  if (!character) {
+    return [];
+  }
+  const images = Array.isArray(character.images)
+    ? character.images.filter((image) => typeof image === 'string' && image.trim() !== '')
+    : [];
+  return images;
+}
+
+export function separateCharacterImages(character) {
+  const clonedCharacter = deepClone(character || {});
+  const images = extractImagesArray(clonedCharacter);
+
+  if (images.length > 0) {
+    delete clonedCharacter.images;
+  }
+
+  return { characterWithoutImages: clonedCharacter, images };
+}
+
+function getMimeTypeFromDataUrl(dataUrl) {
+  const match = /^data:([^;]+);/i.exec(dataUrl || '');
+  return match ? match[1] : 'image/png';
+}
+
+function getExtensionFromDataUrl(dataUrl) {
+  const mime = getMimeTypeFromDataUrl(dataUrl);
+  const slashIndex = mime.indexOf('/');
+  if (slashIndex === -1) {
+    return 'png';
+  }
+  const subtype = mime.substring(slashIndex + 1);
+  if (subtype === 'jpeg') {
+    return 'jpg';
+  }
+  return subtype || 'png';
+}
+
+export async function buildZipFromCharacterData(data, images) {
+  const { default: JSZip } = await import('jszip');
+  const zip = new JSZip();
+  const jsonString = typeof data === 'string' ? data : JSON.stringify(data, null, 2);
+  zip.file('character_data.json', jsonString);
+
+  if (Array.isArray(images) && images.length > 0) {
+    const imageFolder = zip.folder('images');
+    images.forEach((imageDataUrl, index) => {
+      if (typeof imageDataUrl !== 'string') {
+        return;
+      }
+      const commaIndex = imageDataUrl.indexOf(',');
+      const base64Data = commaIndex >= 0 ? imageDataUrl.substring(commaIndex + 1) : imageDataUrl;
+      const extension = getExtensionFromDataUrl(imageDataUrl);
+      imageFolder.file(`image_${index}.${extension || 'png'}`, base64Data, {
+        base64: true,
+      });
+    });
+  }
+
+  return zip.generateAsync({ type: 'uint8array' });
+}
+
+function sortImageEntries(entries) {
+  const regex = /image_(\d+)\..+/i;
+  entries.sort((a, b) => {
+    const matchA = a.relativePath.match(regex);
+    const matchB = b.relativePath.match(regex);
+
+    const numA = matchA ? parseInt(matchA[1], 10) : Infinity;
+    const numB = matchB ? parseInt(matchB[1], 10) : Infinity;
+
+    if (Number.isFinite(numA) && Number.isFinite(numB)) {
+      return numA - numB;
+    }
+    if (Number.isFinite(numA)) {
+      return -1;
+    }
+    if (Number.isFinite(numB)) {
+      return 1;
+    }
+    return a.relativePath.localeCompare(b.relativePath);
+  });
+}
+
+function ensureArrayBuffer(data) {
+  if (data instanceof ArrayBuffer) {
+    return data;
+  }
+  if (ArrayBuffer.isView(data)) {
+    return data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
+  }
+  if (typeof Blob !== 'undefined' && data instanceof Blob) {
+    return data.arrayBuffer();
+  }
+  if (typeof data === 'string') {
+    const buffer = new ArrayBuffer(data.length);
+    const uint8View = new Uint8Array(buffer);
+    for (let i = 0; i < data.length; i += 1) {
+      uint8View[i] = data.charCodeAt(i) & 0xff;
+    }
+    return buffer;
+  }
+  throw new Error('Unsupported ZIP payload type.');
+}
+
+export async function parseCharacterZipData(data) {
+  const buffer = await ensureArrayBuffer(data);
+  const { default: JSZip } = await import('jszip');
+  const zip = await JSZip.loadAsync(buffer);
+  const jsonDataFile = zip.file('character_data.json');
+
+  if (!jsonDataFile) {
+    throw new Error('ZIPファイルに character_data.json が見つかりません。');
+  }
+
+  const jsonContent = await jsonDataFile.async('string');
+  const rawJsonData = JSON.parse(jsonContent);
+
+  const imageEntries = [];
+  const imageFolder = zip.folder('images');
+  if (imageFolder) {
+    const imagePromises = [];
+    imageFolder.forEach((relativePath, fileEntry) => {
+      if (!fileEntry.dir) {
+        const promise = fileEntry
+          .async('base64')
+          .then((base64Data) => {
+            const extension = relativePath.substring(relativePath.lastIndexOf('.') + 1) || 'png';
+            const mimeType = `image/${extension === 'jpg' ? 'jpeg' : extension}`;
+            imageEntries.push({
+              relativePath,
+              imageDataUrl: `data:${mimeType};base64,${base64Data}`,
+            });
+          })
+          .catch((error) => {
+            console.error(`Error loading image ${relativePath} from zip:`, error);
+          });
+        imagePromises.push(promise);
+      }
+    });
+    await Promise.all(imagePromises);
+    sortImageEntries(imageEntries);
+  }
+
+  if (!rawJsonData.character) {
+    rawJsonData.character = {};
+  }
+  rawJsonData.character.images = imageEntries.map((item) => item.imageDataUrl);
+
+  return rawJsonData;
+}

--- a/src/services/driveStorageAdapter.js
+++ b/src/services/driveStorageAdapter.js
@@ -12,8 +12,9 @@ export class DriveStorageAdapter {
   }
 
   async read(id) {
-    const text = await this.gdm.loadFileContent(id);
-    if (!text) return null;
+    const content = await this.gdm.loadFileContent(id);
+    if (!content || content.body === undefined || content.body === null) return null;
+    const text = typeof content.body === 'string' ? content.body : JSON.stringify(content.body);
     return this._deserializeData(text);
   }
 

--- a/tests/unit/__mocks__/jszip.js
+++ b/tests/unit/__mocks__/jszip.js
@@ -6,7 +6,7 @@ import { vi } from 'vitest';
 const JSZip = vi.fn().mockImplementation(() => ({
   file: vi.fn(),
   folder: vi.fn().mockReturnThis(), // method chainingを可能にする
-  generateAsync: vi.fn().mockResolvedValue(new Blob(['zip_blob_content'])),
+  generateAsync: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
 }));
 
 // 静的メソッド loadAsync のモック実装

--- a/tests/unit/driveStorageAdapter.test.js
+++ b/tests/unit/driveStorageAdapter.test.js
@@ -8,7 +8,7 @@ describe('DriveStorageAdapter', () => {
   beforeEach(() => {
     gdm = {
       saveFile: vi.fn().mockResolvedValue({ id: '1' }),
-      loadFileContent: vi.fn().mockResolvedValue(''),
+      loadFileContent: vi.fn().mockResolvedValue({ body: '', mimeType: 'application/json', name: 'test.json' }),
     };
     adapter = new DriveStorageAdapter(gdm);
   });
@@ -25,7 +25,7 @@ describe('DriveStorageAdapter', () => {
       ciphertext: arrayBufferToBase64(new ArrayBuffer(2)),
       iv: arrayBufferToBase64(new Uint8Array(2)),
     });
-    gdm.loadFileContent.mockResolvedValue(payload);
+    gdm.loadFileContent.mockResolvedValue({ body: payload, mimeType: 'application/json', name: 'test.json' });
     const data = await adapter.read('x');
     expect(data.ciphertext.byteLength).toBe(2);
   });


### PR DESCRIPTION
## Summary
- add reusable helpers to package character data with images into ZIP archives and parse them back
- update data and Drive managers to save/load ZIP content alongside JSON, including Google Drive API handling and mocks
- adjust consumers and tests to work with the new Drive file contract and ZIP behavior

## Testing
- npm run lint
- npm test
- npm run e2e *(fails: missing system dependencies for Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68e3663e83408326b6acf638d6bd9981