### PR TITLE
Add GM table interface with routing and session management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "marked": "^15.0.12",
         "pako": "^2.1.0",
         "pinia": "^2.1.7",
-        "vue": "^3.5.13"
+        "vue": "^3.5.13",
+        "vue-router": "^4.4.5"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.24.7",
@@ -9132,6 +9133,21 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "marked": "^15.0.12",
     "pako": "^2.1.0",
     "pinia": "^2.1.7",
-    "vue": "^3.5.13"
+    "vue": "^3.5.13",
+    "vue-router": "^4.4.5"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.24.7",

--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -1,84 +1,11 @@
 <script setup>
-import { ref, computed, watch, onMounted } from 'vue';
-import { useCharacterStore } from '@/features/character-sheet/stores/characterStore.js';
-import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
-import { useGoogleDrive } from '@/features/cloud-sync/composables/useGoogleDrive.js';
-import { useHelp } from '@/shared/composables/useHelp.js';
-import { useDataExport } from '@/features/character-sheet/composables/useDataExport.js';
-import { useKeyboardHandling } from '@/shared/composables/useKeyboardHandling.js';
-import { usePrint } from '@/features/character-sheet/composables/usePrint.js';
-import { messages } from '@/locales/ja.js';
-import { useAppModals } from '@/features/modals/composables/useAppModals.js';
-import { useAppInitialization } from '@/app/providers/useAppInitialization.js';
-
-import { AioniaGameData } from '@/data/gameData.js';
-import CharacterSheetLayout from '@/features/character-sheet/components/CharacterSheetLayout.vue';
-import MainHeader from '@/features/character-sheet/components/ui/MainHeader.vue';
-import MainFooter from '@/features/character-sheet/components/ui/MainFooter.vue';
-import HelpPanel from '@/features/character-sheet/components/ui/HelpPanel.vue';
-import NotificationContainer from '@/features/notifications/components/NotificationContainer.vue';
+import { watch } from 'vue';
+import { RouterView } from 'vue-router';
 import BaseModal from '@/features/modals/components/BaseModal.vue';
+import NotificationContainer from '@/features/notifications/components/NotificationContainer.vue';
 import { useModalStore } from '@/features/modals/stores/modalStore.js';
-const mainHeader = ref(null);
-const helpPanelRef = ref(null);
-
-const characterStore = useCharacterStore();
-const uiStore = useUiStore();
-useKeyboardHandling();
-
-const { dataManager, saveData, handleFileUpload, outputToCocofolia } = useDataExport();
-const { printCharacterSheet, openPreviewPage } = usePrint();
-
-const {
-  canSignInToGoogle,
-  handleSignInClick,
-  handleSignOutClick,
-  saveCharacterToDrive,
-  saveOrUpdateCurrentCharacterInDrive,
-} = useGoogleDrive(dataManager);
-
-const { helpState, isHelpVisible, handleHelpIconMouseOver, handleHelpIconMouseLeave, handleHelpIconClick, closeHelpPanel } = useHelp(
-  helpPanelRef,
-  mainHeader,
-);
 
 const modalStore = useModalStore();
-
-const { openHub, openIoModal, openShareModal } = useAppModals({
-  dataManager,
-  saveCharacterToDrive,
-  handleSignInClick,
-  handleSignOutClick,
-  saveData,
-  handleFileUpload,
-  outputToCocofolia,
-  printCharacterSheet,
-  openPreviewPage,
-  copyEditCallback: () => {
-    uiStore.isViewingShared = false;
-  },
-});
-
-const maxExperiencePoints = computed(() => characterStore.maxExperiencePoints);
-const currentExperiencePoints = computed(() => characterStore.currentExperiencePoints);
-const currentWeight = computed(() => characterStore.currentWeight);
-const experienceStatusClass = computed(() => uiStore.experienceStatusClass);
-
-watch(
-  () => characterStore.calculatedScar,
-  (currentScar) => {
-    characterStore.character.currentScar = currentScar;
-  },
-  { immediate: true },
-);
-
-watch(
-  () => characterStore.character.name,
-  (name) => {
-    document.title = name || messages.ui.header.defaultTitle;
-  },
-  { immediate: true },
-);
 
 watch(
   () => modalStore.isVisible,
@@ -89,55 +16,12 @@ watch(
       document.body.classList.remove('is-modal-open');
     }
   },
+  { immediate: true },
 );
-
-const { initialize } = useAppInitialization(dataManager);
-onMounted(initialize);
 </script>
 
 <template>
-  <MainHeader
-    ref="mainHeader"
-    :help-state="helpState"
-    :default-title="messages.ui.header.defaultTitle"
-    :cloud-hub-label="messages.ui.header.cloudHub"
-    :help-label="messages.ui.header.helpLabel"
-    @open-hub="openHub"
-    @help-mouseover="handleHelpIconMouseOver"
-    @help-mouseleave="handleHelpIconMouseLeave"
-    @help-click="handleHelpIconClick"
-  />
-  <div v-if="uiStore.isViewingShared" class="view-mode-banner">
-    {{ messages.ui.viewModeBanner }}
-  </div>
-  <CharacterSheetLayout />
-  <MainFooter
-    :experience-status-class="experienceStatusClass"
-    :current-experience-points="currentExperiencePoints"
-    :max-experience-points="maxExperiencePoints"
-    :current-weight="currentWeight"
-    :save-local="saveData"
-    :handle-file-upload="handleFileUpload"
-    :open-hub="openHub"
-    :save-to-drive="saveOrUpdateCurrentCharacterInDrive"
-    :experience-label="messages.ui.footer.experience"
-    :io-label="messages.ui.footer.io"
-    :share-label="messages.ui.footer.share"
-    :copy-edit-label="messages.ui.footer.copyEdit"
-    :is-viewing-shared="uiStore.isViewingShared"
-    @io="openIoModal"
-    @share="openShareModal"
-  />
-  <HelpPanel ref="helpPanelRef" :is-visible="isHelpVisible" :help-text="AioniaGameData.helpText" @close="closeHelpPanel" />
+  <RouterView />
   <BaseModal />
   <NotificationContainer />
 </template>
-
-<style scoped>
-.view-mode-banner {
-  background: #333;
-  color: #fff;
-  text-align: center;
-  padding: 0.5rem;
-}
-</style>

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -1,6 +1,7 @@
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import App from './App.vue';
+import router from './router/index.js';
 import { initializeGoogleDriveManager, initializeMockGoogleDriveManager } from '@/infrastructure/google-drive/index.js';
 import '@/shared/styles/style.css';
 
