### PR TITLE
Add parent folder support to shared Drive uploads

### DIFF
--- a/src/composables/useShare.js
+++ b/src/composables/useShare.js
@@ -53,7 +53,15 @@ export function useShare(dataManager) {
       ciphertext: arrayBufferToBase64(data.ciphertext),
       iv: arrayBufferToBase64(data.iv),
     });
-    const id = await manager.uploadAndShareFile(payload, 'share.enc', 'application/json');
+    let parentFolderId = null;
+    if (typeof manager.findOrCreateAioniaCSFolder === 'function') {
+      try {
+        parentFolderId = await manager.findOrCreateAioniaCSFolder();
+      } catch (error) {
+        console.error('Failed to resolve Drive folder for shared snapshot upload:', error);
+      }
+    }
+    const id = await manager.uploadAndShareFile(payload, 'share.enc', 'application/json', parentFolderId ?? null);
     if (!id) {
       throw new Error(messages.share.errors.uploadFailed);
     }

--- a/src/services/driveStorageAdapter.js
+++ b/src/services/driveStorageAdapter.js
@@ -14,7 +14,15 @@ export class DriveStorageAdapter {
   async create(data) {
     this._ensureManager();
     const serialized = this._serializeData(data);
-    const id = await this.gdm.uploadAndShareFile(serialized.body, FILE_NAMES[serialized.kind], serialized.mimeType);
+    let parentFolderId = null;
+    if (typeof this.gdm.findOrCreateAioniaCSFolder === 'function') {
+      try {
+        parentFolderId = await this.gdm.findOrCreateAioniaCSFolder();
+      } catch (error) {
+        console.error('Failed to resolve Drive folder for shared file upload:', error);
+      }
+    }
+    const id = await this.gdm.uploadAndShareFile(serialized.body, FILE_NAMES[serialized.kind], serialized.mimeType, parentFolderId ?? null);
     if (!id) {
       throw new Error(messages.share.errors.uploadFailed);
     }

--- a/src/services/googleDriveManager.js
+++ b/src/services/googleDriveManager.js
@@ -712,7 +712,7 @@ export class GoogleDriveManager {
    * @param {string} mimeType
    * @returns {Promise<string|null>} Uploaded file ID
    */
-  async uploadAndShareFile(fileContent, fileName, mimeType) {
+  async uploadAndShareFile(fileContent, fileName, mimeType, parentFolderId = null) {
     if (!gapi.client || !gapi.client.drive) {
       console.error('GAPI client or Drive API not loaded for uploadAndShareFile.');
       return null;
@@ -722,6 +722,9 @@ export class GoogleDriveManager {
       const delimiter = `\r\n--${boundary}\r\n`;
       const closeDelim = `\r\n--${boundary}--`;
       const metadata = { name: fileName, mimeType };
+      if (parentFolderId) {
+        metadata.parents = [parentFolderId];
+      }
       const payload = prepareMultipartPayload(fileContent);
       const multipartRequestBody =
         delimiter +

--- a/src/services/mockGoogleDriveManager.js
+++ b/src/services/mockGoogleDriveManager.js
@@ -226,8 +226,9 @@ export class MockGoogleDriveManager {
     return file ? file.content : null;
   }
 
-  async uploadAndShareFile(fileContent, fileName, mimeType = 'application/json') {
-    const info = await this.saveFile('shared', fileName, fileContent, null, mimeType);
+  async uploadAndShareFile(fileContent, fileName, mimeType = 'application/json', parentFolderId = null) {
+    const targetParent = parentFolderId ?? 'shared';
+    const info = await this.saveFile(targetParent, fileName, fileContent, null, mimeType);
     return info.id;
   }
 

--- a/tests/unit/composables/useShare.test.js
+++ b/tests/unit/composables/useShare.test.js
@@ -39,10 +39,20 @@ describe('useShare', () => {
   });
 
   test('rejects when uploadAndShareFile returns null', async () => {
-    const googleDriveManager = { uploadAndShareFile: vi.fn().mockResolvedValue(null) };
+    const googleDriveManager = {
+      uploadAndShareFile: vi.fn().mockResolvedValue(null),
+      findOrCreateAioniaCSFolder: vi.fn().mockResolvedValue('folder-xyz'),
+    };
     const { generateShare } = useShare({ googleDriveManager });
     await expect(generateShare({ type: 'snapshot', includeFull: true, password: '', expiresInDays: 0 })).rejects.toThrow(
       'Google Drive へのアップロードに失敗しました',
+    );
+    expect(googleDriveManager.findOrCreateAioniaCSFolder).toHaveBeenCalled();
+    expect(googleDriveManager.uploadAndShareFile).toHaveBeenCalledWith(
+      expect.stringContaining('ciphertext'),
+      'share.enc',
+      'application/json',
+      'folder-xyz',
     );
   });
 });

--- a/tests/unit/driveStorageAdapter.test.js
+++ b/tests/unit/driveStorageAdapter.test.js
@@ -10,6 +10,7 @@ describe('DriveStorageAdapter', () => {
       uploadAndShareFile: vi.fn().mockResolvedValue('1'),
       saveFile: vi.fn().mockResolvedValue({ id: '1' }),
       loadFileContent: vi.fn().mockResolvedValue(''),
+      findOrCreateAioniaCSFolder: vi.fn().mockResolvedValue('folder-123'),
     };
     adapter = new DriveStorageAdapter(gdm);
   });
@@ -18,7 +19,13 @@ describe('DriveStorageAdapter', () => {
     const buf = new ArrayBuffer(8);
     const id = await adapter.create({ ciphertext: buf, iv: new Uint8Array(8) });
     expect(id).toBe('1');
-    expect(gdm.uploadAndShareFile).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('data'), 'application/json');
+    expect(gdm.uploadAndShareFile).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('data'),
+      'application/json',
+      'folder-123',
+    );
+    expect(gdm.findOrCreateAioniaCSFolder).toHaveBeenCalled();
   });
 
   test('read parses saved content', async () => {


### PR DESCRIPTION
## Summary
- allow `GoogleDriveManager.uploadAndShareFile` to accept an optional parent folder so shared uploads can inherit a folder
- resolve the configured Drive folder before invoking shared uploads from the drive storage adapter and share composable
- update the Drive mocks and unit tests to cover the parent folder being passed through when uploading shared files

## Testing
- npm run lint
- npm test
- npm run e2e *(fails: browser dependencies missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a501ee2c8326b34fa7994dbf3cc3