### PR TITLE
Localize share and character sheet text

### DIFF
--- a/src/components/common/BaseListItem.vue
+++ b/src/components/common/BaseListItem.vue
@@ -6,7 +6,7 @@
         class="button-base list-button list-button--delete"
         @click="emitDelete"
         :disabled="!canDelete"
-        aria-label="項目を削除"
+        :aria-label="sheetMessages.aria.deleteItem"
       >
         －
       </button>
@@ -16,11 +16,14 @@
 </template>
 
 <script setup>
+import { messages } from '../../locales/ja.js';
+
 defineProps({
   showDeleteButton: Boolean,
   canDelete: { type: Boolean, default: true },
 });
 const emit = defineEmits(['delete-item']);
+const sheetMessages = messages.sheet;
 function emitDelete() {
   emit('delete-item');
 }

--- a/src/components/modals/contents/ShareOptions.vue
+++ b/src/components/modals/contents/ShareOptions.vue
@@ -1,44 +1,59 @@
 <template>
   <div class="share-options">
     <section class="share-options__section">
-      <h3 class="share-options__heading">今後の変更を反映しますか？</h3>
+      <h3 class="share-options__heading">{{ shareOptions.reflection.title }}</h3>
       <div class="share-options__row">
-        <label class="share-options__option"> <input type="radio" value="snapshot" v-model="type" />反映しない </label>
+        <label class="share-options__option">
+          <input type="radio" value="snapshot" v-model="type" />
+          {{ shareOptions.reflection.choices.snapshot }}
+        </label>
       </div>
       <div class="share-options__row">
         <label class="share-options__option">
-          <input type="radio" value="dynamic" v-model="type" />反映する
-          <div class="share-options__note">Google Drive連携が必要です</div>
+          <input type="radio" value="dynamic" v-model="type" />
+          {{ shareOptions.reflection.choices.dynamic }}
+          <div class="share-options__note">{{ shareOptions.reflection.driveRequired }}</div>
         </label>
       </div>
     </section>
     <section class="share-options__section">
-      <h3 class="share-options__heading">追加オプション</h3>
+      <h3 class="share-options__heading">{{ shareOptions.additional.title }}</h3>
       <div class="share-options__row">
         <label class="share-options__option">
-          <input type="checkbox" v-model="includeFull" />画像・メモ（長文の場合）を含める
-          <div class="share-options__note">Google Drive連携が必要です</div>
+          <input type="checkbox" v-model="includeFull" />
+          {{ shareOptions.additional.includeFull }}
+          <div class="share-options__note">{{ shareOptions.additional.driveRequired }}</div>
         </label>
       </div>
-      <p v-if="showTruncateWarning" class="share-options__warning">内容が一部省略される可能性があります</p>
+      <p v-if="showTruncateWarning" class="share-options__warning">{{ shareOptions.additional.truncateWarning }}</p>
       <div class="share-options__row">
-        <label class="share-options__option"> <input type="checkbox" v-model="enablePassword" />パスワード保護 </label>
+        <label class="share-options__option">
+          <input type="checkbox" v-model="enablePassword" />
+          {{ shareOptions.additional.enablePassword }}
+        </label>
       </div>
       <div class="share-options__row" v-if="enablePassword">
-        <input type="text" v-model="password" class="share-options__password-input" />
+        <input
+          type="text"
+          v-model="password"
+          class="share-options__password-input"
+          :placeholder="shareOptions.additional.passwordPlaceholder"
+        />
       </div>
       <div class="share-options__row">
         <label class="share-options__option"
-          >有効期限
+          >{{ shareOptions.additional.expires.label }}
           <select v-model="expires">
-            <option value="1">1日</option>
-            <option value="7">7日</option>
-            <option value="0">無期限</option>
+            <option value="1">{{ shareOptions.additional.expires.options[1] }}</option>
+            <option value="7">{{ shareOptions.additional.expires.options[7] }}</option>
+            <option value="0">{{ shareOptions.additional.expires.options[0] }}</option>
           </select>
         </label>
       </div>
     </section>
-    <button class="button-base share-options__signin" v-if="needSignin" @click="handleSignin">Google Drive にサインイン</button>
+    <button class="button-base share-options__signin" v-if="needSignin" @click="handleSignin">
+      {{ shareOptions.signIn }}
+    </button>
   </div>
 </template>
 
@@ -46,6 +61,7 @@
 import { ref, computed, defineExpose, watchEffect } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useUiStore } from '../../../stores/uiStore.js';
+import { messages } from '../../../locales/ja.js';
 const props = defineProps({ longData: Boolean });
 const emit = defineEmits(['signin', 'update:canGenerate']);
 const type = ref('snapshot');
@@ -55,6 +71,7 @@ const password = ref('');
 const expires = ref('0');
 const uiStore = useUiStore();
 const { isSignedIn } = storeToRefs(uiStore);
+const shareOptions = messages.share.options;
 const needSignin = computed(() => (type.value === 'dynamic' || includeFull.value) && !isSignedIn.value);
 const showTruncateWarning = computed(() => props.longData && !includeFull.value);
 const canGenerate = computed(() => !needSignin.value);

