### PR TITLE
Remove redundant hidden class scoping from App component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -134,9 +134,6 @@ onMounted(initialize);
 </template>
 
 <style scoped>
-.hidden {
-  display: none !important;
-}
 .view-mode-banner {
   background: #333;
   color: #fff;


### PR DESCRIPTION
## Summary
- remove the scoped `.hidden` utility class from `App.vue` so components rely on the global layout stylesheet

## Testing
- npm run lint
- npm run test
- npm run e2e *(fails: missing system dependencies for Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c1a11d188326b8ab76b63c94f5f4