### PR TITLE
Unify share workflow around encrypted ZIP archives

### DIFF
--- a/src/components/modals/contents/ShareOptions.vue
+++ b/src/components/modals/contents/ShareOptions.vue
@@ -12,20 +12,12 @@
         <label class="share-options__option">
           <input type="radio" value="dynamic" v-model="type" />
           {{ shareOptions.reflection.choices.dynamic }}
-          <div class="share-options__note">{{ shareOptions.reflection.driveRequired }}</div>
         </label>
       </div>
+      <div class="share-options__note">{{ shareOptions.reflection.driveRequired }}</div>
     </section>
     <section class="share-options__section">
       <h3 class="share-options__heading">{{ shareOptions.additional.title }}</h3>
-      <div class="share-options__row">
-        <label class="share-options__option">
-          <input type="checkbox" v-model="includeFull" />
-          {{ shareOptions.additional.includeFull }}
-          <div class="share-options__note">{{ shareOptions.additional.driveRequired }}</div>
-        </label>
-      </div>
-      <p v-if="showTruncateWarning" class="share-options__warning">{{ shareOptions.additional.truncateWarning }}</p>
       <div class="share-options__row">
         <label class="share-options__option">
           <input type="checkbox" v-model="enablePassword" />
@@ -62,24 +54,21 @@ import { ref, computed, defineExpose, watchEffect } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useUiStore } from '../../../stores/uiStore.js';
 import { messages } from '../../../locales/ja.js';
-const props = defineProps({ longData: Boolean });
 const emit = defineEmits(['signin', 'update:canGenerate']);
 const type = ref('snapshot');
-const includeFull = ref(false);
 const enablePassword = ref(false);
 const password = ref('');
 const expires = ref('0');
 const uiStore = useUiStore();
 const { isSignedIn } = storeToRefs(uiStore);
 const shareOptions = messages.share.options;
-const needSignin = computed(() => (type.value === 'dynamic' || includeFull.value) && !isSignedIn.value);
-const showTruncateWarning = computed(() => props.longData && !includeFull.value);
+const needSignin = computed(() => !isSignedIn.value);
 const canGenerate = computed(() => !needSignin.value);
 watchEffect(() => {
   emit('update:canGenerate', canGenerate.value);
 });
 
-defineExpose({ type, includeFull, password, expires, enablePassword });
+defineExpose({ type, password, expires, enablePassword });
 
 function handleSignin() {
   emit('signin');
@@ -97,11 +86,8 @@ function handleSignin() {
   margin-bottom: 8px;
 }
 .share-options__note {
-  margin-left: 50px;
+  margin-left: 4px;
   color: var(--color-text-muted);
-}
-.share-options__warning {
-  color: #f88;
 }
 .share-options__signin {
   margin-top: 10px;

--- a/src/composables/useAppInitialization.js
+++ b/src/composables/useAppInitialization.js
@@ -9,6 +9,7 @@ import { useNotifications } from './useNotifications.js';
 import { useModal } from './useModal.js';
 import PasswordPromptModal from '../components/modals/contents/PasswordPromptModal.vue';
 import { messages } from '../locales/ja.js';
+import { deserializeCharacterPayload } from '../utils/characterSerialization.js';
 
 export function useAppInitialization(dataManager) {
   const characterStore = useCharacterStore();
@@ -79,7 +80,7 @@ export function useAppInitialization(dataManager) {
           passwordPromptHandler: promptPassword,
         });
       }
-      const parsed = JSON.parse(new TextDecoder().decode(buffer));
+      const parsed = await deserializeCharacterPayload(buffer);
       Object.assign(characterStore.character, parsed.character);
       characterStore.skills.splice(0, characterStore.skills.length, ...parsed.skills);
       characterStore.specialSkills.splice(0, characterStore.specialSkills.length, ...parsed.specialSkills);

--- a/src/composables/useAppModals.js
+++ b/src/composables/useAppModals.js
@@ -75,7 +75,7 @@ export function useAppModals(options) {
       }
       return;
     }