--- a/src/components/sections/AdventureLogSection.vue
+++ b/src/components/sections/AdventureLogSection.vue
@@ -1,14 +1,14 @@
 <template>
   <div id="adventure_log_section" class="adventure-log-section">
-    <div class="box-title">冒険の記録</div>
+    <div class="box-title">{{ sheetMessages.sections.adventureLog.title }}</div>
     <div class="box-content">
       <div class="base-list-header">
         <div class="delete-button-wrapper base-list-header-placeholder"></div>
         <div class="flex-grow">
           <div class="history-item-inputs">
-            <div class="flex-history-name"><label>シナリオ名</label></div>
-            <div class="flex-history-exp"><label>経験点</label></div>
-            <div class="flex-history-scar"><label>傷痕増加</label></div>
+            <div class="flex-history-name"><label>{{ sheetMessages.sections.adventureLog.columns.scenario }}</label></div>
+            <div class="flex-history-exp"><label>{{ sheetMessages.sections.adventureLog.columns.experience }}</label></div>
+            <div class="flex-history-scar"><label>{{ sheetMessages.sections.adventureLog.columns.scar }}</label></div>
             <div class="flex-history-memo"></div>
           </div>
         </div>
@@ -52,7 +52,7 @@
               <div class="flex-history-memo">
                 <BaseInput
                   type="text"
-                  placeholder="メモ"
+                  :placeholder="sheetMessages.placeholders.adventureMemo"
                   :model-value="history.memo"
                   @update:model-value="(v) => characterStore.updateHistoryItem(index, 'memo', v)"
                   :disabled="uiStore.isViewingShared"
@@ -67,7 +67,7 @@
           type="button"
           class="button-base list-button list-button--add"
           @click="characterStore.addHistoryItem"
-          aria-label="冒険記録を追加"
+          :aria-label="sheetMessages.aria.addAdventureLog"
         >
           ＋
         </button>
@@ -81,9 +81,11 @@ import BaseInput from '../common/BaseInput.vue';
 import BaseListItem from '../common/BaseListItem.vue';
 import { useCharacterStore } from '../../stores/characterStore.js';
 import { useUiStore } from '../../stores/uiStore.js';
+import { messages } from '../../locales/ja.js';
 
 const characterStore = useCharacterStore();
 const uiStore = useUiStore();
