### PR TITLE
Unify character export pipeline around zip archives

### DIFF
--- a/src/composables/useGoogleDrive.js
+++ b/src/composables/useGoogleDrive.js
@@ -187,7 +187,7 @@ export function useGoogleDrive(dataManager) {
           loadPromise.then((result) => resolve(result)).catch(() => resolve(null));
         },
         folderId,
-        ['application/json'],
+        ['application/json', 'application/zip'],
       );
     });
   }

--- a/src/services/driveStorageAdapter.js
+++ b/src/services/driveStorageAdapter.js
@@ -38,7 +38,7 @@ export class DriveStorageAdapter {
       throw new Error('更新対象のIDが指定されていません');
     }
     const serialized = this._serializeData(data);
-    const result = await this.gdm.saveFile(null, FILE_NAMES[serialized.kind], serialized.body, id);
+    const result = await this.gdm.saveFile(null, FILE_NAMES[serialized.kind], serialized.body, id, serialized.mimeType);
     if (!result || !result.id) {
       throw new Error('Google Drive の共有ファイル更新に失敗しました');
     }

--- a/src/utils/characterSerialization.js
+++ b/src/utils/characterSerialization.js
@@ -1,0 +1,219 @@
+import { deepClone } from './utils.js';
+
+function filterSkills(skills) {
+  if (!Array.isArray(skills)) {
+    return [];
+  }
+  return skills.map((skill) => ({
+    id: skill.id,
+    checked: Boolean(skill.checked),
+    canHaveExperts: Boolean(skill.canHaveExperts),
+    experts: skill.canHaveExperts
+      ? skill.experts?.filter((expert) => expert.value && expert.value.trim() !== '').map((expert) => ({ value: expert.value })) || []
+      : [],
+  }));
+}
+
+function filterSpecialSkills(specialSkills) {
+  if (!Array.isArray(specialSkills)) {
+    return [];
+  }
+  return specialSkills.filter((ss) => ss.group && ss.name);
+}
+
+function filterHistories(histories) {
+  if (!Array.isArray(histories)) {
+    return [];
+  }
+  return histories.filter(
+    (history) =>
+      history.sessionName ||
+      (history.gotExperiments !== null && history.gotExperiments !== '') ||
+      (history.increasedScar !== null && history.increasedScar !== undefined) ||
+      history.memo,
+  );
+}
+
+export function serializeCharacterForExport({ character, skills, specialSkills, equipments, histories, includeImages = true }) {
+  const characterClone = deepClone(character || {});
+  let images = [];
+
+  if (!includeImages) {
+    delete characterClone.images;
+  } else if (Array.isArray(characterClone.images) && characterClone.images.length > 0) {
+    images = characterClone.images.slice();
+    delete characterClone.images;
+  }
+
+  const payload = {
+    character: characterClone,
+    skills: filterSkills(skills),
+    specialSkills: filterSpecialSkills(specialSkills),
+    equipments: deepClone(equipments || {}),
+    histories: filterHistories(histories),
+  };
+
+  return { data: payload, images };
+}
+
+function toTimestampString(date) {
+  const target = date instanceof Date ? date : new Date(date);
+  const year = target.getFullYear();
+  const month = String(target.getMonth() + 1).padStart(2, '0');
+  const day = String(target.getDate()).padStart(2, '0');
+  const hours = String(target.getHours()).padStart(2, '0');
+  const minutes = String(target.getMinutes()).padStart(2, '0');
+  const seconds = String(target.getSeconds()).padStart(2, '0');
+  return `${year}${month}${day}${hours}${minutes}${seconds}`;
+}
+
+function deriveImageExtension(imageDataUrl, index) {
+  if (typeof imageDataUrl !== 'string') {
+    return `image_${index}.png`;
+  }
+  const match = imageDataUrl.match(/^data:image\/(.+?);/i);
+  const ext = match ? match[1].toLowerCase() : 'png';
+  const normalized = ext === 'jpg' ? 'jpeg' : ext;
+  return `image_${index}.${normalized || 'png'}`;
+}
+
+export async function buildCharacterArchive({ data, images = [] }) {
+  const jsonString = JSON.stringify(data, null, 2);
+  const { default: JSZip } = await import('jszip');
+  const zip = new JSZip();
+  zip.file('character_data.json', jsonString);
+
+  if (Array.isArray(images) && images.length > 0) {
+    const imageFolder = zip.folder('images');
+    images.forEach((imageDataUrl, index) => {
+      const fileName = deriveImageExtension(imageDataUrl, index);
+      const base64Data = typeof imageDataUrl === 'string' ? imageDataUrl.substring(imageDataUrl.indexOf(',') + 1) : '';
+      imageFolder.file(fileName, base64Data, { base64: true });
+    });
+  }
+
+  const archive = await zip.generateAsync({ type: 'uint8array' });
+  return {
+    content: archive,
+    mimeType: 'application/zip',
+  };
+}
+
+function isLikelyBase64(str) {
+  return /^[A-Za-z0-9+/=\r\n]+$/.test(str);
+}
+
+function base64ToUint8Array(base64) {
+  const normalized = base64.replace(/\s+/g, '');
+  const binary = atob(normalized);
+  const len = binary.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function stringToUint8Array(str) {
+  const bytes = new Uint8Array(str.length);
+  for (let i = 0; i < str.length; i += 1) {
+    bytes[i] = str.charCodeAt(i) & 0xff;
+  }
+  return bytes;
+}
+
+async function extractImagesFromZip(zip) {
+  const imageFolder = zip.folder('images');
+  if (!imageFolder) {
+    return [];
+  }
+
+  const imageData = [];
+  const tasks = [];
+
+  imageFolder.forEach((relativePath, fileEntry) => {
+    if (fileEntry.dir) {
+      return;
+    }
+    const task = fileEntry
+      .async('base64')
+      .then((base64) => {
+        const extension = relativePath.substring(relativePath.lastIndexOf('.') + 1) || 'png';
+        const mimeType = `image/${extension === 'jpg' ? 'jpeg' : extension}`;
+        imageData.push({
+          path: relativePath,
+          dataUrl: `data:${mimeType};base64,${base64}`,
+        });
+      })
+      .catch((error) => {
+        console.error(`Failed to extract image ${relativePath} from archive:`, error);
+      });
+    tasks.push(task);
+  });
+
+  await Promise.all(tasks);
+
+  imageData.sort((a, b) => {
+    const regex = /image_(\d+)\./i;
+    const matchA = a.path.match(regex);
+    const matchB = b.path.match(regex);
+    const indexA = matchA ? parseInt(matchA[1], 10) : Number.MAX_SAFE_INTEGER;
+    const indexB = matchB ? parseInt(matchB[1], 10) : Number.MAX_SAFE_INTEGER;
+    if (indexA !== indexB) {
+      return indexA - indexB;
+    }
+    return a.path.localeCompare(b.path);
+  });
+
+  return imageData.map((entry) => entry.dataUrl);
+}
+
+export async function deserializeCharacterPayload(content) {
+  if (content == null) {
+    throw new Error('No content to deserialize');
+  }
+
+  if (typeof content === 'string') {
+    try {
+      return JSON.parse(content);
+    } catch (jsonError) {
+      try {
+        const bytes = isLikelyBase64(content) ? base64ToUint8Array(content) : stringToUint8Array(content);
+        return deserializeCharacterPayload(bytes);
+      } catch (nestedError) {
+        throw jsonError;
+      }
+    }
+  }
+
+  if (content instanceof ArrayBuffer) {
+    return deserializeCharacterPayload(new Uint8Array(content));
+  }
+
+  if (ArrayBuffer.isView(content)) {
+    const view = content instanceof Uint8Array ? content : new Uint8Array(content.buffer);
+    const { default: JSZip } = await import('jszip');
+    const zip = await JSZip.loadAsync(view);
+    const jsonFile = zip.file('character_data.json');
+    if (!jsonFile) {
+      throw new Error('character_data.json がアーカイブ内に見つかりません');
+    }
+
+    const jsonContent = await jsonFile.async('string');
+    const parsed = JSON.parse(jsonContent);
+    if (!parsed.character) {
+      parsed.character = {};
+    }
+    const images = await extractImagesFromZip(zip);
+    if (images.length > 0) {
+      parsed.character.images = images;
+    } else if (!Array.isArray(parsed.character.images)) {
+      parsed.character.images = [];
+    }
+    return parsed;
+  }
+
+  throw new Error('Unsupported content type for deserialization');
+}
+
+export { toTimestampString };

--- a/src/utils/characterSerialization.js
+++ b/src/utils/characterSerialization.js
@@ -9,7 +9,7 @@ function filterSkills(skills) {
     checked: Boolean(skill.checked),
     canHaveExperts: Boolean(skill.canHaveExperts),
     experts: skill.canHaveExperts
-      ? skill.experts?.filter((expert) => expert.value && expert.value.trim() !== '').map((expert) => ({ value: expert.value })) || []
+      ? (skill.experts || []).filter((expert) => expert.value && expert.value.trim() !== '').map((expert) => ({ value: expert.value }))
       : [],
   }));
 }

