### PR TITLE
Clarify configured Drive folder terminology

### DIFF
--- a/src/services/dataManager.js
+++ b/src/services/dataManager.js
@@ -146,8 +146,8 @@ export class DataManager {
   }
 
   /**
-   * Saves character data to the user's appDataFolder.
-   * Adds an index entry when creating a new file.
+   * Saves character data to the configured Google Drive character folder.
+   * Handles both creating new files and updating existing ones without index management.
    */
   async saveDataToAppData(character, skills, specialSkills, equipments, histories, currentFileId) {
     if (!this.googleDriveManager) {

--- a/src/services/googleDriveManager.js
+++ b/src/services/googleDriveManager.js
@@ -590,7 +590,7 @@ export class GoogleDriveManager {
   }
 
   /**
-   * Finds or creates the .AioniaCS folder in the user's Drive root.
+   * Finds or creates the configured character folder in the user's Drive root.
    * @returns {Promise<string|null>} The ID of the folder, or null if not available.
    */
   async findOrCreateAioniaCSFolder() {
@@ -635,7 +635,7 @@ export class GoogleDriveManager {
   }
 
   /**
-   * Finds a file by name inside the .AioniaCS folder.
+   * Finds a file by name inside the configured character folder.
    * @param {string} fileName - The target file name.
    * @returns {Promise<{id: string, name: string}|null>} File info or null when not found.
    */
@@ -672,7 +672,7 @@ export class GoogleDriveManager {
    * @returns {Promise<Array>}
    */
   async readIndexFile() {
-    console.warn('readIndexFile is deprecated. .AioniaCS folder now stores files directly.');
+    console.warn('readIndexFile is deprecated. Configured Drive folder now stores files directly.');
     return [];
   }
 
@@ -680,7 +680,7 @@ export class GoogleDriveManager {
    * Deprecated no-op: retained for backward compatibility.
    */
   async writeIndexFile() {
-    console.warn('writeIndexFile is deprecated. .AioniaCS folder now stores files directly.');
+    console.warn('writeIndexFile is deprecated. Configured Drive folder now stores files directly.');
     return null;
   }
 

--- a/tests/integrity/data-resilience.test.js
+++ b/tests/integrity/data-resilience.test.js
@@ -18,7 +18,7 @@ describe('DataManager data integrity', () => {
     dm.setGoogleDriveManager(gdm);
   });
 
-  it('saves a new character into the .AioniaCS folder', async () => {
+  it('saves a new character into the configured Drive folder', async () => {
     const result = await dm.saveDataToAppData({ name: 'Hero' }, [], [], {}, [], null);
 
     expect(result?.id).toBeTruthy();


### PR DESCRIPTION
## Summary
- refresh Google Drive manager documentation to describe the user-configured character folder
- align DataManager save documentation with the direct save flow instead of the legacy appData index
- update integrity test wording to mention the configured Drive folder

## Testing
- npm run lint
- npm test
- npm run e2e *(fails: Playwright browsers require system dependencies in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b9c5d2c88326a1f3b50888d88060