+const sheetMessages = messages.sheet;
 
 function hasHistoryContent(h) {
   return !!(

--- a/src/components/sections/CharacterBasicInfo.vue
+++ b/src/components/sections/CharacterBasicInfo.vue
@@ -1,15 +1,15 @@
 <template>
   <div id="character_info" class="character-info">
-    <div class="box-title">基本情報</div>
+    <div class="box-title">{{ basicInfoTexts.title }}</div>
     <div class="box-content">
       <CharacterImageDisplay v-model:images="characterStore.character.images" />
       <div class="info-row">
         <div class="info-item info-item--double">
-          <label for="name">キャラクター名</label>
+          <label for="name">{{ basicInfoTexts.fields.name }}</label>
           <input type="text" id="name" v-model="characterStore.character.name" :disabled="uiStore.isViewingShared" />
         </div>
         <div class="info-item info-item--double">
-          <label for="player_name">プレイヤー名</label>
+          <label for="player_name">{{ basicInfoTexts.fields.playerName }}</label>
           <input type="text" id="player_name" v-model="characterStore.character.playerName" :disabled="uiStore.isViewingShared" />
         </div>
       </div>
@@ -21,7 +21,7 @@
             'info-item--double': characterStore.character.species === 'other',
           }"
         >
-          <label for="species">種族</label>
+          <label for="species">{{ basicInfoTexts.fields.species }}</label>
           <select id="species" v-model="characterStore.character.species" @change="handleSpeciesChange" :disabled="uiStore.isViewingShared">
             <option v-for="option in AioniaGameData.speciesOptions" :key="option.value" :value="option.value" :disabled="option.disabled">
               {{ option.label }}
@@ -29,39 +29,39 @@
           </select>
         </div>
         <div class="info-item info-item--double" v-if="characterStore.character.species === 'other'">
-          <label for="rare_species">種族名（希少人種）</label>
+          <label for="rare_species">{{ basicInfoTexts.fields.rareSpecies }}</label>
           <input type="text" id="rare_species" v-model="characterStore.character.rareSpecies" :disabled="uiStore.isViewingShared" />
         </div>
       </div>
       <div class="info-row">
         <div class="info-item info-item--quadruple">
-          <label for="gender">性別</label>
+          <label for="gender">{{ basicInfoTexts.fields.gender }}</label>
           <input type="text" id="gender" v-model="characterStore.character.gender" :disabled="uiStore.isViewingShared" />
         </div>
         <div class="info-item info-item--quadruple">
-          <label for="age">年齢</label>
+          <label for="age">{{ basicInfoTexts.fields.age }}</label>
           <input type="number" id="age" v-model.number="characterStore.character.age" min="0" :disabled="uiStore.isViewingShared" />
         </div>
         <div class="info-item info-item--quadruple">
-          <label for="height">身長</label>
+          <label for="height">{{ basicInfoTexts.fields.height }}</label>
           <input type="text" id="height" v-model="characterStore.character.height" :disabled="uiStore.isViewingShared" />
         </div>
         <div class="info-item info-item--quadruple">
-          <label for="weight_char">体重</label>
+          <label for="weight_char">{{ basicInfoTexts.fields.weight }}</label>
           <input type="text" id="weight_char" v-model="characterStore.character.weight" :disabled="uiStore.isViewingShared" />
         </div>
       </div>
       <div class="info-row">
         <div class="info-item info-item--triple">
-          <label for="origin">出身地</label>
+          <label for="origin">{{ basicInfoTexts.fields.origin }}</label>
           <input type="text" id="origin" v-model="characterStore.character.origin" :disabled="uiStore.isViewingShared" />
         </div>
         <div class="info-item info-item--triple">
-          <label for="occupation">職業</label>
+          <label for="occupation">{{ basicInfoTexts.fields.occupation }}</label>
           <input type="text" id="occupation" v-model="characterStore.character.occupation" :disabled="uiStore.isViewingShared" />
         </div>
         <div class="info-item info-item--triple">
-          <label for="faith">信仰</label>
+          <label for="faith">{{ basicInfoTexts.fields.faith }}</label>
           <input type="text" id="faith" v-model="characterStore.character.faith" :disabled="uiStore.isViewingShared" />
         </div>
       </div>
@@ -74,9 +74,11 @@ import CharacterImageDisplay from '../ui/CharacterImageDisplay.vue';
 import { AioniaGameData } from '../../data/gameData.js';
 import { useCharacterStore } from '../../stores/characterStore.js';
 import { useUiStore } from '../../stores/uiStore.js';
+import { messages } from '../../locales/ja.js';
 
 const characterStore = useCharacterStore();
 const uiStore = useUiStore();
+const basicInfoTexts = messages.sheet.sections.basicInfo;
 
 const handleSpeciesChange = () => {
   characterStore.handleSpeciesChange();

--- a/src/components/sections/CharacterMemoSection.vue
+++ b/src/components/sections/CharacterMemoSection.vue
@@ -1,11 +1,11 @@
 <template>
   <div id="character_memo" class="character-memo">
-    <div class="box-title">キャラクターメモ</div>
+    <div class="box-title">{{ sheetMessages.sections.memo.title }}</div>
     <div class="box-content">
       <textarea
         id="character_text"
         class="character-memo-textarea"
-        :placeholder="AioniaGameData.placeholderTexts.characterMemo"
+        :placeholder="sheetMessages.placeholders.characterMemo"
         v-model="localValue"
         :readonly="uiStore.isViewingShared"
       ></textarea>
@@ -15,12 +15,13 @@
 
 <script setup>
 import { computed } from 'vue';
-import { AioniaGameData } from '../../data/gameData.js';
 import { useCharacterStore } from '../../stores/characterStore.js';
 import { useUiStore } from '../../stores/uiStore.js';
+import { messages } from '../../locales/ja.js';
 
 const characterStore = useCharacterStore();
 const uiStore = useUiStore();
+const sheetMessages = messages.sheet;
 const localValue = computed({
   get: () => characterStore.character.memo,
   set: (val) => {

--- a/src/components/sections/ItemsSection.vue
+++ b/src/components/sections/ItemsSection.vue
@@ -2,10 +2,10 @@
   <div id="items_section" class="items">
     <div class="box-title">
       <div class="box-title-main">
-        <span class="box-title-text">所持品</span>
+        <span class="box-title-text">{{ sheetMessages.sections.items.title }}</span>
         <label class="description-toggle">
           <input type="checkbox" v-model="uiStore.showItemDescriptions" />
-          説明を表示
+          {{ sheetMessages.toggles.showDescription }}
         </label>
       </div>
       <LoadIndicator />
@@ -37,7 +37,7 @@
                   type="text"
                   :id="`${slot.key}_name`"
                   v-model="characterStore.equipments[slot.key].name"
-                  :placeholder="gameData.placeholderTexts[slot.placeholderKey]"
+                  :placeholder="sheetMessages.placeholders[slot.placeholderKey]"
                   class="flex-item-2"
                   :disabled="uiStore.isViewingShared"
                 />
@@ -53,7 +53,7 @@
         </div>
       </div>
       <div>
-        <label for="other_items" class="block-label">その他所持品</label>
+        <label for="other_items" class="block-label">{{ sheetMessages.sections.items.labels.otherItems }}</label>
         <textarea
           id="other_items"
           class="items-textarea"
@@ -71,14 +71,31 @@ import { AioniaGameData as gameData } from '../../data/gameData.js';
 import { useCharacterStore } from '../../stores/characterStore.js';
 import { useUiStore } from '../../stores/uiStore.js';
 import LoadIndicator from '../ui/LoadIndicator.vue';
+import { messages } from '../../locales/ja.js';
 
 const characterStore = useCharacterStore();
 const uiStore = useUiStore();
+const sheetMessages = messages.sheet;
 
 const equipmentSlots = [
-  { key: 'weapon1', label: '武器1', optionsKey: 'weaponOptions', placeholderKey: 'weaponName' },
-  { key: 'weapon2', label: '武器2', optionsKey: 'weaponOptions', placeholderKey: 'weaponName' },
-  { key: 'armor', label: '防具', optionsKey: 'armorOptions', placeholderKey: 'armorName' },
+  {
+    key: 'weapon1',
+    label: sheetMessages.sections.items.labels.slots.weapon1,
+    optionsKey: 'weaponOptions',
+    placeholderKey: 'weaponName',
+  },
+  {
+    key: 'weapon2',
+    label: sheetMessages.sections.items.labels.slots.weapon2,
+    optionsKey: 'weaponOptions',
+    placeholderKey: 'weaponName',
+  },
+  {
+    key: 'armor',
+    label: sheetMessages.sections.items.labels.slots.armor,
+    optionsKey: 'armorOptions',
+    placeholderKey: 'armorName',
+  },
 ];
 
 const optionDescriptionMaps = computed(() =>

--- a/src/components/sections/ScarWeaknessSection.vue
+++ b/src/components/sections/ScarWeaknessSection.vue
@@ -1,12 +1,12 @@
 <template>
   <div id="scar_weakness_section" class="scar-weakness">
-    <div class="box-title">傷痕と弱点</div>
+    <div class="box-title">{{ scarWeaknessTexts.title }}</div>
     <div class="box-content">
       <div class="scar-section">
-        <div class="sub-box-title sub-box-title--scar">傷痕</div>
+        <div class="sub-box-title sub-box-title--scar">{{ scarWeaknessTexts.scar.title }}</div>
         <div class="info-row">
           <div class="info-item info-item--double">
-            <label for="initial_scar">初期値</label>
+            <label for="initial_scar">{{ scarWeaknessTexts.scar.initial }}</label>
             <input
               type="number"
               id="initial_scar"
@@ -16,7 +16,7 @@
             />
           </div>
           <div class="info-item info-item--double">
-            <label for="current_scar" class="link-checkbox-main-label">現在値（初期値+増加分）</label>
+            <label for="current_scar" class="link-checkbox-main-label">{{ scarWeaknessTexts.scar.current }}</label>
             <input
               type="number"
               id="current_scar"
@@ -29,12 +29,12 @@
         </div>
       </div>
       <div class="weakness-section">
-        <div class="sub-box-title sub-box-title--weakness">弱点</div>
+        <div class="sub-box-title sub-box-title--weakness">{{ scarWeaknessTexts.weakness.title }}</div>
         <ul class="weakness-list list-reset">
           <li class="base-list-header">
             <div class="flex-weakness-number base-list-header-placeholder"></div>
-            <div class="flex-weakness-text"><label>弱点</label></div>
-            <div class="flex-weakness-acquired"><label>獲得</label></div>
+            <div class="flex-weakness-text"><label>{{ scarWeaknessTexts.weakness.columns.text }}</label></div>
+            <div class="flex-weakness-acquired"><label>{{ scarWeaknessTexts.weakness.columns.acquired }}</label></div>
           </li>
           <li v-for="(weakness, index) in characterStore.character.weaknesses" :key="index" class="base-list-item">
             <div class="flex-weakness-number">{{ index < 9 ? index + 1 : 'X' }}</div>
@@ -59,9 +59,11 @@
 import { computed } from 'vue';
 import { useCharacterStore } from '../../stores/characterStore.js';
 import { useUiStore } from '../../stores/uiStore.js';
+import { messages } from '../../locales/ja.js';
 
 const characterStore = useCharacterStore();
 const uiStore = useUiStore();
+const scarWeaknessTexts = messages.sheet.sections.scarWeakness;
 const sessionNames = computed(() => characterStore.sessionNamesForWeaknessDropdown);
 const calculatedScar = computed(() => characterStore.calculatedScar);
 </script>

--- a/src/components/sections/SkillsSection.vue
+++ b/src/components/sections/SkillsSection.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="skills" class="skills">
-    <div class="box-title">技能</div>
+    <div class="box-title">{{ sheetMessages.sections.skills.title }}</div>
     <ul class="skills-list box-content list-reset">
       <li v-for="skill in localSkills" :key="skill.id" class="skill-list">
         <div class="skill-header">
@@ -16,7 +16,7 @@
                   class="button-base list-button list-button--delete"
                   @click="characterStore.removeExpert(skill.id, expIndex)"
                   :disabled="skill.experts.length <= 1 && expert.value === ''"
-                  aria-label="専門技能を削除"
+                  :aria-label="sheetMessages.aria.removeExpert"
                 >
                   －
                 </button>
@@ -35,7 +35,7 @@
               type="button"
               class="button-base list-button list-button--add"
               @click="characterStore.addExpert(skill.id)"
-              aria-label="専門技能を追加"
+              :aria-label="sheetMessages.aria.addExpert"
             >
               ＋
             </button>
@@ -47,15 +47,16 @@
 </template>
 
 <script setup>
-import { AioniaGameData } from '../../data/gameData.js';
 import { useCharacterStore } from '../../stores/characterStore.js';
 import { useUiStore } from '../../stores/uiStore.js';
+import { messages } from '../../locales/ja.js';
 
 const characterStore = useCharacterStore();
 const uiStore = useUiStore();
+const sheetMessages = messages.sheet;
 const localSkills = characterStore.skills;
 const expertPlaceholder = (skill) =>
-  skill.checked ? AioniaGameData.placeholderTexts.expertSkill : AioniaGameData.placeholderTexts.expertSkillDisabled;
+  skill.checked ? sheetMessages.placeholders.expertSkill : sheetMessages.placeholders.expertSkillDisabled;
 </script>
 
 <style scoped>

--- a/src/components/sections/SpecialSkillsSection.vue
+++ b/src/components/sections/SpecialSkillsSection.vue
@@ -2,10 +2,10 @@
   <div id="special_skills" class="special-skills">
     <div class="box-title">
       <div class="box-title-main">
-        <span class="box-title-text">特技</span>
+        <span class="box-title-text">{{ sheetMessages.sections.specialSkills.title }}</span>
         <label class="description-toggle">
           <input type="checkbox" v-model="uiStore.showSpecialSkillDescriptions" />
-          説明を表示
+          {{ sheetMessages.toggles.showDescription }}
         </label>
       </div>
     </div>
@@ -13,9 +13,9 @@
       <ul class="list-reset">
         <li class="base-list-header special-skill-list-header">
           <div class="flex-item-delete"></div>
-          <div class="flex-item-group">種類</div>
-          <div class="flex-item-name">名称</div>
-          <div class="flex-item-acquired">獲得</div>
+          <div class="flex-item-group">{{ sheetMessages.sections.specialSkills.columns.group }}</div>
+          <div class="flex-item-name">{{ sheetMessages.sections.specialSkills.columns.name }}</div>
+          <div class="flex-item-acquired">{{ sheetMessages.sections.specialSkills.columns.acquired }}</div>
         </li>
       </ul>
       <ul class="list-reset special-skills-list">
@@ -26,7 +26,7 @@
               class="button-base list-button list-button--delete"
               @click="characterStore.removeSpecialSkill(index)"
               :disabled="localSpecialSkills.length <= 1 && !hasSpecialSkillContent(specialSkill)"
-              aria-label="特技を削除"
+              :aria-label="sheetMessages.aria.removeSpecialSkill"
             >
               －
             </button>
@@ -76,7 +76,7 @@
               v-if="specialSkill.group === 'free'"
               v-model="specialSkill.note"
               class="special-skill-note-input"
-              :placeholder="AioniaGameData.placeholderTexts.specialSkillNote"
+              :placeholder="sheetMessages.placeholders.specialSkillNote"
               :disabled="uiStore.isViewingShared"
             ></textarea>
             <input
@@ -85,7 +85,7 @@
               v-model="specialSkill.note"
               v-show="specialSkill.showNote"
               class="special-skill-note-input"
-              :placeholder="AioniaGameData.placeholderTexts.specialSkillNote"
+              :placeholder="sheetMessages.placeholders.specialSkillNote"
               :disabled="uiStore.isViewingShared"
             />
             <textarea
@@ -105,7 +105,7 @@
           type="button"
           class="button-base list-button list-button--add"
           @click="characterStore.addSpecialSkillItem()"
-          aria-label="特技を追加"
+          :aria-label="sheetMessages.aria.addSpecialSkill"
         >
           ＋
         </button>
@@ -119,9 +119,11 @@ import { computed } from 'vue';
 import { AioniaGameData } from '../../data/gameData.js';
 import { useCharacterStore } from '../../stores/characterStore.js';
 import { useUiStore } from '../../stores/uiStore.js';
+import { messages } from '../../locales/ja.js';
 
 const characterStore = useCharacterStore();
 const uiStore = useUiStore();
+const sheetMessages = messages.sheet;
 const localSpecialSkills = characterStore.specialSkills;
 
 const specialSkillDescriptionMap = computed(() => {

--- a/src/components/ui/CharacterHub.vue
+++ b/src/components/ui/CharacterHub.vue
@@ -3,7 +3,7 @@
     <template v-if="uiStore.isSignedIn">
       <div class="character-hub--actions">
         <div class="character-hub--config">
-          <label class="character-hub--label" for="drive_folder_path">保存先フォルダ</label>
+          <label class="character-hub--label" for="drive_folder_path">{{ hubMessages.driveFolder.label }}</label>
           <div class="character-hub--input-group">
             <input
               id="drive_folder_path"
@@ -11,7 +11,7 @@
               type="text"
               v-model="folderPathInput"
               :disabled="!uiStore.isSignedIn"
-              placeholder="慈悲なきアイオニア"
+              :placeholder="hubMessages.driveFolder.placeholder"
               @blur="commitFolderPath"
               @keyup.enter.prevent="commitFolderPath"
             />
@@ -26,18 +26,22 @@
           </div>
         </div>
         <button class="button-base character-hub--button" :disabled="!isDriveReady" @click="loadCharacterFromDrive">
-          Driveから読み込む
+          {{ hubMessages.buttons.load }}
         </button>
         <button class="button-base character-hub--button" :disabled="!isDriveReady" @click="saveNewCharacter">
-          新しい冒険者として保存
+          {{ hubMessages.buttons.saveNew }}
         </button>
-        <button class="button-base character-hub--button" :disabled="!isOverwriteEnabled" @click="saveOverwrite">上書き保存</button>
-        <button class="button-base character-hub--button" @click="emitSignOut">ログアウト</button>
+        <button class="button-base character-hub--button" :disabled="!isOverwriteEnabled" @click="saveOverwrite">
+          {{ hubMessages.buttons.overwrite }}
+        </button>
+        <button class="button-base character-hub--button" @click="emitSignOut">{{ hubMessages.buttons.signOut }}</button>
       </div>
     </template>
     <template v-else>
       <div class="character-hub--actions">
-        <button class="button-base character-hub--button" :disabled="!canSignIn" @click="emitSignIn">Googleにログイン</button>
+        <button class="button-base character-hub--button" :disabled="!canSignIn" @click="emitSignIn">
+          {{ hubMessages.buttons.signIn }}
+        </button>
       </div>
     </template>
   </div>
@@ -71,7 +75,8 @@ const {
 const canSignIn = computed(() => canSignInToGoogle.value);
 const isOverwriteEnabled = computed(() => isDriveReady.value && !!uiStore.currentDriveFileId);
 const folderPathInput = ref(uiStore.driveFolderPath);
-const changeFolderLabel = messages.characterHub.driveFolder.changeButton;
+const hubMessages = messages.characterHub;
+const changeFolderLabel = hubMessages.driveFolder.changeButton;
 const isFolderPickerEnabled = computed(() => isDriveReady.value && uiStore.isSignedIn);
 
 watch(

--- a/src/components/ui/CharacterImageDisplay.vue
+++ b/src/components/ui/CharacterImageDisplay.vue
@@ -2,12 +2,12 @@
   <div class="character-image-container">
     <div class="image-display-area">
       <div class="image-display-wrapper" v-if="imagesInternal.length > 0">
-        <img v-if="currentImageSrc" :src="currentImageSrc" class="character-image-display" alt="Character Image" />
+        <img v-if="currentImageSrc" :src="currentImageSrc" class="character-image-display" :alt="sheetMessages.images.alt" />
         <button
           @click="previousImage"
           class="button-base button-imagenav button-imagenav--prev"
           :disabled="imagesInternal.length <= 1"
-          aria-label="前の画像"
+          :aria-label="sheetMessages.images.previous"
         >
           &lt;
         </button>
@@ -15,24 +15,26 @@
           @click="nextImage"
           class="button-base button-imagenav button-imagenav--next"
           :disabled="imagesInternal.length <= 1"
-          aria-label="次の画像"
+          :aria-label="sheetMessages.images.next"
         >
           &gt;
         </button>
         <div class="image-count-display">{{ currentImageIndex + 1 }} / {{ imagesInternal.length }}</div>
       </div>
-      <div class="character-image-placeholder" v-else>No Image</div>
+      <div class="character-image-placeholder" v-else>{{ sheetMessages.images.empty }}</div>
     </div>
     <div class="image-controls" v-if="!uiStore.isViewingShared">
       <input type="file" id="character_image_upload" @change="handleImageUpload" accept="image/*" style="display: none" />
-      <label for="character_image_upload" class="button-base imagefile-button imagefile-button--upload">画像を追加</label>
+      <label for="character_image_upload" class="button-base imagefile-button imagefile-button--upload">
+        {{ sheetMessages.images.add }}
+      </label>
       <button
         :disabled="!currentImageSrc"
         @click="removeCurrentImage"
         class="button-base imagefile-button imagefile-button--delete"
-        aria-label="現在の画像を削除"
+        :aria-label="sheetMessages.images.deleteAria"
       >
-        削除
+        {{ sheetMessages.images.delete }}
       </button>
     </div>
   </div>
@@ -54,6 +56,7 @@ const props = defineProps({
 const emit = defineEmits(['update:images']);
 const uiStore = useUiStore();
 const { showToast } = useNotifications();
+const sheetMessages = messages.sheet;
 
 const imagesInternal = ref([...props.images]);
 let updatingFromParent = false;

--- a/src/components/ui/LoadIndicator.vue
+++ b/src/components/ui/LoadIndicator.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="load-indicator">
-    <span class="load-indicator--label"> 荷重: {{ loadValue }}</span>
+    <span class="load-indicator--label"> {{ sheetMessages.loadIndicator.label }}: {{ loadValue }}</span>
     <div class="load-indicator--steps">
       <div v-for="i in 15" :key="i" :class="['load-indicator--step', stepClasses[i - 1]]"></div>
     </div>
@@ -11,6 +11,7 @@
 import { computed } from 'vue';
 import { useCharacterStore } from '../../stores/characterStore.js';
 import { calculateStepClasses } from '../../utils/loadIndicator.js';
+import { messages } from '../../locales/ja.js';
 
 const props = defineProps({
   load: Number,
@@ -20,6 +21,7 @@ const characterStore = useCharacterStore();
 
 const loadValue = computed(() => props.load ?? characterStore.currentWeight);
 const stepClasses = computed(() => calculateStepClasses(loadValue.value));
+const sheetMessages = messages.sheet;
 </script>
 
 <style scoped>

--- a/src/composables/useShare.js
+++ b/src/composables/useShare.js
@@ -55,7 +55,7 @@ export function useShare(dataManager) {
     });
     const id = await manager.uploadAndShareFile(payload, 'share.enc', 'application/json');
     if (!id) {
-      throw new Error('Google Drive へのアップロードに失敗しました');
+      throw new Error(messages.share.errors.uploadFailed);
     }
     return id;
   }

--- a/src/data/gameData.js
+++ b/src/data/gameData.js
@@ -303,16 +303,6 @@ export const AioniaGameData = {
     maxInitialBonus: 20, // 初期ボーナスの上限
   },
 
-  // プレースホルダーテキスト
-  placeholderTexts: {
-    expertSkill: '専門技能',
-    expertSkillDisabled: '専門技能 (技能選択で有効)',
-    weaponName: '装備名',
-    armorName: '装備名',
-    specialSkillNote: '詳細',
-    characterMemo: 'キャラクター背景、設定、その他メモを記入',
-  },
-
   // 設定値
   config: {
     initialSpecialSkillCount: 8,

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -84,10 +84,45 @@ export const messages = {
       title: 'Google Drive',
       message: 'サインインしてください',
     }),
+    options: {
+      reflection: {
+        title: '今後の変更を反映しますか？',
+        choices: {
+          snapshot: '反映しない',
+          dynamic: '反映する',
+        },
+        driveRequired: 'Google Drive連携が必要です',
+      },
+      additional: {
+        title: '追加オプション',
+        includeFull: '画像・メモ（長文の場合）を含める',
+        driveRequired: 'Google Drive連携が必要です',
+        truncateWarning: '内容が一部省略される可能性があります',
+        enablePassword: 'パスワード保護',
+        passwordPlaceholder: 'パスワード',
+        expires: {
+          label: '有効期限',
+          options: {
+            1: '1日',
+            7: '7日',
+            0: '無期限',
+          },
+        },
+      },
+      signIn: 'Google Drive にサインイン',
+    },
     generateFailed: (err) => ({
       title: '共有リンク生成失敗',
       message: err.message,
     }),
+    errors: {
+      uploadFailed: 'Google Drive へのアップロードに失敗しました',
+      missingReadId: '読み込み対象のIDが指定されていません',
+      fetchFailed: 'Google Drive からファイルを取得できませんでした',
+      missingUpdateId: '更新対象のIDが指定されていません',
+      updateFailed: 'Google Drive の共有ファイル更新に失敗しました',
+      managerMissing: 'Google Drive マネージャーが設定されていません',
+    },
     loadError: {
       ...shareLoadErrorTexts,
       toast: (key) => ({
@@ -131,10 +166,25 @@ export const messages = {
     },
     driveFolder: {
       changeButton: '選択',
+      label: '保存先フォルダ',
+      placeholder: '慈悲なきアイオニア',
+    },
+    buttons: {
+      load: 'Driveから読み込む',
+      saveNew: '新しい冒険者として保存',
+      overwrite: '上書き保存',
+      signOut: 'ログアウト',
+      signIn: 'Googleにログイン',
     },
   },
   image: {
     loadError: (err) => ({ title: '画像読み込み失敗', message: err.message }),
+    uploadErrors: {
+      noFile: '画像ファイルが選択されていません。',
+      unsupportedType: '対応していない画像形式です。JPEG、PNG、GIF、WebP、SVG を指定してください。',
+      tooLarge: 'ファイルサイズが大きすぎます（最大10MB）。',
+      readError: '画像の読み込み中にエラーが発生しました。',
+    },
   },
   dataExport: {
     loadError: (msg) => ({ title: '読み込み失敗', message: msg }),
@@ -185,6 +235,107 @@ export const messages = {
           output: '駒出力',
           print: '印刷',
           driveFolder: 'フォルダ変更',
+        },
+      },
+    },
+  },
+  sheet: {
+    loadIndicator: {
+      label: '荷重',
+    },
+    toggles: {
+      showDescription: '説明を表示',
+    },
+    images: {
+      alt: 'キャラクター画像',
+      previous: '前の画像',
+      next: '次の画像',
+      add: '画像を追加',
+      delete: '削除',
+      deleteAria: '現在の画像を削除',
+      empty: '画像はありません',
+    },
+    placeholders: {
+      expertSkill: '専門技能',
+      expertSkillDisabled: '専門技能 (技能選択で有効)',
+      specialSkillNote: '詳細',
+      characterMemo: 'キャラクター背景、設定、その他メモを記入',
+      weaponName: '装備名',
+      armorName: '装備名',
+      adventureMemo: 'メモ',
+    },
+    aria: {
+      deleteItem: '項目を削除',
+      removeExpert: '専門技能を削除',
+      addExpert: '専門技能を追加',
+      removeSpecialSkill: '特技を削除',
+      addSpecialSkill: '特技を追加',
+      addAdventureLog: '冒険記録を追加',
+    },
+    sections: {
+      basicInfo: {
+        title: '基本情報',
+        fields: {
+          name: 'キャラクター名',
+          playerName: 'プレイヤー名',
+          species: '種族',
+          rareSpecies: '種族名（希少人種）',
+          gender: '性別',
+          age: '年齢',
+          height: '身長',
+          weight: '体重',
+          origin: '出身地',
+          occupation: '職業',
+          faith: '信仰',
+        },
+      },
+      scarWeakness: {
+        title: '傷痕と弱点',
+        scar: {
+          title: '傷痕',
+          initial: '初期値',
+          current: '現在値（初期値+増加分）',
+        },
+        weakness: {
+          title: '弱点',
+          columns: {
+            text: '弱点',
+            acquired: '獲得',
+          },
+        },
+      },
+      skills: {
+        title: '技能',
+      },
+      memo: {
+        title: 'キャラクターメモ',
+      },
+      specialSkills: {
+        title: '特技',
+        columns: {
+          group: '種類',
+          name: '名称',
+          acquired: '獲得',
+        },
+      },
+      items: {
+        title: '所持品',
+        labels: {
+          otherItems: 'その他所持品',
+          slots: {
+            weapon1: '武器1',
+            weapon2: '武器2',
+            armor: '防具',
+          },
+        },
+      },
+      adventureLog: {
+        title: '冒険の記録',
+        columns: {
+          scenario: 'シナリオ名',
+          experience: '経験点',
+          scar: '傷痕増加',
+          memo: 'メモ',
         },
       },
     },

--- a/src/services/driveStorageAdapter.js
+++ b/src/services/driveStorageAdapter.js
@@ -1,4 +1,5 @@
 import { arrayBufferToBase64, base64ToArrayBuffer } from '../libs/sabalessshare/src/crypto.js';
+import { messages } from '../locales/ja.js';
 
 const FILE_NAMES = {
   data: 'sls_dynamic_data.json',
@@ -15,7 +16,7 @@ export class DriveStorageAdapter {
     const serialized = this._serializeData(data);
     const id = await this.gdm.uploadAndShareFile(serialized.body, FILE_NAMES[serialized.kind], serialized.mimeType);
     if (!id) {
-      throw new Error('Google Drive へのアップロードに失敗しました');
+      throw new Error(messages.share.errors.uploadFailed);
     }
     return id;
   }
@@ -23,11 +24,11 @@ export class DriveStorageAdapter {
   async read(id) {
     this._ensureManager();
     if (!id) {
-      throw new Error('読み込み対象のIDが指定されていません');
+      throw new Error(messages.share.errors.missingReadId);
     }
     const text = await this.gdm.loadFileContent(id);
     if (!text) {
-      throw new Error('Google Drive からファイルを取得できませんでした');
+      throw new Error(messages.share.errors.fetchFailed);
     }
     return this._deserializeData(text);
   }
@@ -35,12 +36,12 @@ export class DriveStorageAdapter {
   async update(id, data) {
     this._ensureManager();
     if (!id) {
-      throw new Error('更新対象のIDが指定されていません');
+      throw new Error(messages.share.errors.missingUpdateId);
     }
     const serialized = this._serializeData(data);
     const result = await this.gdm.saveFile(null, FILE_NAMES[serialized.kind], serialized.body, id, serialized.mimeType);
     if (!result || !result.id) {
-      throw new Error('Google Drive の共有ファイル更新に失敗しました');
+      throw new Error(messages.share.errors.updateFailed);
     }
   }
 
@@ -80,7 +81,7 @@ export class DriveStorageAdapter {
 
   _ensureManager() {
     if (!this.gdm) {
-      throw new Error('Google Drive マネージャーが設定されていません');
+      throw new Error(messages.share.errors.managerMissing);
     }
   }
 }

--- a/src/services/imageManager.js
+++ b/src/services/imageManager.js
@@ -1,4 +1,4 @@
-// src/imageManager.js
+import { messages } from '../locales/ja.js';
 
 export const ImageManager = {
   /**
@@ -12,17 +12,17 @@ export const ImageManager = {
       const maxSize = 10 * 1024 * 1024; // 10 MB
 
       if (!file) {
-        reject(new Error('No file provided.'));
+        reject(new Error(messages.image.uploadErrors.noFile));
         return;
       }
 
       if (!allowedTypes.includes(file.type)) {
-        reject(new Error('Unsupported file type. Please upload JPEG, PNG, GIF, or WebP images.'));
+        reject(new Error(messages.image.uploadErrors.unsupportedType));
         return;
       }
 
       if (file.size > maxSize) {
-        reject(new Error('File is too large. Maximum size is 10MB.'));
+        reject(new Error(messages.image.uploadErrors.tooLarge));
         return;
       }
 
@@ -36,7 +36,7 @@ export const ImageManager = {
       };
       reader.onerror = (e) => {
         console.error('FileReader error:', e);
-        reject(new Error('Error reading file.'));
+        reject(new Error(messages.image.uploadErrors.readError));
       };
       reader.readAsDataURL(file); // Reads the file as a base64 encoded string
     });


### PR DESCRIPTION
## Summary
- add structured locale entries for share options, drive errors, sheet labels, and image upload messaging
- update share modal, Google Drive integration, and image manager to read user-facing text from the locale tables
- replace hard-coded character sheet labels, placeholders, and aria text with locale-driven copies for consistent localization

## Testing
- npm run lint
- npm test
- npm run e2e *(fails: Playwright browsers require missing system dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e478cd06c8832686ae724ddb9a8cb6