@@ -13,4 +14,5 @@ if (useMockDrive) {
 
 const app = createApp(App);
 app.use(createPinia());
+app.use(router);
 app.mount('#app');

--- a/src/app/router/index.js
+++ b/src/app/router/index.js
@@ -1,0 +1,28 @@
+import { createRouter, createWebHistory } from 'vue-router';
+import CharacterSheetPage from '@/features/character-sheet/pages/CharacterSheetPage.vue';
+import GmTablePage from '@/features/gm-table/pages/GmTablePage.vue';
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    {
+      path: '/',
+      name: 'character-sheet',
+      component: CharacterSheetPage,
+    },
+    {
+      path: '/gm-table',
+      name: 'gm-table',
+      component: GmTablePage,
+    },
+    {
+      path: '/:pathMatch(.*)*',
+      redirect: '/',
+    },
+  ],
+  scrollBehavior() {
+    return { top: 0 };
+  },
+});
+
+export default router;

--- a/src/features/character-sheet/components/ui/MainHeader.vue
+++ b/src/features/character-sheet/components/ui/MainHeader.vue
@@ -4,6 +4,14 @@
       <span class="icon-svg icon-svg-cloud" aria-label="cloud"></span>
     </button>
     <div class="main-header__title">{{ titleText }}</div>
+    <button
+      v-if="showGmTableButton"
+      class="button-base gm-table-button"
+      type="button"
+      @click="$emit('open-gm-table')"
+    >
+      {{ gmTableLabel }}
+    </button>
     <div
       class="button-base header-help-icon"
       ref="helpIcon"
@@ -28,9 +36,11 @@ const props = defineProps({
   defaultTitle: String,
   cloudHubLabel: String,
   helpLabel: String,
+  gmTableLabel: { type: String, default: 'GMテーブル' },
+  showGmTableButton: { type: Boolean, default: false },
 });
 
-const emit = defineEmits(['open-hub', 'help-mouseover', 'help-mouseleave', 'help-click']);
+const emit = defineEmits(['open-hub', 'help-mouseover', 'help-mouseleave', 'help-click', 'open-gm-table']);
 
 const headerEl = ref(null);
 const helpIcon = ref(null);
@@ -68,6 +78,25 @@ defineExpose({ headerEl, helpIcon });
   font-family: 'Cinzel Decorative', 'Shippori Mincho', serif;
   color: var(--color-accent);
   font-size: min(4vw, 30px);
