### PR TITLE
Refactor Drive sharing workflow

### DIFF
--- a/src/composables/useShare.js
+++ b/src/composables/useShare.js
@@ -46,14 +46,19 @@ export function useShare(dataManager) {
 
   async function _uploadHandler(data) {
     const manager = dataManager.googleDriveManager;
-    if (!manager || typeof manager.uploadAndShareFile !== 'function') {
+    if (!manager || typeof manager.saveFile !== 'function') {
       throw new Error(messages.share.needSignIn().message);
     }
     const payload = JSON.stringify({
       ciphertext: arrayBufferToBase64(data.ciphertext),
       iv: arrayBufferToBase64(data.iv),
     });
-    const id = await manager.uploadAndShareFile(payload, 'share.enc', 'application/json');
+    const folderId = typeof manager.findOrCreateAioniaCSFolder === 'function' ? await manager.findOrCreateAioniaCSFolder() : null;
+    const result = await manager.saveFile(folderId, 'share.enc', payload, {
+      mimeType: 'application/json',
+      sharePublicly: true,
+    });
+    const id = result?.id;
     if (!id) {
       throw new Error(messages.share.errors.uploadFailed);
     }

--- a/src/services/dataManager.js
+++ b/src/services/dataManager.js
@@ -131,13 +131,10 @@ export class DataManager {
     const sanitizedFileName = `${this._sanitizeFileName(character.name)}.zip`;
 
     try {
-      const result = await this.googleDriveManager.saveFile(
-        targetFolderId,
-        sanitizedFileName,
-        archive.content,
-        currentFileId,
-        archive.mimeType,
-      );
+      const result = await this.googleDriveManager.saveFile(targetFolderId, sanitizedFileName, archive.content, {
+        fileId: currentFileId,
+        mimeType: archive.mimeType,
+      });
       return result;
     } catch (error) {
       console.error('Error saving data to Google Drive:', error);

--- a/src/services/mockGoogleDriveManager.js
+++ b/src/services/mockGoogleDriveManager.js
@@ -208,14 +208,17 @@ export class MockGoogleDriveManager {
       .map((file) => ({ id: file.id, name: file.name }));
   }
 
-  async saveFile(folderId, fileName, fileContent, fileId = null, mimeType = 'application/json') {
+  async saveFile(folderId, fileName, fileContent, options = {}) {
+    const { fileId = null, mimeType = 'application/json', sharePublicly = false } = options;
     const id = fileId || `file-${this.state.fileCounter++}`;
+    const previous = this.state.files[id] || {};
     this.state.files[id] = {
       id,
       name: fileName,
       content: fileContent,
       parentId: folderId,
       mimeType,
+      shared: sharePublicly || Boolean(previous.shared),
     };
     this._saveState();
     return { id, name: fileName };
@@ -224,11 +227,6 @@ export class MockGoogleDriveManager {
   async loadFileContent(fileId) {
     const file = this.state.files[fileId];
     return file ? file.content : null;
-  }
-
-  async uploadAndShareFile(fileContent, fileName, mimeType = 'application/json') {
-    const info = await this.saveFile('shared', fileName, fileContent, null, mimeType);
-    return info.id;
   }
 
   showFilePicker(callback, parentFolderId = null) {
@@ -292,7 +290,7 @@ export class MockGoogleDriveManager {
     const mimeType = payload?.mimeType || 'application/zip';
     const extension = mimeType === 'application/zip' ? 'zip' : 'json';
     const fileName = `${sanitizeFileName(payload?.name)}.${extension}`;
-    return this.saveFile(folderId, fileName, payload?.content || '', null, mimeType);
+    return this.saveFile(folderId, fileName, payload?.content || '', { mimeType });
   }
 
   async updateCharacterFile(id, payload) {
@@ -301,7 +299,7 @@ export class MockGoogleDriveManager {
     const mimeType = payload?.mimeType || 'application/zip';
     const extension = mimeType === 'application/zip' ? 'zip' : 'json';
     const fileName = `${sanitizeFileName(payload?.name)}.${extension}`;
-    return this.saveFile(folderId, fileName, payload?.content || '', id, mimeType);
+    return this.saveFile(folderId, fileName, payload?.content || '', { fileId: id, mimeType });
   }
 
   async loadCharacterFile(id) {

--- a/tests/unit/composables/useShare.test.js
+++ b/tests/unit/composables/useShare.test.js
@@ -38,11 +38,24 @@ describe('useShare', () => {
     );
   });
 
-  test('rejects when uploadAndShareFile returns null', async () => {
-    const googleDriveManager = { uploadAndShareFile: vi.fn().mockResolvedValue(null) };
+  test('rejects when saveFile returns null', async () => {
+    const googleDriveManager = {
+      saveFile: vi.fn().mockResolvedValue(null),
+      findOrCreateAioniaCSFolder: vi.fn().mockResolvedValue('folder-1'),
+    };
     const { generateShare } = useShare({ googleDriveManager });
     await expect(generateShare({ type: 'snapshot', includeFull: true, password: '', expiresInDays: 0 })).rejects.toThrow(
       'Google Drive へのアップロードに失敗しました',
+    );
+    expect(googleDriveManager.findOrCreateAioniaCSFolder).toHaveBeenCalled();
+    expect(googleDriveManager.saveFile).toHaveBeenCalledWith(
+      'folder-1',
+      'share.enc',
+      expect.any(String),
+      expect.objectContaining({
+        mimeType: 'application/json',
+        sharePublicly: true,
+      }),
     );
   });
 });

--- a/tests/unit/driveStorageAdapter.test.js
+++ b/tests/unit/driveStorageAdapter.test.js
@@ -7,9 +7,9 @@ describe('DriveStorageAdapter', () => {
   let gdm;
   beforeEach(() => {
     gdm = {
-      uploadAndShareFile: vi.fn().mockResolvedValue('1'),
       saveFile: vi.fn().mockResolvedValue({ id: '1' }),
       loadFileContent: vi.fn().mockResolvedValue(''),
+      findOrCreateAioniaCSFolder: vi.fn().mockResolvedValue('folder-1'),
     };
     adapter = new DriveStorageAdapter(gdm);
   });
@@ -18,7 +18,15 @@ describe('DriveStorageAdapter', () => {
     const buf = new ArrayBuffer(8);
     const id = await adapter.create({ ciphertext: buf, iv: new Uint8Array(8) });
     expect(id).toBe('1');
-    expect(gdm.uploadAndShareFile).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('data'), 'application/json');
+    expect(gdm.saveFile).toHaveBeenCalledWith(
+      'folder-1',
+      'sls_dynamic_data.json',
+      expect.any(String),
+      expect.objectContaining({
+        mimeType: 'application/json',
+        sharePublicly: true,
+      }),
+    );
   });
 
   test('read parses saved content', async () => {
@@ -38,6 +46,15 @@ describe('DriveStorageAdapter', () => {
 
   test('update calls saveFile with id', async () => {
     await adapter.update('u1', new Uint8Array(4));
-    expect(gdm.saveFile).toHaveBeenCalledWith(null, expect.stringContaining('pointer'), expect.any(String), 'u1', 'text/plain');
+    expect(gdm.saveFile).toHaveBeenCalledWith(
+      null,
+      expect.stringContaining('pointer'),
+      expect.any(String),
+      expect.objectContaining({
+        fileId: 'u1',
+        mimeType: 'text/plain',
+        sharePublicly: true,
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- extend GoogleDriveManager.saveFile with options for MIME type, updates, and optional public sharing, and remove the redundant uploadAndShareFile helper
- update sharing flows to pass configured Drive folder IDs and request public permissions through the new saveFile API
- refresh mocks and unit tests to cover the revised sharing contract and folder handling

## Testing
- npm run lint
- npm test
- npm run e2e *(fails: host system missing Playwright browser dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e4afdb344c83269fbc02d8a3d9f840