### PR TITLE
feat: set parent folder when sharing Drive files

### DIFF
--- a/src/composables/useShare.js
+++ b/src/composables/useShare.js
@@ -53,7 +53,8 @@ export function useShare(dataManager) {
       ciphertext: arrayBufferToBase64(data.ciphertext),
       iv: arrayBufferToBase64(data.iv),
     });
-    const id = await manager.uploadAndShareFile(payload, 'share.enc', 'application/json');
+    const parentFolderId = typeof manager.findOrCreateAioniaCSFolder === 'function' ? await manager.findOrCreateAioniaCSFolder() : null;
+    const id = await manager.uploadAndShareFile(payload, 'share.enc', 'application/json', parentFolderId);
     if (!id) {
       throw new Error(messages.share.errors.uploadFailed);
     }

--- a/src/services/driveStorageAdapter.js
+++ b/src/services/driveStorageAdapter.js
@@ -14,7 +14,8 @@ export class DriveStorageAdapter {
   async create(data) {
     this._ensureManager();
     const serialized = this._serializeData(data);
-    const id = await this.gdm.uploadAndShareFile(serialized.body, FILE_NAMES[serialized.kind], serialized.mimeType);
+    const parentFolderId = typeof this.gdm.findOrCreateAioniaCSFolder === 'function' ? await this.gdm.findOrCreateAioniaCSFolder() : null;
+    const id = await this.gdm.uploadAndShareFile(serialized.body, FILE_NAMES[serialized.kind], serialized.mimeType, parentFolderId);
     if (!id) {
       throw new Error(messages.share.errors.uploadFailed);
     }

--- a/src/services/googleDriveManager.js
+++ b/src/services/googleDriveManager.js
@@ -710,9 +710,10 @@ export class GoogleDriveManager {
    * @param {string|ArrayBuffer} fileContent
    * @param {string} fileName
    * @param {string} mimeType
+   * @param {string|null} parentFolderId - Optional parent folder ID.
    * @returns {Promise<string|null>} Uploaded file ID
    */
-  async uploadAndShareFile(fileContent, fileName, mimeType) {
+  async uploadAndShareFile(fileContent, fileName, mimeType, parentFolderId = null) {
     if (!gapi.client || !gapi.client.drive) {
       console.error('GAPI client or Drive API not loaded for uploadAndShareFile.');
       return null;
@@ -722,6 +723,9 @@ export class GoogleDriveManager {
       const delimiter = `\r\n--${boundary}\r\n`;
       const closeDelim = `\r\n--${boundary}--`;
       const metadata = { name: fileName, mimeType };
+      if (parentFolderId) {
+        metadata.parents = [parentFolderId];
+      }
       const payload = prepareMultipartPayload(fileContent);
       const multipartRequestBody =
         delimiter +

--- a/src/services/mockGoogleDriveManager.js
+++ b/src/services/mockGoogleDriveManager.js
@@ -226,8 +226,9 @@ export class MockGoogleDriveManager {
     return file ? file.content : null;
   }
 
-  async uploadAndShareFile(fileContent, fileName, mimeType = 'application/json') {
-    const info = await this.saveFile('shared', fileName, fileContent, null, mimeType);
+  async uploadAndShareFile(fileContent, fileName, mimeType = 'application/json', parentFolderId = null) {
+    const targetParent = parentFolderId ?? 'shared';
+    const info = await this.saveFile(targetParent, fileName, fileContent, null, mimeType);
     return info.id;
   }
 

--- a/tests/unit/composables/useShare.test.js
+++ b/tests/unit/composables/useShare.test.js
@@ -45,4 +45,15 @@ describe('useShare', () => {
       'Google Drive へのアップロードに失敗しました',
     );
   });
+
+  test('uploads snapshot data into the configured Drive folder', async () => {
+    const googleDriveManager = {
+      uploadAndShareFile: vi.fn().mockResolvedValue('file-1'),
+      findOrCreateAioniaCSFolder: vi.fn().mockResolvedValue('folder-1'),
+    };
+    const { generateShare } = useShare({ googleDriveManager });
+    await expect(generateShare({ type: 'snapshot', includeFull: true, password: '', expiresInDays: 0 })).resolves.toBe('link');
+    expect(googleDriveManager.findOrCreateAioniaCSFolder).toHaveBeenCalled();
+    expect(googleDriveManager.uploadAndShareFile).toHaveBeenCalledWith(expect.any(String), 'share.enc', 'application/json', 'folder-1');
+  });
 });

--- a/tests/unit/driveStorageAdapter.test.js
+++ b/tests/unit/driveStorageAdapter.test.js
@@ -10,6 +10,7 @@ describe('DriveStorageAdapter', () => {
       uploadAndShareFile: vi.fn().mockResolvedValue('1'),
       saveFile: vi.fn().mockResolvedValue({ id: '1' }),
       loadFileContent: vi.fn().mockResolvedValue(''),
+      findOrCreateAioniaCSFolder: vi.fn().mockResolvedValue('folder-1'),
     };
     adapter = new DriveStorageAdapter(gdm);
   });
@@ -18,7 +19,13 @@ describe('DriveStorageAdapter', () => {
     const buf = new ArrayBuffer(8);
     const id = await adapter.create({ ciphertext: buf, iv: new Uint8Array(8) });
     expect(id).toBe('1');
-    expect(gdm.uploadAndShareFile).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('data'), 'application/json');
+    expect(gdm.findOrCreateAioniaCSFolder).toHaveBeenCalled();
+    expect(gdm.uploadAndShareFile).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('data'),
+      'application/json',
+      'folder-1',
+    );
   });
 
   test('read parses saved content', async () => {


### PR DESCRIPTION
## Summary
- allow Google Drive uploads for shared files to accept a parent folder id
- resolve the configured Drive folder before creating shared uploads and pass it through
- update mocks and unit tests to verify the parent folder is applied when sharing

## Testing
- npx vitest run tests/unit/driveStorageAdapter.test.js tests/unit/composables/useShare.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e4a501ee2c8326b34fa7994dbf3cc3