### PR TITLE
Ensure shared payload includes character images

### DIFF
--- a/src/composables/useShare.js
+++ b/src/composables/useShare.js
@@ -21,11 +21,15 @@ export function useShare(dataManager) {
       includeImages: includeFull,
     });
 
-    if (includeFull && images.length > 0) {
-      data.character.images = images;
-    }
+    const payload = {
+      ...data,
+      character: {
+        ...(data.character || {}),
+        ...(includeFull && images.length > 0 ? { images } : {}),
+      },
+    };
 
-    return new TextEncoder().encode(JSON.stringify(data)).buffer;
+    return new TextEncoder().encode(JSON.stringify(payload)).buffer;
   }
 
   function isLongData() {

--- a/tests/unit/composables/useShare.test.js
+++ b/tests/unit/composables/useShare.test.js
@@ -2,12 +2,29 @@ import { setActivePinia, createPinia } from 'pinia';
 import { useShare } from '../../../src/composables/useShare.js';
 import { useCharacterStore } from '../../../src/stores/characterStore.js';
 
-vi.mock('../../../src/libs/sabalessshare/src/index.js', () => ({
-  createShareLink: vi.fn(async ({ uploadHandler }) => {
-    await uploadHandler({ ciphertext: new ArrayBuffer(4), iv: new Uint8Array(12) });
+const { shareLinkCalls, dynamicLinkCalls, createShareLinkMock, createDynamicLinkMock } = vi.hoisted(() => {
+  const shareCalls = [];
+  const dynamicCalls = [];
+  const shareMock = vi.fn(async (options) => {
+    shareCalls.push(options);
+    if (typeof options.uploadHandler === 'function') {
+      await options.uploadHandler({ ciphertext: new ArrayBuffer(4), iv: new Uint8Array(12) });
+    }
     return 'link';
-  }),
-  createDynamicLink: vi.fn(),
+  });
+  const dynamicMock = vi.fn(async (options) => {
+    dynamicCalls.push(options);
+    return { shareLink: 'dynamic-link' };
+  });
+  return { shareLinkCalls: shareCalls, dynamicLinkCalls: dynamicCalls, createShareLinkMock: shareMock, createDynamicLinkMock: dynamicMock };
+});
+
+vi.mock('../../../src/libs/sabalessshare/src/index.js', () => ({
+  createShareLink: createShareLinkMock,
+}));
+
+vi.mock('../../../src/libs/sabalessshare/src/dynamic.js', () => ({
+  createDynamicLink: createDynamicLinkMock,
 }));
 
 vi.mock('../../../src/libs/sabalessshare/src/crypto.js', async () => await import('../__mocks__/sabalessshare.js'));
@@ -19,8 +36,10 @@ vi.mock('../../../src/composables/useNotifications.js', () => ({
 describe('useShare', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    shareLinkCalls.length = 0;
+    dynamicLinkCalls.length = 0;
     const store = useCharacterStore();
-    store.character = { name: 'Hero' };
+    store.character = { name: 'Hero', images: [] };
     store.skills = [];
     store.specialSkills = [];
     store.equipments = {};
@@ -44,5 +63,45 @@ describe('useShare', () => {
     await expect(generateShare({ type: 'snapshot', includeFull: true, password: '', expiresInDays: 0 })).rejects.toThrow(
       'Google Drive へのアップロードに失敗しました',
     );
+  });
+
+  test('includes images in cloud share payload when includeFull is true', async () => {
+    const store = useCharacterStore();
+    const images = ['data:image/png;base64,AAA', 'data:image/jpeg;base64,BBB'];
+    store.character = { name: 'Hero', images };
+
+    const googleDriveManager = { uploadAndShareFile: vi.fn().mockResolvedValue('file-id') };
+    const { generateShare } = useShare({ googleDriveManager });
+
+    const result = await generateShare({ type: 'snapshot', includeFull: true, password: '', expiresInDays: 0 });
+    expect(result).toBe('link');
+    expect(createShareLinkMock).toHaveBeenCalledTimes(1);
+    expect(shareLinkCalls).toHaveLength(1);
+
+    const [{ data }] = shareLinkCalls;
+    const payload = JSON.parse(new TextDecoder().decode(new Uint8Array(data)));
+    expect(payload.character.images).toEqual(images);
+    expect(payload.skills).toEqual([]);
+  });
+
+  test('includes images in dynamic share payload when includeFull is true', async () => {
+    const store = useCharacterStore();
+    const images = ['data:image/png;base64,CCC'];
+    store.character = { name: 'Hero', images };
+
+    const googleDriveManager = {
+      uploadAndShareFile: vi.fn().mockResolvedValueOnce('data-file').mockResolvedValueOnce('pointer-file'),
+    };
+    const { generateShare } = useShare({ googleDriveManager });
+
+    const result = await generateShare({ type: 'dynamic', includeFull: true, password: '', expiresInDays: 0 });
+    expect(result).toBe('dynamic-link');
+    expect(createDynamicLinkMock).toHaveBeenCalledTimes(1);
+    expect(dynamicLinkCalls).toHaveLength(1);
+
+    const [{ data }] = dynamicLinkCalls;
+    const payload = JSON.parse(new TextDecoder().decode(new Uint8Array(data)));
+    expect(payload.character.images).toEqual(images);
+    expect(payload.skills).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- ensure the share payload rebuilds the character object with images before encoding
- extend useShare unit coverage to confirm cloud and dynamic shares embed image data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e49208e27c832692495430097483d6