-    const { generateShare, copyLink, isLongData } = useShare(dataManager);
+    const { generateShare, copyLink } = useShare(dataManager);
     const { showToast } = useNotifications();
     const modalStore = useModalStore();
     const generateButton = reactive({
@@ -89,7 +89,6 @@ export function useAppModals(options) {
     }
     const result = await showModal({
       component: ShareOptions,
-      props: { longData: isLongData() },
       title: messages.ui.modal.shareTitle,
       buttons: [
         generateButton,
@@ -105,8 +104,7 @@ export function useAppModals(options) {
     const optsComp = result.component;
     const opts = {
       type: optsComp.type.value,
-      includeFull: optsComp.includeFull.value,
-      password: optsComp.password.value || '',
+      password: optsComp.enablePassword.value ? optsComp.password.value || '' : '',
       expiresInDays: Number(optsComp.expires.value) || 0,
     };
     try {

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -91,13 +91,10 @@ export const messages = {
           snapshot: '反映しない',
           dynamic: '反映する',
         },
-        driveRequired: 'Google Drive連携が必要です',
+        driveRequired: '共有リンクの生成には Google Drive 連携が必要です',
       },
       additional: {
         title: '追加オプション',
-        includeFull: '画像・メモ（長文の場合）を含める',
-        driveRequired: 'Google Drive連携が必要です',
-        truncateWarning: '内容が一部省略される可能性があります',
         enablePassword: 'パスワード保護',
         passwordPlaceholder: 'パスワード',
         expires: {

--- a/tests/unit/components/ShareOptions.test.js
+++ b/tests/unit/components/ShareOptions.test.js
@@ -14,12 +14,8 @@ describe('ShareOptions', () => {
   test('emits canGenerate updates', async () => {
     const uiStore = useUiStore();
     uiStore.isSignedIn = false;
-    const wrapper = mount(ShareOptions, {
-      props: { longData: false },
-    });
+    const wrapper = mount(ShareOptions, {});
 
-    await wrapper.find('input[value="dynamic"]').setValue();
-    await nextTick();
     let events = wrapper.emitted('update:canGenerate');
     expect(events[events.length - 1][0]).toBe(false);
 
@@ -29,16 +25,19 @@ describe('ShareOptions', () => {
     expect(events[events.length - 1][0]).toBe(true);
   });
 
-  test('truncate warning shown only when full content disabled', async () => {
+  test('sign-in button toggles with authentication state and password input toggles', async () => {
     const uiStore = useUiStore();
+    uiStore.isSignedIn = false;
+    const wrapper = mount(ShareOptions);
+
+    expect(wrapper.find('.share-options__signin').exists()).toBe(true);
+
     uiStore.isSignedIn = true;
-    const wrapper = mount(ShareOptions, {
-      props: { longData: true },
-    });
-    expect(wrapper.find('.share-options__warning').exists()).toBe(true);
+    await nextTick();
+    expect(wrapper.find('.share-options__signin').exists()).toBe(false);
 
     await wrapper.find('input[type="checkbox"]').setChecked();
     await nextTick();
-    expect(wrapper.find('.share-options__warning').exists()).toBe(false);
+    expect(wrapper.find('input.share-options__password-input').exists()).toBe(true);
   });
 });

--- a/tests/unit/composables/useShare.test.js
+++ b/tests/unit/composables/useShare.test.js
@@ -7,13 +7,33 @@ vi.mock('../../../src/libs/sabalessshare/src/index.js', () => ({
     await uploadHandler({ ciphertext: new ArrayBuffer(4), iv: new Uint8Array(12) });
     return 'link';
   }),
-  createDynamicLink: vi.fn(),
+}));
+
+vi.mock('../../../src/libs/sabalessshare/src/dynamic.js', () => ({
+  createDynamicLink: vi.fn(async () => ({ shareLink: 'dynamic-link' })),
 }));
 
 vi.mock('../../../src/libs/sabalessshare/src/crypto.js', async () => await import('../__mocks__/sabalessshare.js'));
 
 vi.mock('../../../src/composables/useNotifications.js', () => ({
   useNotifications: () => ({ showToast: vi.fn() }),
+}));
+
+vi.mock('../../../src/utils/characterSerialization.js', () => ({
+  serializeCharacterForExport: vi.fn(() => ({
+    data: {
+      character: { name: 'Hero' },
+      skills: [],
+      specialSkills: [],
+      equipments: {},
+      histories: [],
+    },
+    images: [],
+  })),
+  buildCharacterArchive: vi.fn(async () => ({
+    content: new Uint8Array([1, 2, 3]),
+    mimeType: 'application/zip',
+  })),
 }));
 
 describe('useShare', () => {
@@ -33,16 +53,32 @@ describe('useShare', () => {
 
   test('rejects when Google Drive manager is missing', async () => {
     const { generateShare } = useShare({ googleDriveManager: null });
-    await expect(generateShare({ type: 'snapshot', includeFull: true, password: '', expiresInDays: 0 })).rejects.toThrow(
-      'サインインしてください',
-    );
+    await expect(generateShare({ type: 'snapshot', password: '', expiresInDays: 0 })).rejects.toThrow('サインインしてください');
   });
 
   test('rejects when uploadAndShareFile returns null', async () => {
     const googleDriveManager = { uploadAndShareFile: vi.fn().mockResolvedValue(null) };
     const { generateShare } = useShare({ googleDriveManager });
-    await expect(generateShare({ type: 'snapshot', includeFull: true, password: '', expiresInDays: 0 })).rejects.toThrow(
+    await expect(generateShare({ type: 'snapshot', password: '', expiresInDays: 0 })).rejects.toThrow(
       'Google Drive へのアップロードに失敗しました',
     );
+  });
+
+  test('generates snapshot share link using cloud mode', async () => {
+    const googleDriveManager = { uploadAndShareFile: vi.fn().mockResolvedValue('file-id') };
+    const { generateShare } = useShare({ googleDriveManager });
+    const link = await generateShare({ type: 'snapshot', password: '', expiresInDays: 0 });
+    expect(link).toBe('link');
+    const { createShareLink } = await import('../../../src/libs/sabalessshare/src/index.js');
+    expect(createShareLink).toHaveBeenCalledWith(expect.objectContaining({ mode: 'cloud', expiresInDays: 0 }));
+  });
+
+  test('generates dynamic share link when selected', async () => {
+    const googleDriveManager = { uploadAndShareFile: vi.fn().mockResolvedValue('file-id') };
+    const { generateShare } = useShare({ googleDriveManager });
+    const link = await generateShare({ type: 'dynamic', password: '', expiresInDays: 7 });
+    expect(link).toBe('dynamic-link');
+    const { createDynamicLink } = await import('../../../src/libs/sabalessshare/src/dynamic.js');
+    expect(createDynamicLink).toHaveBeenCalledWith(expect.objectContaining({ expiresInDays: 7, password: undefined }));
   });
 });


### PR DESCRIPTION
## Summary
- switch the sharing composable to always archive character data as an encrypted ZIP before uploading, matching the Drive save path
- load shared payloads with the archive deserializer and streamline the share options UI to remove the image toggle
- update localized strings and unit tests to reflect the ZIP-based workflow and new modal behaviours

## Testing
- npm run lint
- npm test
- npm run e2e

------
https://chatgpt.com/codex/tasks/task_e_68e4cad7070883269c6e4a4d5ac67e8b