### PR TITLE
Fix session memo window interactions

### DIFF
--- a/src/features/gm-table/components/SessionMemoWindow.css
+++ b/src/features/gm-table/components/SessionMemoWindow.css
@@ -74,14 +74,41 @@
 }
 
 .session-memo-window__resize-handle {
+  position: absolute;
   width: 18px;
   height: 18px;
-  position: absolute;
+}
+
+.session-memo-window__resize-handle--se {
   right: 8px;
   bottom: 8px;
   cursor: se-resize;
   border-right: 2px solid var(--color-border-normal);
   border-bottom: 2px solid var(--color-border-normal);
+}
+
+.session-memo-window__resize-handle--sw {
+  left: 8px;
+  bottom: 8px;
+  cursor: sw-resize;
+  border-left: 2px solid var(--color-border-normal);
+  border-bottom: 2px solid var(--color-border-normal);
+}
+
+.session-memo-window__resize-handle--ne {
+  right: 8px;
+  top: 8px;
+  cursor: ne-resize;
+  border-right: 2px solid var(--color-border-normal);
+  border-top: 2px solid var(--color-border-normal);
+}
+
+.session-memo-window__resize-handle--nw {
+  left: 8px;
+  top: 8px;
+  cursor: nw-resize;
+  border-left: 2px solid var(--color-border-normal);
+  border-top: 2px solid var(--color-border-normal);
 }
 
 .is-minimized {

--- a/src/features/gm-table/components/SessionMemoWindow.vue
+++ b/src/features/gm-table/components/SessionMemoWindow.vue
@@ -1,9 +1,19 @@
 <template>
-  <div class="session-memo-window" :class="{ 'is-minimized': minimized }" :style="windowStyle">
+  <div
+    ref="windowRef"
+    class="session-memo-window"
+    :class="{ 'is-minimized': minimized }"
+    :style="windowStyle"
+  >
     <header class="session-memo-window__header" @pointerdown="startDrag">
       <span class="session-memo-window__title">{{ title }}</span>
       <div class="session-memo-window__actions">
-        <button class="session-memo-window__button" type="button" @click="$emit('toggle-minimize')">
+        <button
+          class="session-memo-window__button"
+          type="button"
+          @pointerdown.stop
+          @click="$emit('toggle-minimize')"
+        >
           {{ minimized ? '▶' : '▼' }}
         </button>
       </div>
@@ -15,12 +25,22 @@
         @input="$emit('update:memo', $event.target.value)"
       ></textarea>
     </section>
-    <div v-show="!minimized" class="session-memo-window__resize-handle" @pointerdown="startResize"></div>
+    <div
+      v-for="direction in resizeDirections"
+      v-show="!minimized"
+      :key="direction"
+      class="session-memo-window__resize-handle"
+      :class="`session-memo-window__resize-handle--${direction}`"
+      @pointerdown="(event) => startResize(direction, event)"
+    ></div>
   </div>
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, reactive } from 'vue';
+import { computed, onBeforeUnmount, onMounted, reactive, ref } from 'vue';
+
+const MIN_WIDTH = 240;
+const MIN_HEIGHT = 200;
 
 const props = defineProps({
   memo: { type: String, default: '' },
@@ -38,6 +58,7 @@ const props = defineProps({
 
 const emit = defineEmits(['update:memo', 'update:position', 'update:size', 'toggle-minimize']);
 
+const windowRef = ref(null);
 const dragState = reactive({
   active: false,
   pointerId: null,
@@ -54,8 +75,51 @@ const resizeState = reactive({
   startY: 0,
   baseWidth: 0,
   baseHeight: 0,
+  baseTop: 0,
+  baseLeft: 0,
+  direction: 'se',
   target: null,
 });
+const resizeDirections = ['se', 'sw', 'ne', 'nw'];
+
+function getCurrentDimensions() {
+  const rect = windowRef.value?.getBoundingClientRect();
+  const width = rect?.width ?? props.size.width;
+  const height = rect?.height ?? props.size.height;
+  return { width, height };
+}
+
+function clampToViewport(top, left, width, height) {
+  if (typeof window === 'undefined') {
+    return { top, left, width, height };
+  }
+
+  let clampedWidth = width;
+  let clampedHeight = height;
+
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+
+  if (clampedWidth > viewportWidth) {
+    clampedWidth = viewportWidth;
+  }
+  if (clampedHeight > viewportHeight) {
+    clampedHeight = viewportHeight;
+  }
+
+  const maxLeft = Math.max(viewportWidth - clampedWidth, 0);
+  const maxTop = Math.max(viewportHeight - clampedHeight, 0);
+
+  const clampedLeft = Math.min(Math.max(left, 0), maxLeft);
+  const clampedTop = Math.min(Math.max(top, 0), maxTop);
+
+  return {
+    top: clampedTop,
+    left: clampedLeft,
+    width: clampedWidth,
+    height: clampedHeight,
+  };
+}
 
 const windowStyle = computed(() => ({
   top: `${props.position.top}px`,
@@ -83,10 +147,14 @@ function onDrag(event) {
   if (!dragState.active || event.pointerId !== dragState.pointerId) return;
   const deltaX = event.clientX - dragState.startX;
   const deltaY = event.clientY - dragState.startY;
-  emit('update:position', {
-    top: dragState.baseTop + deltaY,
-    left: dragState.baseLeft + deltaX,
-  });
+  const { width, height } = getCurrentDimensions();
+  const { top, left } = clampToViewport(
+    dragState.baseTop + deltaY,
+    dragState.baseLeft + deltaX,
+    width,
+    height,
+  );
+  emit('update:position', { top, left });
 }
 
 function endDrag(event) {
@@ -99,7 +167,7 @@ function endDrag(event) {
   dragState.target = null;
 }
 
-function startResize(event) {
+function startResize(direction, event) {
   if (dragState.active) return;
   resizeState.active = true;
   resizeState.pointerId = event.pointerId;
@@ -107,10 +175,14 @@ function startResize(event) {
   resizeState.startY = event.clientY;
   resizeState.baseWidth = props.size.width;
   resizeState.baseHeight = props.size.height;
+  resizeState.baseTop = props.position.top;
+  resizeState.baseLeft = props.position.left;
+  resizeState.direction = direction;
   resizeState.target = event.currentTarget;
   if (resizeState.target?.setPointerCapture) {
     resizeState.target.setPointerCapture(event.pointerId);
   }
+  event.stopPropagation();
   event.preventDefault();
 }
 
@@ -118,9 +190,42 @@ function onResize(event) {
   if (!resizeState.active || event.pointerId !== resizeState.pointerId) return;
   const deltaX = event.clientX - resizeState.startX;
   const deltaY = event.clientY - resizeState.startY;
-  const width = Math.max(240, resizeState.baseWidth + deltaX);
-  const height = Math.max(200, resizeState.baseHeight + deltaY);
+  const direction = resizeState.direction;
+
+  let width = resizeState.baseWidth;
+  let height = resizeState.baseHeight;
+  let top = resizeState.baseTop;
+  let left = resizeState.baseLeft;
+
+  if (direction.includes('e')) {
+    width = resizeState.baseWidth + deltaX;
+  }
+  if (direction.includes('s')) {
+    height = resizeState.baseHeight + deltaY;
+  }
+  if (direction.includes('w')) {
+    width = resizeState.baseWidth - deltaX;
+    left = resizeState.baseLeft + deltaX;
+  }
+  if (direction.includes('n')) {
+    height = resizeState.baseHeight - deltaY;
+    top = resizeState.baseTop + deltaY;
+  }
+
+  width = Math.max(MIN_WIDTH, width);
+  height = Math.max(MIN_HEIGHT, height);
+
+  if (direction.includes('w')) {
+    left = resizeState.baseLeft + (resizeState.baseWidth - width);
+  }
+  if (direction.includes('n')) {
+    top = resizeState.baseTop + (resizeState.baseHeight - height);
+  }
+
+  ({ top, left, width, height } = clampToViewport(top, left, width, height));
+
   emit('update:size', { width, height });
+  emit('update:position', { top, left });
 }
 
 function endResize(event) {


### PR DESCRIPTION
## Summary
- prevent the session memo minimize button from triggering drag gestures so the toggle works reliably
- clamp window dragging and resizing to the viewport to keep the memo accessible
- add resize handles and logic for all four corners of the session memo window

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e61242c4988326aff6bd9a919aaf48