+}
+
+.gm-table-button {
+  margin-right: 12px;
+  padding: 8px 18px;
+  font-size: 16px;
+  border: 1px solid var(--color-border-normal);
+  background: var(--color-panel-body);
+  color: var(--color-text-normal);
+  border-radius: 999px;
+  box-shadow: 0 2px 6px rgb(0 0 0 / 35%);
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.gm-table-button:hover,
+.gm-table-button:focus {
+  background: var(--color-accent);
+  color: var(--color-text-inverse);
+  border-color: var(--color-accent-light);
 }
 
 .google-drive-button-container {

--- a/src/features/character-sheet/pages/CharacterSheetPage.vue
+++ b/src/features/character-sheet/pages/CharacterSheetPage.vue
@@ -1,0 +1,129 @@
+<script setup>
+import { ref, computed, watch, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import { useCharacterStore } from '@/features/character-sheet/stores/characterStore.js';
+import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
+import { useGoogleDrive } from '@/features/cloud-sync/composables/useGoogleDrive.js';
+import { useHelp } from '@/shared/composables/useHelp.js';
+import { useDataExport } from '@/features/character-sheet/composables/useDataExport.js';
+import { useKeyboardHandling } from '@/shared/composables/useKeyboardHandling.js';
+import { usePrint } from '@/features/character-sheet/composables/usePrint.js';
+import { messages } from '@/locales/ja.js';
+import { useAppModals } from '@/features/modals/composables/useAppModals.js';
+import { useAppInitialization } from '@/app/providers/useAppInitialization.js';
+import { AioniaGameData } from '@/data/gameData.js';
+import CharacterSheetLayout from '@/features/character-sheet/components/CharacterSheetLayout.vue';
+import MainHeader from '@/features/character-sheet/components/ui/MainHeader.vue';
+import MainFooter from '@/features/character-sheet/components/ui/MainFooter.vue';
+import HelpPanel from '@/features/character-sheet/components/ui/HelpPanel.vue';
+
+const mainHeader = ref(null);
+const helpPanelRef = ref(null);
+
+const characterStore = useCharacterStore();
+const uiStore = useUiStore();
+const router = useRouter();
+useKeyboardHandling();
+
+const { dataManager, saveData, handleFileUpload, outputToCocofolia } = useDataExport();
+const { printCharacterSheet, openPreviewPage } = usePrint();
+
+const { handleSignInClick, handleSignOutClick, saveCharacterToDrive, saveOrUpdateCurrentCharacterInDrive } =
+  useGoogleDrive(dataManager);
+
+const { helpState, isHelpVisible, handleHelpIconMouseOver, handleHelpIconMouseLeave, handleHelpIconClick, closeHelpPanel } = useHelp(
+  helpPanelRef,
+  mainHeader,
+);
+
+const { openHub, openIoModal, openShareModal } = useAppModals({
+  dataManager,
+  saveCharacterToDrive,
+  handleSignInClick,
+  handleSignOutClick,
+  saveData,
+  handleFileUpload,
+  outputToCocofolia,
+  printCharacterSheet,
+  openPreviewPage,
+  copyEditCallback: () => {
+    uiStore.isViewingShared = false;
+  },
+});
+
+const maxExperiencePoints = computed(() => characterStore.maxExperiencePoints);
+const currentExperiencePoints = computed(() => characterStore.currentExperiencePoints);
+const currentWeight = computed(() => characterStore.currentWeight);
+const experienceStatusClass = computed(() => uiStore.experienceStatusClass);
+
+watch(
+  () => characterStore.calculatedScar,
+  (currentScar) => {
+    characterStore.character.currentScar = currentScar;
+  },
+  { immediate: true },
+);
+
+watch(
+  () => characterStore.character.name,
+  (name) => {
+    document.title = name || messages.ui.header.defaultTitle;
+  },
+  { immediate: true },
+);
+
+const { initialize } = useAppInitialization(dataManager);
+onMounted(initialize);
+
+function navigateToGmTable() {
+  router.push({ name: 'gm-table' });
+}
+</script>
+
+<template>
+  <MainHeader
+    ref="mainHeader"
+    :help-state="helpState"
+    :default-title="messages.ui.header.defaultTitle"
+    :cloud-hub-label="messages.ui.header.cloudHub"
+    :help-label="messages.ui.header.helpLabel"
+    :gm-table-label="messages.ui.header.gmTable"
+    show-gm-table-button
+    @open-hub="openHub"
+    @help-mouseover="handleHelpIconMouseOver"
+    @help-mouseleave="handleHelpIconMouseLeave"
+    @help-click="handleHelpIconClick"
+    @open-gm-table="navigateToGmTable"
+  />
+  <div v-if="uiStore.isViewingShared" class="view-mode-banner">
+    {{ messages.ui.viewModeBanner }}
+  </div>
+  <CharacterSheetLayout />
+  <MainFooter
+    :experience-status-class="experienceStatusClass"
+    :current-experience-points="currentExperiencePoints"
+    :max-experience-points="maxExperiencePoints"
+    :current-weight="currentWeight"
+    :save-local="saveData"
+    :handle-file-upload="handleFileUpload"
+    :open-hub="openHub"
+    :save-to-drive="saveOrUpdateCurrentCharacterInDrive"
+    :experience-label="messages.ui.footer.experience"
+    :io-label="messages.ui.footer.io"
+    :share-label="messages.ui.footer.share"
+    :copy-edit-label="messages.ui.footer.copyEdit"
+    :is-viewing-shared="uiStore.isViewingShared"
+    @io="openIoModal"
+    @share="openShareModal"
+  />
+  <HelpPanel ref="helpPanelRef" :is-visible="isHelpVisible" :help-text="AioniaGameData.helpText" @close="closeHelpPanel" />
+</template>
+
+<style scoped>
+.view-mode-banner {
+  background: #333;
+  color: #fff;
+  text-align: center;
+  padding: 0.5rem;
+}
+</style>

--- a/src/features/gm-table/components/SessionMemoWindow.vue
+++ b/src/features/gm-table/components/SessionMemoWindow.vue
@@ -1,0 +1,256 @@
+<template>
+  <div class="session-memo-window" :class="{ 'is-minimized': minimized }" :style="windowStyle">
+    <header class="session-memo-window__header" @pointerdown="startDrag">
+      <span class="session-memo-window__title">{{ title }}</span>
+      <div class="session-memo-window__actions">
+        <button class="session-memo-window__button" type="button" @click="$emit('toggle-minimize')">
+          {{ minimized ? '▶' : '▼' }}
+        </button>
+      </div>
+    </header>
+    <section v-show="!minimized" class="session-memo-window__body">
+      <textarea
+        class="session-memo-window__textarea"
+        :value="memo"
+        @input="$emit('update:memo', $event.target.value)"
+      ></textarea>
+    </section>
+    <div v-show="!minimized" class="session-memo-window__resize-handle" @pointerdown="startResize"></div>
+  </div>
+</template>
+
+<script setup>
+import { computed, onBeforeUnmount, onMounted, reactive } from 'vue';
+
+const props = defineProps({
+  memo: { type: String, default: '' },
+  title: { type: String, default: 'セッションメモ' },
+  position: {
+    type: Object,
+    default: () => ({ top: 120, left: 40 }),
+  },
+  size: {
+    type: Object,
+    default: () => ({ width: 320, height: 420 }),
+  },
+  minimized: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(['update:memo', 'update:position', 'update:size', 'toggle-minimize']);
+
+const dragState = reactive({
+  active: false,
+  pointerId: null,
+  startX: 0,
+  startY: 0,
+  baseTop: 0,
+  baseLeft: 0,
+  target: null,
+});
+const resizeState = reactive({
+  active: false,
+  pointerId: null,
+  startX: 0,
+  startY: 0,
+  baseWidth: 0,
+  baseHeight: 0,
+  target: null,
+});
+
+const windowStyle = computed(() => ({
+  top: `${props.position.top}px`,
+  left: `${props.position.left}px`,
+  width: `${props.size.width}px`,
+  height: props.minimized ? 'auto' : `${props.size.height}px`,
+}));
+
+function startDrag(event) {
+  if (resizeState.active) return;
+  dragState.active = true;
+  dragState.pointerId = event.pointerId;
+  dragState.startX = event.clientX;
+  dragState.startY = event.clientY;
+  dragState.baseTop = props.position.top;
+  dragState.baseLeft = props.position.left;
+  dragState.target = event.currentTarget;
+  if (dragState.target?.setPointerCapture) {
+    dragState.target.setPointerCapture(event.pointerId);
+  }
+  event.preventDefault();
+}
+
+function onDrag(event) {
+  if (!dragState.active || event.pointerId !== dragState.pointerId) return;
+  const deltaX = event.clientX - dragState.startX;
+  const deltaY = event.clientY - dragState.startY;
+  emit('update:position', {
+    top: dragState.baseTop + deltaY,
+    left: dragState.baseLeft + deltaX,
+  });
+}
+
+function endDrag(event) {
+  if (!dragState.active || event.pointerId !== dragState.pointerId) return;
+  dragState.active = false;
+  if (dragState.target?.releasePointerCapture) {
+    dragState.target.releasePointerCapture(event.pointerId);
+  }
+  dragState.pointerId = null;
+  dragState.target = null;
+}
+
+function startResize(event) {
+  if (dragState.active) return;
+  resizeState.active = true;
+  resizeState.pointerId = event.pointerId;
+  resizeState.startX = event.clientX;
+  resizeState.startY = event.clientY;
+  resizeState.baseWidth = props.size.width;
+  resizeState.baseHeight = props.size.height;
+  resizeState.target = event.currentTarget;
+  if (resizeState.target?.setPointerCapture) {
+    resizeState.target.setPointerCapture(event.pointerId);
+  }
+  event.preventDefault();
+}
+
+function onResize(event) {
+  if (!resizeState.active || event.pointerId !== resizeState.pointerId) return;
+  const deltaX = event.clientX - resizeState.startX;
+  const deltaY = event.clientY - resizeState.startY;
+  const width = Math.max(240, resizeState.baseWidth + deltaX);
+  const height = Math.max(200, resizeState.baseHeight + deltaY);
+  emit('update:size', { width, height });
+}
+
+function endResize(event) {
+  if (!resizeState.active || event.pointerId !== resizeState.pointerId) return;
+  resizeState.active = false;
+  if (resizeState.target?.releasePointerCapture) {
+    resizeState.target.releasePointerCapture(event.pointerId);
+  }
+  resizeState.pointerId = null;
+  resizeState.target = null;
+}
+
+function onPointerMove(event) {
+  onDrag(event);
+  onResize(event);
+}
+
+function onPointerUp(event) {
+  endDrag(event);
+  endResize(event);
+}
+
+function addGlobalListeners() {
+  if (typeof window === 'undefined') return;
+  window.addEventListener('pointermove', onPointerMove);
+  window.addEventListener('pointerup', onPointerUp);
+}
+
+function removeGlobalListeners() {
+  if (typeof window === 'undefined') return;
+  window.removeEventListener('pointermove', onPointerMove);
+  window.removeEventListener('pointerup', onPointerUp);
+}
+
+onMounted(addGlobalListeners);
+onBeforeUnmount(removeGlobalListeners);
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    removeGlobalListeners();
+  });
+}
+</script>
+
+<style scoped>
+.session-memo-window {
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  background: rgba(24, 21, 32, 0.95);
+  border: 1px solid var(--color-border-strong);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 70%);
+  border-radius: 12px;
+  backdrop-filter: blur(6px);
+  overflow: hidden;
+  z-index: 240;
+}
+
+.session-memo-window__header {
+  cursor: move;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  background: linear-gradient(135deg, rgba(68, 54, 89, 0.95), rgba(30, 26, 46, 0.95));
+  color: var(--color-text-inverse);
+  font-family: 'Cinzel Decorative', 'Shippori Mincho', serif;
+  user-select: none;
+}
+
+.session-memo-window__title {
+  font-size: 1rem;
+}
+
+.session-memo-window__actions {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.session-memo-window__button {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid var(--color-border-normal);
+  background: rgba(15, 12, 22, 0.65);
+  color: var(--color-text-inverse);
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.session-memo-window__button:hover {
+  background: var(--color-accent);
+  transform: translateY(-1px);
+}
+
+.session-memo-window__body {
+  flex: 1;
+  padding: 0.75rem;
+}
+
+.session-memo-window__textarea {
+  width: 100%;
+  height: 100%;
+  background: rgba(12, 10, 18, 0.75);
+  border: 1px solid var(--color-border-normal);
+  border-radius: 8px;
+  color: var(--color-text-normal);
+  padding: 0.75rem;
+  resize: none;
+  font-family: 'Shippori Mincho', serif;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.session-memo-window__resize-handle {
+  width: 18px;
+  height: 18px;
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
+  cursor: se-resize;
+  border-right: 2px solid rgba(255, 255, 255, 0.4);
+  border-bottom: 2px solid rgba(255, 255, 255, 0.4);
+}
+
+.is-minimized {
+  height: auto !important;
+}
+</style>

--- a/src/features/gm-table/pages/GmTablePage.vue
+++ b/src/features/gm-table/pages/GmTablePage.vue
@@ -1,0 +1,788 @@
+<script setup>
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { useRouter } from 'vue-router';
+import { DataManager } from '@/features/character-sheet/services/dataManager.js';
+import { AioniaGameData } from '@/data/gameData.js';
+import { deserializeCharacterPayload } from '@/shared/utils/characterSerialization.js';
+import { messages } from '@/locales/ja.js';
+import { useNotifications } from '@/features/notifications/composables/useNotifications.js';
+import { useCharacterStore } from '@/features/character-sheet/stores/characterStore.js';
+import SessionMemoWindow from '../components/SessionMemoWindow.vue';
+import { useGmTableStore } from '../stores/useGmTableStore.js';
+import { downloadGmSession, readGmSessionFile } from '../services/gmSessionManager.js';
+
+const router = useRouter();
+const dataManager = new DataManager(AioniaGameData);
+const gmStore = useGmTableStore();
+const characterStore = useCharacterStore();
+const { showToast } = useNotifications();
+
+const gmMessages = messages.gmTable;
+
+const characterFileInput = ref(null);
+const reloadFileInput = ref(null);
+const sessionFileInput = ref(null);
+
+const pendingReloadId = ref(null);
+const activeMenuId = ref(null);
+
+const baseSkills = computed(() =>
+  AioniaGameData.baseSkills.map((skill) => ({
+    id: skill.id,
+    name: skill.name,
+    canHaveExperts: skill.canHaveExperts,
+  })),
+);
+
+const specialSkillDescriptions = computed(() => {
+  const map = new Map();
+  Object.values(AioniaGameData.specialSkillData).forEach((group) => {
+    group.forEach((item) => {
+      map.set(item.value, item.description);
+      map.set(item.label, item.description);
+    });
+  });
+  return map;
+});
+
+function clone(value) {
+  return value ? JSON.parse(JSON.stringify(value)) : value;
+}
+
+function getWeaknesses(column) {
+  const weaknesses = column.data?.character?.weaknesses || [];
+  return weaknesses.filter((item) => item && item.text && item.text.trim() !== '');
+}
+
+function getSkillSummary(column) {
+  const list = column.data?.skills || [];
+  return list
+    .filter((skill) => skill.checked)
+    .map((skill) => {
+      const experts = (skill.experts || []).map((expert) => expert?.value?.trim()).filter(Boolean);
+      return experts.length > 0 ? `${skill.name}（${experts.join('、')}）` : skill.name;
+    });
+}
+
+function getSkillState(column, skillId) {
+  return (column.data?.skills || []).find((skill) => skill.id === skillId) || null;
+}
+
+function getSpecialSkillTooltip(skill) {
+  const description = specialSkillDescriptions.value.get(skill.name) || specialSkillDescriptions.value.get(skill.value);
+  if (skill.note) {
+    return `${skill.name}\n${skill.note}`;
+  }
+  if (description) {
+    return description;
+  }
+  return `${skill.name}\n説明`;
+}
+
+function calculateWeight(column) {
+  const equipments = column.data?.equipments || {};
+  const weaponWeights = AioniaGameData.equipmentWeights.weapon;
+  const armorWeights = AioniaGameData.equipmentWeights.armor;
+  const total =
+    (weaponWeights[equipments.weapon1?.group] || 0) +
+    (weaponWeights[equipments.weapon2?.group] || 0) +
+    (armorWeights[equipments.armor?.group] || 0);
+  let penalty = 'none';
+  if (total >= 5) {
+    penalty = 'heavy';
+  } else if (total >= 3) {
+    penalty = 'light';
+  }
+  return { total, penalty };
+}
+
+function weightPenaltyLabel(key) {
+  const labels = {
+    none: gmMessages.weight.penaltyNone,
+    light: gmMessages.weight.penaltyLight,
+    heavy: gmMessages.weight.penaltyHeavy,
+  };
+  return labels[key] || gmMessages.weight.penaltyNone;
+}
+
+function handleDocumentClick(event) {
+  if (!event.target.closest('.gm-character-menu') && !event.target.closest('.gm-character-menu-trigger')) {
+    activeMenuId.value = null;
+  }
+}
+
+onMounted(() => {
+  document.title = gmMessages.pageTitle;
+  document.addEventListener('click', handleDocumentClick);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', handleDocumentClick);
+});
+
+function triggerAddCharacter() {
+  characterFileInput.value?.click();
+}
+
+function triggerSessionLoad() {
+  sessionFileInput.value?.click();
+}
+
+async function parseCharacterFile(file) {
+  try {
+    const lower = file.name.toLowerCase();
+    let raw;
+    if (lower.endsWith('.zip')) {
+      const buffer = await file.arrayBuffer();
+      raw = await deserializeCharacterPayload(buffer);
+    } else {
+      const text = await file.text();
+      raw = await deserializeCharacterPayload(text);
+    }
+    return dataManager.parseLoadedData(raw);
+  } catch (error) {
+    console.error('Failed to parse character file', error);
+    throw new Error(gmMessages.errors.characterLoad);
+  }
+}
+
+async function handleCharacterFileChange(event) {
+  const file = event.target.files?.[0] || null;
+  event.target.value = '';
+  if (!file) return;
+  try {
+    const parsed = await parseCharacterFile(file);
+    gmStore.addCharacter({ parsedData: parsed, sourceName: file.name });
+    showToast({ type: 'success', title: gmMessages.toasts.added.title, message: gmMessages.toasts.added.message(file.name) });
+  } catch (error) {
+    showToast({ type: 'error', title: gmMessages.toasts.loadError.title, message: error.message });
+  }
+}
+
+async function handleReloadFileChange(event) {
+  const file = event.target.files?.[0] || null;
+  const columnId = pendingReloadId.value;
+  pendingReloadId.value = null;
+  event.target.value = '';
+  if (!file || !columnId) return;
+  try {
+    const parsed = await parseCharacterFile(file);
+    gmStore.replaceCharacter(columnId, { parsedData: parsed, sourceName: file.name });
+    showToast({ type: 'success', title: gmMessages.toasts.reloaded.title, message: gmMessages.toasts.reloaded.message(file.name) });
+  } catch (error) {
+    showToast({ type: 'error', title: gmMessages.toasts.loadError.title, message: error.message });
+  }
+}
+
+async function handleSessionFileChange(event) {
+  const file = event.target.files?.[0] || null;
+  event.target.value = '';
+  if (!file) return;
+  try {
+    const payload = await readGmSessionFile(file);
+    gmStore.loadFromSession(payload);
+    showToast({ type: 'success', title: gmMessages.toasts.sessionLoaded.title, message: gmMessages.toasts.sessionLoaded.message });
+  } catch (error) {
+    showToast({ type: 'error', title: gmMessages.toasts.sessionLoadError.title, message: error.message });
+  }
+}
+
+function openMenu(columnId) {
+  activeMenuId.value = activeMenuId.value === columnId ? null : columnId;
+}
+
+function editCharacter(column) {
+  const data = column.data;
+  Object.assign(characterStore.character, clone(data.character));
+  characterStore.skills.splice(0, characterStore.skills.length, ...clone(data.skills));
+  characterStore.specialSkills.splice(0, characterStore.specialSkills.length, ...clone(data.specialSkills));
+  Object.assign(characterStore.equipments, clone(data.equipments));
+  characterStore.histories.splice(0, characterStore.histories.length, ...clone(data.histories));
+  activeMenuId.value = null;
+  router.push({ name: 'character-sheet' });
+}
+
+function reloadCharacter(column) {
+  pendingReloadId.value = column.id;
+  reloadFileInput.value?.click();
+}
+
+function deleteCharacter(column) {
+  const name = column.data?.character?.name || gmMessages.labels.unknownCharacter;
+  const confirmed = typeof window === 'undefined' ? true : window.confirm(gmMessages.confirm.delete(name));
+  if (confirmed) {
+    gmStore.removeCharacter(column.id);
+    showToast({ type: 'info', title: gmMessages.toasts.removed.title, message: gmMessages.toasts.removed.message });
+  }
+  activeMenuId.value = null;
+}
+
+function toggleMemoRow() {
+  gmStore.toggleRow('memo');
+}
+
+function toggleWeaknessRow() {
+  gmStore.toggleRow('weaknesses');
+}
+
+function toggleSkillDetail() {
+  gmStore.setSkillDetailExpanded(!gmStore.skillDetailExpanded);
+}
+
+function saveSession() {
+  const payload = gmStore.toSessionPayload();
+  downloadGmSession(payload, gmMessages.session.defaultFileName);
+  showToast({ type: 'success', title: gmMessages.toasts.sessionSaved.title, message: gmMessages.toasts.sessionSaved.message });
+}
+
+const memoWindowPosition = computed(() => ({ top: gmStore.sessionWindow.top, left: gmStore.sessionWindow.left }));
+const memoWindowSize = computed(() => ({ width: gmStore.sessionWindow.width, height: gmStore.sessionWindow.height }));
+
+function updateMemoPosition(position) {
+  gmStore.updateSessionWindow(position);
+}
+
+function updateMemoSize(size) {
+  gmStore.updateSessionWindow(size);
+}
+
+function toggleMemoWindow() {
+  gmStore.updateSessionWindow({ minimized: !gmStore.sessionWindow.minimized });
+}
+
+function goToSheet() {
+  router.push({ name: 'character-sheet' });
+}
+</script>
+
+<template>
+  <div class="gm-table-page">
+    <header class="gm-table-page__header">
+      <div class="gm-table-page__title-block">
+        <h1 class="gm-table-page__title">{{ gmMessages.pageTitle }}</h1>
+        <p class="gm-table-page__subtitle">{{ gmMessages.pageSubtitle }}</p>
+      </div>
+      <div class="gm-table-page__actions">
+        <button type="button" class="gm-table-button" @click="goToSheet">{{ gmMessages.actions.backToSheet }}</button>
+        <button type="button" class="gm-table-button" @click="saveSession" :disabled="!gmStore.hasCharacters">
+          {{ gmMessages.actions.saveSession }}
+        </button>
+        <button type="button" class="gm-table-button" @click="triggerSessionLoad">
+          {{ gmMessages.actions.loadSession }}
+        </button>
+      </div>
+    </header>
+    <div class="gm-table-container">
+      <table class="gm-table">
+        <thead>
+          <tr>
+            <th class="gm-table__row-label gm-table__sticky">{{ gmMessages.headers.characterName }}</th>
+            <th v-for="column in gmStore.columns" :key="column.id" class="gm-table__character-header">
+              <div class="gm-character-header">
+                <span class="gm-character-header__name">{{ column.data.character.name || gmMessages.labels.unknownCharacter }}</span>
+                <button
+                  type="button"
+                  class="gm-character-header__settings gm-character-menu-trigger"
+                  @click.stop="openMenu(column.id)"
+                  :aria-label="gmMessages.actions.openCharacterMenu(column.data.character.name || gmMessages.labels.unknownCharacter)"
+                >
+                  ⚙️
+                </button>
+                <transition name="fade">
+                  <div v-if="activeMenuId === column.id" class="gm-character-menu" @click.stop>
+                    <button type="button" class="gm-character-menu__item" @click="editCharacter(column)">
+                      {{ gmMessages.characterMenu.edit }}
+                    </button>
+                    <button type="button" class="gm-character-menu__item" @click="reloadCharacter(column)">
+                      {{ gmMessages.characterMenu.reload }}
+                    </button>
+                    <button type="button" class="gm-character-menu__item gm-character-menu__item--danger" @click="deleteCharacter(column)">
+                      {{ gmMessages.characterMenu.remove }}
+                    </button>
+                  </div>
+                </transition>
+              </div>
+            </th>
+            <th class="gm-table__add-column">
+              <button type="button" class="gm-add-button" @click="triggerAddCharacter">+</button>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="gm-row gm-row--memo" :class="{ 'is-collapsed': !gmStore.rowVisibility.memo }">
+            <th class="gm-table__row-label gm-table__sticky">
+              <button type="button" class="gm-toggle" @click="toggleMemoRow">
+                {{ gmStore.rowVisibility.memo ? '▼' : '▶' }}
+              </button>
+              <span>{{ gmMessages.rows.memo }}</span>
+            </th>
+            <td v-for="column in gmStore.columns" :key="column.id" class="gm-cell gm-cell--memo">
+              <textarea
+                class="gm-memo-textarea"
+                :value="column.memo"
+                :placeholder="gmMessages.placeholders.characterMemo"
+                @input="gmStore.setCharacterMemo(column.id, $event.target.value)"
+              ></textarea>
+            </td>
+            <td class="gm-table__spacer"></td>
+          </tr>
+          <tr class="gm-row gm-row--weakness" :class="{ 'is-collapsed': !gmStore.rowVisibility.weaknesses }">
+            <th class="gm-table__row-label gm-table__sticky">
+              <button type="button" class="gm-toggle" @click="toggleWeaknessRow">
+                {{ gmStore.rowVisibility.weaknesses ? '▼' : '▶' }}
+              </button>
+              <span>{{ gmMessages.rows.weakness }}</span>
+            </th>
+            <td v-for="column in gmStore.columns" :key="column.id" class="gm-cell">
+              <ul class="gm-weakness-list">
+                <li v-for="(weakness, index) in getWeaknesses(column)" :key="index" class="gm-weakness-item">
+                  <span class="gm-weakness-text">{{ weakness.text }}</span>
+                  <span v-if="weakness.acquired" class="gm-weakness-tag">{{ weakness.acquired }}</span>
+                </li>
+                <li v-if="getWeaknesses(column).length === 0" class="gm-weakness-empty">{{ gmMessages.labels.noWeakness }}</li>
+              </ul>
+            </td>
+            <td class="gm-table__spacer"></td>
+          </tr>
+          <tr v-if="!gmStore.skillDetailExpanded" class="gm-row gm-row--skills">
+            <th class="gm-table__row-label gm-table__sticky">
+              <button type="button" class="gm-toggle gm-toggle--action" @click="toggleSkillDetail">
+                {{ gmMessages.rows.skillToggle.detail }}
+              </button>
+              <span>{{ gmMessages.rows.skills }}</span>
+            </th>
+            <td v-for="column in gmStore.columns" :key="column.id" class="gm-cell">
+              <div class="gm-tag-list">
+                <code v-for="(skill, index) in getSkillSummary(column)" :key="index" class="gm-tag">{{ skill }}</code>
+                <span v-if="getSkillSummary(column).length === 0" class="gm-empty">{{ gmMessages.labels.noSkill }}</span>
+              </div>
+            </td>
+            <td class="gm-table__spacer"></td>
+          </tr>
+          <template v-else>
+            <tr v-for="(skill, index) in baseSkills" :key="skill.id" class="gm-row gm-row--skill-detail">
+              <th class="gm-table__row-label gm-table__sticky">
+                <div class="gm-skill-detail-label">
+                  <span>{{ skill.name }}</span>
+                  <button
+                    v-if="index === 0"
+                    type="button"
+                    class="gm-toggle gm-toggle--action"
+                    @click="toggleSkillDetail"
+                  >
+                    {{ gmMessages.rows.skillToggle.summary }}
+                  </button>
+                </div>
+              </th>
+              <td v-for="column in gmStore.columns" :key="column.id" class="gm-cell gm-cell--skill-detail">
+                <div class="gm-skill-detail">
+                  <span class="gm-skill-check" :class="{ 'is-checked': getSkillState(column, skill.id)?.checked }">
+                    {{ getSkillState(column, skill.id)?.checked ? '✓' : '—' }}
+                  </span>
+                  <span class="gm-skill-expert" v-if="skill.canHaveExperts">
+                    {{
+                      (getSkillState(column, skill.id)?.experts || [])
+                        .map((expert) => expert?.value?.trim())
+                        .filter(Boolean)
+                        .join('、') || gmMessages.labels.noExpert
+                    }}
+                  </span>
+                </div>
+              </td>
+              <td class="gm-table__spacer"></td>
+            </tr>
+          </template>
+          <tr class="gm-row gm-row--special-skills">
+            <th class="gm-table__row-label gm-table__sticky">{{ gmMessages.rows.specialSkills }}</th>
+            <td v-for="column in gmStore.columns" :key="column.id" class="gm-cell">
+              <div class="gm-tag-list">
+                <code
+                  v-for="(skill, index) in column.data.specialSkills.filter((s) => s.name)"
+                  :key="`${skill.name}-${index}`"
+                  class="gm-tag"
+                  :title="getSpecialSkillTooltip(skill)"
+                >
+                  {{ skill.name }}
+                </code>
+                <span v-if="column.data.specialSkills.filter((s) => s.name).length === 0" class="gm-empty">
+                  {{ gmMessages.labels.noSpecialSkill }}
+                </span>
+              </div>
+            </td>
+            <td class="gm-table__spacer"></td>
+          </tr>
+          <tr class="gm-row gm-row--weight">
+            <th class="gm-table__row-label gm-table__sticky">{{ gmMessages.rows.weight }}</th>
+            <td v-for="column in gmStore.columns" :key="column.id" class="gm-cell">
+              <div class="gm-weight">
+                <span class="gm-weight__value">{{ calculateWeight(column).total }}</span>
+                <span class="gm-weight__separator">/</span>
+                <span class="gm-weight__penalty" :class="`is-${calculateWeight(column).penalty}`">
+                  {{ weightPenaltyLabel(calculateWeight(column).penalty) }}
+                </span>
+              </div>
+            </td>
+            <td class="gm-table__spacer"></td>
+          </tr>
+        </tbody>
+      </table>
+      <input ref="characterFileInput" type="file" class="gm-file-input" accept=".json,.zip" @change="handleCharacterFileChange" />
+      <input ref="reloadFileInput" type="file" class="gm-file-input" accept=".json,.zip" @change="handleReloadFileChange" />
+      <input ref="sessionFileInput" type="file" class="gm-file-input" accept=".json" @change="handleSessionFileChange" />
+    </div>
+    <SessionMemoWindow
+      :memo="gmStore.sessionMemo"
+      :position="memoWindowPosition"
+      :size="memoWindowSize"
+      :minimized="gmStore.sessionWindow.minimized"
+      :title="gmMessages.session.memoTitle"
+      @update:memo="gmStore.updateSessionMemo"
+      @update:position="updateMemoPosition"
+      @update:size="updateMemoSize"
+      @toggle-minimize="toggleMemoWindow"
+    />
+  </div>
+</template>
+
+<style scoped>
+.gm-table-page {
+  min-height: 100vh;
+  padding: 96px 24px 48px;
+  background: radial-gradient(circle at top, rgba(40, 32, 60, 0.85), rgba(18, 14, 26, 0.98));
+  color: var(--color-text-normal);
+}
+
+.gm-table-page__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 16px;
+  margin-bottom: 32px;
+}
+
+.gm-table-page__title {
+  font-family: 'Cinzel Decorative', 'Shippori Mincho', serif;
+  font-size: clamp(28px, 5vw, 42px);
+  margin: 0;
+  color: var(--color-accent-light);
+}
+
+.gm-table-page__subtitle {
+  margin: 4px 0 0;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.gm-table-page__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.gm-table-button {
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border-normal);
+  background: rgba(28, 23, 40, 0.85);
+  color: var(--color-text-inverse);
+  font-size: 0.95rem;
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgb(0 0 0 / 45%);
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.gm-table-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.gm-table-button:not(:disabled):hover {
+  transform: translateY(-2px);
+  background: var(--color-accent);
+}
+
+.gm-table-container {
+  overflow-x: auto;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(20, 16, 28, 0.85);
+  box-shadow: inset 0 0 24px rgb(0 0 0 / 45%);
+}
+
+.gm-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  min-width: 720px;
+}
+
+.gm-table__row-label {
+  min-width: 200px;
+  background: rgba(32, 24, 44, 0.95);
+  color: var(--color-text-inverse);
+  font-weight: 600;
+  padding: 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  position: relative;
+}
+
+.gm-table__sticky {
+  position: sticky;
+  left: 0;
+  z-index: 2;
+}
+
+.gm-table__character-header {
+  min-width: 240px;
+  padding: 0;
+  background: rgba(17, 14, 24, 0.8);
+}
+
+.gm-character-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  gap: 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  position: relative;
+}
+
+.gm-character-header__name {
+  font-family: 'Shippori Mincho', serif;
+  font-size: 1.1rem;
+  color: var(--color-text-normal);
+  flex: 1;
+}
+
+.gm-character-header__settings {
+  border: none;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+
+.gm-character-menu {
+  position: absolute;
+  top: 58px;
+  right: 16px;
+  background: rgba(28, 24, 40, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  box-shadow: 0 10px 26px rgb(0 0 0 / 65%);
+  display: flex;
+  flex-direction: column;
+  min-width: 160px;
+  z-index: 5;
+}
+
+.gm-character-menu__item {
+  padding: 12px 16px;
+  background: none;
+  border: none;
+  color: var(--color-text-normal);
+  text-align: left;
+  cursor: pointer;
+}
+
+.gm-character-menu__item:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.gm-character-menu__item--danger {
+  color: #ff8585;
+}
+
+.gm-add-button {
+  width: 48px;
+  height: 48px;
+  margin: 12px auto;
+  border-radius: 50%;
+  border: 1px dashed rgba(255, 255, 255, 0.4);
+  background: transparent;
+  color: var(--color-text-inverse);
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.gm-row:nth-child(odd) td {
+  background: rgba(18, 16, 28, 0.6);
+}
+
+.gm-row:nth-child(even) td {
+  background: rgba(24, 20, 32, 0.75);
+}
+
+.gm-cell {
+  padding: 16px;
+  vertical-align: top;
+  min-width: 220px;
+}
+
+.gm-cell--memo {
+  min-width: 260px;
+}
+
+.gm-memo-textarea {
+  width: 100%;
+  min-height: 120px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(12, 10, 18, 0.75);
+  color: var(--color-text-normal);
+  padding: 12px;
+  resize: vertical;
+  font-family: 'Shippori Mincho', serif;
+}
+
+.gm-weakness-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.gm-weakness-item {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+}
+
+.gm-weakness-tag {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 12px;
+  padding: 2px 10px;
+  font-size: 0.75rem;
+}
+
+.gm-tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.gm-tag {
+  background: rgba(255, 255, 255, 0.08);
+  padding: 4px 10px;
+  border-radius: 10px;
+  font-family: 'Fira Code', 'Shippori Mincho', monospace;
+  font-size: 0.85rem;
+  color: var(--color-text-inverse);
+}
+
+.gm-empty {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.gm-skill-detail {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.gm-skill-check {
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.gm-skill-check.is-checked {
+  background: rgba(92, 200, 150, 0.25);
+  border-color: rgba(92, 200, 150, 0.6);
+}
+
+.gm-skill-expert {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.gm-weight {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 1.2rem;
+}
+
+.gm-weight__penalty.is-none {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.gm-weight__penalty.is-light {
+  color: #ffd166;
+}
+
+.gm-weight__penalty.is-heavy {
+  color: #ff6b6b;
+}
+
+.gm-toggle {
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  color: var(--color-text-inverse);
+  padding: 4px 12px;
+  cursor: pointer;
+}
+
+.gm-toggle--action {
+  background: rgba(95, 68, 140, 0.4);
+}
+
+.gm-table__add-column,
+.gm-table__spacer {
+  width: 120px;
+  background: rgba(17, 14, 24, 0.8);
+}
+
+.gm-table__spacer {
+  border-left: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.gm-table__add-column {
+  text-align: center;
+}
+
+.gm-file-input {
+  display: none;
+}
+
+.gm-row.is-collapsed td {
+  display: none;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.15s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+@media (max-width: 960px) {
+  .gm-table-page {
+    padding: 96px 12px 48px;
+  }
+
+  .gm-table__row-label {
+    min-width: 180px;
+  }
+
+  .gm-cell {
+    min-width: 200px;
+  }
+}
+</style>

--- a/src/features/gm-table/services/gmSessionManager.js
+++ b/src/features/gm-table/services/gmSessionManager.js
@@ -1,0 +1,25 @@
+const DEFAULT_FILE_NAME = 'gm-session.json';
+
+export function downloadGmSession(payload, fileName = DEFAULT_FILE_NAME) {
+  if (!payload) return;
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+export async function readGmSessionFile(file) {
+  if (!file) return null;
+  const text = await file.text();
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    console.error('Failed to parse GM session file:', error);
+    throw new Error('GMセッションデータの読み込みに失敗しました');
+  }
+}

--- a/src/features/gm-table/stores/useGmTableStore.js
+++ b/src/features/gm-table/stores/useGmTableStore.js
@@ -1,0 +1,130 @@
+import { defineStore } from 'pinia';
+
+function cloneData(value) {
+  return value ? JSON.parse(JSON.stringify(value)) : value;
+}
+
+function createId() {
+  const globalCrypto = typeof globalThis !== 'undefined' ? globalThis.crypto : undefined;
+  if (globalCrypto && typeof globalCrypto.randomUUID === 'function') {
+    return globalCrypto.randomUUID();
+  }
+  return `gm-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+const defaultWindowState = () => ({
+  top: 120,
+  left: 40,
+  width: 360,
+  height: 420,
+  minimized: false,
+});
+
+export const useGmTableStore = defineStore('gmTable', {
+  state: () => ({
+    columns: [],
+    sessionMemo: '',
+    rowVisibility: {
+      memo: true,
+      weaknesses: false,
+    },
+    skillDetailExpanded: false,
+    sessionWindow: defaultWindowState(),
+  }),
+  getters: {
+    hasCharacters(state) {
+      return state.columns.length > 0;
+    },
+  },
+  actions: {
+    addCharacter({ parsedData, sourceName }) {
+      if (!parsedData) return;
+      this.columns.push({
+        id: createId(),
+        data: cloneData(parsedData),
+        memo: '',
+        sourceName: sourceName || '',
+        updatedAt: Date.now(),
+      });
+    },
+    replaceCharacter(id, { parsedData, sourceName }) {
+      const index = this.columns.findIndex((column) => column.id === id);
+      if (index === -1 || !parsedData) {
+        return;
+      }
+      const target = this.columns[index];
+      this.columns[index] = {
+        ...target,
+        data: cloneData(parsedData),
+        sourceName: sourceName || target.sourceName || '',
+        updatedAt: Date.now(),
+      };
+    },
+    removeCharacter(id) {
+      this.columns = this.columns.filter((column) => column.id !== id);
+    },
+    setCharacterMemo(id, value) {
+      const target = this.columns.find((column) => column.id === id);
+      if (target) {
+        target.memo = value;
+      }
+    },
+    toggleRow(key) {
+      if (Object.prototype.hasOwnProperty.call(this.rowVisibility, key)) {
+        this.rowVisibility[key] = !this.rowVisibility[key];
+      }
+    },
+    setSkillDetailExpanded(value) {
+      this.skillDetailExpanded = !!value;
+    },
+    updateSessionMemo(value) {
+      this.sessionMemo = value;
+    },
+    updateSessionWindow(partial) {
+      this.sessionWindow = {
+        ...this.sessionWindow,
+        ...partial,
+      };
+    },
+    resetWindowState() {
+      this.sessionWindow = defaultWindowState();
+    },
+    toSessionPayload() {
+      return {
+        version: 1,
+        sessionMemo: this.sessionMemo,
+        rowVisibility: { ...this.rowVisibility },
+        skillDetailExpanded: this.skillDetailExpanded,
+        sessionWindow: { ...this.sessionWindow },
+        characters: this.columns.map((column) => ({
+          id: column.id,
+          memo: column.memo,
+          sourceName: column.sourceName,
+          updatedAt: column.updatedAt,
+          data: cloneData(column.data),
+        })),
+      };
+    },
+    loadFromSession(payload) {
+      if (!payload || typeof payload !== 'object') return;
+      const { sessionMemo = '', rowVisibility = {}, skillDetailExpanded = false, sessionWindow = null, characters = [] } = payload;
+
+      this.sessionMemo = sessionMemo || '';
+      this.rowVisibility = {
+        memo: typeof rowVisibility.memo === 'boolean' ? rowVisibility.memo : true,
+        weaknesses: typeof rowVisibility.weaknesses === 'boolean' ? rowVisibility.weaknesses : false,
+      };
+      this.skillDetailExpanded = !!skillDetailExpanded;
+      this.sessionWindow = sessionWindow ? { ...defaultWindowState(), ...sessionWindow } : defaultWindowState();
+      this.columns = Array.isArray(characters)
+        ? characters.map((column) => ({
+            id: column.id || createId(),
+            memo: column.memo || '',
+            sourceName: column.sourceName || '',
+            updatedAt: column.updatedAt || Date.now(),
+            data: cloneData(column.data || {}),
+          }))
+        : [];
+    },
+  },
+});

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -172,6 +172,7 @@ export const messages = {
       defaultTitle: 'Aionia TRPG Character Sheet',
       cloudHub: 'Cloud Hub',
       helpLabel: '?',
+      gmTable: 'GMテーブル',
     },
     footer: {
       experience: '経験点',
@@ -310,6 +311,88 @@ export const messages = {
           memo: 'メモ',
         },
       },
+    },
+  },
+  gmTable: {
+    pageTitle: 'GMテーブル',
+    pageSubtitle: 'セッション中の仲間たちを俯瞰し、瞬時に判断するための指令卓',
+    headers: {
+      characterName: 'キャラクター名',
+    },
+    rows: {
+      memo: 'キャラクターメモ',
+      weakness: '弱点',
+      skills: '技能',
+      specialSkills: '特技',
+      weight: '荷重',
+      skillToggle: {
+        detail: '詳細表示に切り替え',
+        summary: '一覧表示に戻す',
+      },
+    },
+    characterMenu: {
+      edit: '編集',
+      reload: '再読込',
+      remove: '削除',
+    },
+    actions: {
+      backToSheet: 'キャラシへ戻る',
+      saveSession: 'GMセッション保存',
+      loadSession: 'GMセッション読み込み',
+      openCharacterMenu: (name) => `${name}の操作メニューを開く`,
+    },
+    labels: {
+      unknownCharacter: '名もなき冒険者',
+      noWeakness: '登録された弱点はありません',
+      noSkill: '習得技能なし',
+      noExpert: '専門技能なし',
+      noSpecialSkill: '特技は未習得です',
+    },
+    placeholders: {
+      characterMemo: 'セッション用メモを記入',
+    },
+    weight: {
+      penaltyNone: 'ペナルティなし',
+      penaltyLight: '軽度ペナルティ',
+      penaltyHeavy: '重度ペナルティ',
+    },
+    session: {
+      memoTitle: 'セッション全体メモ',
+      defaultFileName: 'gm-session.json',
+    },
+    toasts: {
+      added: {
+        title: 'キャラクター追加',
+        message: (fileName) => `${fileName} を読み込みました`,
+      },
+      reloaded: {
+        title: 'キャラクター更新',
+        message: (fileName) => `${fileName} を再読込しました`,
+      },
+      removed: {
+        title: 'キャラクター削除',
+        message: 'テーブルからキャラクターを削除しました',
+      },
+      loadError: {
+        title: '読み込み失敗',
+      },
+      sessionSaved: {
+        title: 'セッション保存',
+        message: '現在のテーブルをJSONとして保存しました',
+      },
+      sessionLoaded: {
+        title: 'セッション読込',
+        message: 'GMセッションデータを読み込みました',
+      },
+      sessionLoadError: {
+        title: 'セッション読込失敗',
+      },
+    },
+    errors: {
+      characterLoad: 'キャラクターデータの解析に失敗しました',
+    },
+    confirm: {
+      delete: (name) => `${name} をテーブルから削除しますか？`,
     },
   },
   outputButton: {


### PR DESCRIPTION
## Summary
- integrate vue-router, move the character sheet view into a dedicated page component, and simplify the app shell
- implement the GM table feature with a Pinia store, floating session memo, and support for saving/loading combined session JSON files
- expose navigation and locale updates so the main header can open the new GM table view

## Testing
- npm run lint *(passes with pre-existing warnings)*
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5fea4d1388326bfd836d8520a09dd