--- a/tests/unit/__mocks__/jszip.js
+++ b/tests/unit/__mocks__/jszip.js
@@ -5,8 +5,8 @@ import { vi } from 'vitest';
 // JSZipコンストラクタのモック実装
 const JSZip = vi.fn().mockImplementation(() => ({
   file: vi.fn(),
-  folder: vi.fn().mockReturnThis(), // method chainingを可能にする
-  generateAsync: vi.fn().mockResolvedValue(new Blob(['zip_blob_content'])),
+  folder: vi.fn().mockReturnValue({ file: vi.fn() }),
+  generateAsync: vi.fn().mockResolvedValue(new Uint8Array([0x01, 0x02])),
 }));
 
 // 静的メソッド loadAsync のモック実装

--- a/tests/unit/dataManager.test.js
+++ b/tests/unit/dataManager.test.js
@@ -16,6 +16,8 @@ describe('DataManager', () => {
   let mockEquipments;
   let mockHistories;
   let currentFileReaderInstance;
+  let mockZipInstance;
+  let mockImageFolder;
 
   beforeEach(() => {
     // 各テストの前に、すべてのモックの状態をリセットします
@@ -53,6 +55,14 @@ describe('DataManager', () => {
     document.body.removeChild = vi.fn();
     const mockAnchor = { click: vi.fn(), href: '', download: '' };
     document.createElement = vi.fn().mockReturnValue(mockAnchor);
+
+    mockImageFolder = { file: vi.fn() };
+    mockZipInstance = {
+      file: vi.fn(),
+      folder: vi.fn().mockReturnValue(mockImageFolder),
+      generateAsync: vi.fn().mockResolvedValue(new Uint8Array([0x01, 0x02])),
+    };
+    JSZip.mockImplementation(() => mockZipInstance);
 
     // FileReaderのモック
     global.FileReader = vi.fn().mockImplementation(() => {
@@ -117,12 +127,15 @@ describe('DataManager', () => {
   });
 
   describe('saveData', () => {
-    it('should save as JSON if no images are present', async () => {
+    it('should save archive even if no images are present', async () => {
       mockCharacter.images = [];
       await dm.saveData(mockCharacter, mockSkills, mockSpecialSkills, mockEquipments, mockHistories);
-      expect(JSZip).not.toHaveBeenCalled();
+      expect(JSZip).toHaveBeenCalledTimes(1);
+      expect(mockZipInstance.file).toHaveBeenCalledWith('character_data.json', expect.any(String));
+      expect(mockZipInstance.folder).not.toHaveBeenCalled();
+      expect(mockZipInstance.generateAsync).toHaveBeenCalledWith({ type: 'uint8array' });
       const mockAnchor = document.createElement.mock.results[0].value;
-      expect(mockAnchor.download).toMatch(/^TestChar_\d{14}\.json$/);
+      expect(mockAnchor.download).toMatch(/^TestChar_\d{14}\.zip$/);
       expect(mockAnchor.click).toHaveBeenCalled();
     });
 
@@ -132,34 +145,26 @@ describe('DataManager', () => {
       const sanitized = dm._sanitizeFileName(mockCharacter.name);
       await dm.saveData(mockCharacter, mockSkills, mockSpecialSkills, mockEquipments, mockHistories);
       const mockAnchor = document.createElement.mock.results[0].value;
-      const regex = new RegExp(`^${sanitized}_\\d{14}\\.json$`);
+      const regex = new RegExp(`^${sanitized}_\\d{14}\\.zip$`);
       expect(mockAnchor.download).toMatch(regex);
     });
 
     it('should save as ZIP if images are present', async () => {
       mockCharacter.images = ['data:image/png;base64,mockimgdata1', 'data:image/jpeg;base64,mockimgdata2'];
-      // `new JSZip()`が呼び出されたときのインスタンスの振る舞いを定義
-      const mockZipInstance = {
-        file: vi.fn(),
-        folder: vi.fn().mockReturnThis(),
-        generateAsync: vi.fn().mockResolvedValue(new Blob(['zip_blob_content'])),
-      };
-      JSZip.mockImplementation(() => mockZipInstance);
-
       await dm.saveData(mockCharacter, mockSkills, mockSpecialSkills, mockEquipments, mockHistories);
       expect(JSZip).toHaveBeenCalledTimes(1);
       expect(mockZipInstance.folder).toHaveBeenCalledWith('images');
 
       // fileメソッドの呼び出しを検証
       expect(mockZipInstance.file).toHaveBeenCalledWith('character_data.json', expect.any(String));
-      expect(mockZipInstance.file).toHaveBeenCalledWith('image_0.png', 'mockimgdata1', { base64: true });
-      expect(mockZipInstance.file).toHaveBeenCalledWith('image_1.jpeg', 'mockimgdata2', { base64: true });
+      expect(mockImageFolder.file).toHaveBeenCalledWith('image_0.png', 'mockimgdata1', { base64: true });
+      expect(mockImageFolder.file).toHaveBeenCalledWith('image_1.jpeg', 'mockimgdata2', { base64: true });
 
       const jsonDataCall = mockZipInstance.file.mock.calls.find((call) => call[0] === 'character_data.json');
       const jsonDataInZip = JSON.parse(jsonDataCall[1]);
       expect(jsonDataInZip.character.images).toBeUndefined();
       expect(mockZipInstance.generateAsync).toHaveBeenCalledWith({
-        type: 'blob',
+        type: 'uint8array',
       });
       const mockAnchor = document.createElement.mock.results[0].value;
       expect(mockAnchor.download).toMatch(/^TestChar_\d{14}\.zip$/);
@@ -200,7 +205,7 @@ describe('DataManager', () => {
       const mockJsonStringInZip = JSON.stringify(mockJsonDataInZip);
       const mockImageBase64Data = 'mockimagedatafromzip';
       const mockImageFileName = 'image_0.png';
-      const mockZipInstance = {
+      const zipLoadMock = {
         file: vi
           .fn()
           .mockImplementation((filename) =>
@@ -220,7 +225,7 @@ describe('DataManager', () => {
           return { forEach: vi.fn() };
         }),
       };
-      JSZip.loadAsync.mockResolvedValue(mockZipInstance);
+      JSZip.loadAsync.mockResolvedValue(zipLoadMock);
       const mockZipFileObj = new File(['zip_content_array_buffer'], 'test.zip', { type: 'application/zip' });
       const mockEvent = { target: { files: [mockZipFileObj], value: '' } };
       await new Promise((resolve) => {
@@ -238,11 +243,11 @@ describe('DataManager', () => {
     });
 
     it('should call onError if ZIP loading fails (e.g. character_data.json missing)', async () => {
-      const mockZipInstance = {
+      const zipLoadMock = {
         file: vi.fn().mockReturnValue(null),
         folder: vi.fn().mockReturnValue({ forEach: vi.fn() }),
       };
-      JSZip.loadAsync.mockResolvedValue(mockZipInstance);
+      JSZip.loadAsync.mockResolvedValue(zipLoadMock);
       const mockZipFileObj = new File(['zip_content'], 'test.zip', {
         type: 'application/zip',
       });
@@ -253,15 +258,15 @@ describe('DataManager', () => {
         dm.handleFileUpload(mockEvent, onSuccessMock, onErrorMock);
       });
       expect(currentFileReaderInstance.readAsArrayBuffer).toHaveBeenCalledWith(mockZipFileObj);
-      expect(onErrorMock).toHaveBeenCalledWith(expect.stringContaining('ZIPファイルに character_data.json が見つかりません。'));
+      expect(onErrorMock).toHaveBeenCalledWith(expect.stringContaining('ZIP: character_data.json がアーカイブ内に見つかりません'));
     });
   });
 
   describe('saveDataToAppData', () => {
     beforeEach(() => {
       dm.googleDriveManager = {
-        createCharacterFile: vi.fn().mockResolvedValue({ id: '1', name: 'c.json' }),
-        updateCharacterFile: vi.fn().mockResolvedValue({ id: '1', name: 'c.json' }),
+        createCharacterFile: vi.fn().mockResolvedValue({ id: '1', name: 'c.zip' }),
+        updateCharacterFile: vi.fn().mockResolvedValue({ id: '1', name: 'c.zip' }),
         findOrCreateAioniaCSFolder: vi.fn().mockResolvedValue('folder-id'),
         isFileInConfiguredFolder: vi.fn().mockResolvedValue(true),
       };
@@ -270,12 +275,23 @@ describe('DataManager', () => {
     test('creates new file when no id', async () => {
       const res = await dm.saveDataToAppData(mockCharacter, mockSkills, mockSpecialSkills, mockEquipments, mockHistories, null);
       expect(dm.googleDriveManager.createCharacterFile).toHaveBeenCalled();
+      const payload = dm.googleDriveManager.createCharacterFile.mock.calls[0][0];
+      expect(payload.mimeType).toBe('application/zip');
+      expect(payload.name).toBe('TestChar');
+      expect(payload.content).toBeInstanceOf(Uint8Array);
       expect(res.id).toBe('1');
     });
 
     test('updates file when id exists', async () => {
       await dm.saveDataToAppData(mockCharacter, mockSkills, mockSpecialSkills, mockEquipments, mockHistories, '1');
-      expect(dm.googleDriveManager.updateCharacterFile).toHaveBeenCalledWith('1', expect.any(Object));
+      expect(dm.googleDriveManager.updateCharacterFile).toHaveBeenCalledWith(
+        '1',
+        expect.objectContaining({
+          mimeType: 'application/zip',
+          name: 'TestChar',
+          content: expect.any(Uint8Array),
+        }),
+      );
     });
 
     test('creates new file when existing file is outside configured folder', async () => {

--- a/tests/unit/dataManager.test.js
+++ b/tests/unit/dataManager.test.js
@@ -258,7 +258,7 @@ describe('DataManager', () => {
         dm.handleFileUpload(mockEvent, onSuccessMock, onErrorMock);
       });
       expect(currentFileReaderInstance.readAsArrayBuffer).toHaveBeenCalledWith(mockZipFileObj);
-      expect(onErrorMock).toHaveBeenCalledWith(expect.stringContaining('ZIP: character_data.json がアーカイブ内に見つかりません'));
+      expect(onErrorMock).toHaveBeenCalledWith(expect.stringContaining('(ZIP: character_data.json がアーカイブ内に見つかりません)'));
     });
   });
 

--- a/tests/unit/driveStorageAdapter.test.js
+++ b/tests/unit/driveStorageAdapter.test.js
@@ -38,6 +38,6 @@ describe('DriveStorageAdapter', () => {
 
   test('update calls saveFile with id', async () => {
     await adapter.update('u1', new Uint8Array(4));
-    expect(gdm.saveFile).toHaveBeenCalledWith(null, expect.stringContaining('pointer'), expect.any(String), 'u1');
+    expect(gdm.saveFile).toHaveBeenCalledWith(null, expect.stringContaining('pointer'), expect.any(String), 'u1', 'text/plain');
   });
 });


### PR DESCRIPTION
## Summary
- centralize character serialization/deserialization in a shared utility and reuse it for download/share flows
- package character data as zip archives for local saves and Google Drive updates, including Drive client and mock adjustments
- update unit tests and JSZip mocks for the archive pipeline and binary upload behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3e52691b083269b84b7738380e9da