### PR TITLE
Refactor GM session memo into resizable panel

### DIFF
--- a/src/features/gm-table/components/SessionMemoWindow.css
+++ b/src/features/gm-table/components/SessionMemoWindow.css
@@ -1,89 +1,216 @@
 .session-memo-window {
   position: fixed;
+  inset: auto;
   display: flex;
   flex-direction: column;
   background: var(--color-panel-body);
   border: 1px solid var(--color-border-normal);
-  box-shadow: 0 12px 32px rgb(0 0 0 / 70%);
-  border-radius: 12px;
-  backdrop-filter: blur(6px);
+  color: var(--color-text-normal);
+  box-shadow: 0 24px 64px rgb(0 0 0 / 75%);
+  backdrop-filter: blur(8px);
   overflow: hidden;
   z-index: 240;
 }
 
+.session-memo-window--bottom {
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-radius: 24px 24px 0 0;
+  max-height: 80vh;
+  padding-bottom: env(safe-area-inset-bottom, 0);
+}
+
+.session-memo-window--left {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  border-radius: 0 24px 24px 0;
+  max-width: min(520px, 90vw);
+}
+
+.session-memo-window--right {
+  top: 0;
+  bottom: 0;
+  right: 0;
+  border-radius: 24px 0 0 24px;
+  max-width: min(520px, 90vw);
+}
+
+.session-memo-window.is-minimized {
+  overflow: visible;
+}
+
 .session-memo-window__header {
-  cursor: move;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.5rem 0.75rem;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
   background: var(--color-panel-header);
-  color: var(--color-text-normal);
+  border-bottom: 1px solid var(--color-border-normal);
   font-family: 'Cinzel Decorative', 'Shippori Mincho', serif;
   user-select: none;
 }
 
 .session-memo-window__title {
   font-size: 1rem;
+  letter-spacing: 0.04em;
 }
 
 .session-memo-window__actions {
   display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.session-memo-window__orientation {
+  display: inline-flex;
+  align-items: center;
   gap: 0.25rem;
+  padding: 0.25rem;
+  border-radius: 999px;
+  background: var(--color-panel-sub-header);
+  border: 1px solid var(--color-border-normal);
 }
 
 .session-memo-window__button {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
   border: 1px solid var(--color-border-normal);
   background: var(--color-panel-sub-header);
   color: var(--color-text-normal);
-  font-size: 0.9rem;
-  display: flex;
+  font-size: 0.85rem;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   transition:
     background-color 0.2s ease,
+    box-shadow 0.2s ease,
     transform 0.2s ease;
 }
 
 .session-memo-window__button:hover {
   background: var(--color-accent);
+  color: var(--color-text-strong);
   transform: translateY(-1px);
+}
+
+.session-memo-window__button--toggle {
+  width: 36px;
+  height: 32px;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.session-memo-window__button--toggle.is-active {
+  background: var(--color-accent);
+  color: var(--color-text-strong);
+  box-shadow: 0 0 0 1px var(--color-border-strong);
+}
+
+.session-memo-window__button--minimize {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  font-size: 0.95rem;
 }
 
 .session-memo-window__body {
   flex: 1;
-  padding: 0.75rem;
+  padding: 0.75rem 1rem 1rem;
+  display: flex;
 }
 
 .session-memo-window__textarea {
+  flex: 1;
+  min-height: 160px;
   width: 100%;
-  height: 100%;
   background: var(--color-input-bg);
   border: 1px solid var(--color-border-normal);
-  border-radius: 8px;
+  border-radius: 12px;
   color: var(--color-text-normal);
-  padding: 0.75rem;
+  padding: 0.75rem 1rem;
   resize: none;
   font-family: 'Shippori Mincho', serif;
   font-size: 0.95rem;
-  line-height: 1.5;
+  line-height: 1.6;
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 6%);
+}
+
+.session-memo-window__textarea:focus {
+  outline: none;
+  box-shadow:
+    inset 0 0 0 1px var(--color-border-strong),
+    0 0 16px rgb(120 160 255 / 25%);
+}
+
+.session-memo-window--bottom .session-memo-window__body {
+  overflow-y: auto;
 }
 
 .session-memo-window__resize-handle {
-  width: 18px;
-  height: 18px;
   position: absolute;
-  right: 8px;
-  bottom: 8px;
-  cursor: se-resize;
-  border-right: 2px solid var(--color-border-normal);
-  border-bottom: 2px solid var(--color-border-normal);
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.is-minimized {
-  height: auto !important;
+.session-memo-window__resize-handle--bottom {
+  top: -12px;
+  left: 0;
+  right: 0;
+  height: 16px;
+  cursor: ns-resize;
+}
+
+.session-memo-window__resize-handle--left {
+  top: 0;
+  bottom: 0;
+  right: -12px;
+  width: 16px;
+  cursor: ew-resize;
+}
+
+.session-memo-window__resize-handle--right {
+  top: 0;
+  bottom: 0;
+  left: -12px;
+  width: 16px;
+  cursor: ew-resize;
+}
+
+.session-memo-window__resize-grip {
+  display: block;
+  background: var(--color-border-normal);
+  border-radius: 999px;
+  opacity: 0.65;
+  transition: opacity 0.2s ease;
+}
+
+.session-memo-window__resize-handle--bottom .session-memo-window__resize-grip {
+  width: 64px;
+  height: 4px;
+}
+
+.session-memo-window__resize-handle--left .session-memo-window__resize-grip,
+.session-memo-window__resize-handle--right .session-memo-window__resize-grip {
+  width: 4px;
+  height: 64px;
+}
+
+.session-memo-window__resize-handle:hover .session-memo-window__resize-grip {
+  opacity: 1;
+}
+
+@media (max-width: 768px) {
+  .session-memo-window--left,
+  .session-memo-window--right {
+    max-width: 92vw;
+  }
+
+  .session-memo-window__actions {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
 }

--- a/src/features/gm-table/pages/GmTablePage.vue
+++ b/src/features/gm-table/pages/GmTablePage.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { onBeforeUnmount, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { DataManager } from '@/features/character-sheet/services/dataManager.js';
 import { AioniaGameData } from '@/data/gameData.js';
@@ -162,15 +162,12 @@ function saveSession() {
   showToast({ type: 'success', title: gmMessages.toasts.sessionSaved.title, message: gmMessages.toasts.sessionSaved.message });
 }
 
-const memoWindowPosition = computed(() => ({ top: gmStore.sessionWindow.top, left: gmStore.sessionWindow.left }));
-const memoWindowSize = computed(() => ({ width: gmStore.sessionWindow.width, height: gmStore.sessionWindow.height }));
-
-function updateMemoPosition(position) {
-  gmStore.updateSessionWindow(position);
-}
-
 function updateMemoSize(size) {
   gmStore.updateSessionWindow(size);
+}
+
+function updateMemoOrientation(orientation) {
+  gmStore.updateSessionWindow({ orientation });
 }
 
 function toggleMemoWindow() {
@@ -216,13 +213,17 @@ function goToSheet() {
     <input ref="sessionFileInput" type="file" class="gm-file-input" accept=".json" @change="handleSessionFileChange" />
     <SessionMemoWindow
       :memo="gmStore.sessionMemo"
-      :position="memoWindowPosition"
-      :size="memoWindowSize"
+      :width="gmStore.sessionWindow.width"
+      :height="gmStore.sessionWindow.height"
+      :orientation="gmStore.sessionWindow.orientation"
       :minimized="gmStore.sessionWindow.minimized"
       :title="gmMessages.session.memoTitle"
+      :orientation-labels="gmMessages.session.positionLabels"
+      :position-toggle-label="gmMessages.session.positionToggle"
+      :minimize-labels="gmMessages.session.toggleLabels"
       @update:memo="gmStore.updateSessionMemo"
-      @update:position="updateMemoPosition"
       @update:size="updateMemoSize"
+      @update:orientation="updateMemoOrientation"
       @toggle-minimize="toggleMemoWindow"
     />
   </div>

--- a/src/features/gm-table/stores/useGmTableStore.js
+++ b/src/features/gm-table/stores/useGmTableStore.js
@@ -12,13 +12,41 @@ function createId() {
   return `gm-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+const ORIENTATIONS = ['bottom', 'left', 'right'];
+const MIN_WINDOW_WIDTH = 260;
+const MIN_WINDOW_HEIGHT = 180;
+
 const defaultWindowState = () => ({
-  top: 120,
-  left: 40,
+  orientation: 'bottom',
   width: 360,
-  height: 420,
+  height: 320,
   minimized: false,
 });
+
+function normalizeWindowState(raw) {
+  const defaults = defaultWindowState();
+  if (!raw || typeof raw !== 'object') {
+    return defaults;
+  }
+
+  if (typeof raw.orientation === 'string' && ORIENTATIONS.includes(raw.orientation)) {
+    return {
+      ...defaults,
+      ...raw,
+      orientation: raw.orientation,
+      width: typeof raw.width === 'number' ? Math.max(MIN_WINDOW_WIDTH, raw.width) : defaults.width,
+      height: typeof raw.height === 'number' ? Math.max(MIN_WINDOW_HEIGHT, raw.height) : defaults.height,
+      minimized: typeof raw.minimized === 'boolean' ? raw.minimized : defaults.minimized,
+    };
+  }
+
+  return {
+    ...defaults,
+    width: typeof raw.width === 'number' ? Math.max(MIN_WINDOW_WIDTH, raw.width) : defaults.width,
+    height: typeof raw.height === 'number' ? Math.max(MIN_WINDOW_HEIGHT, raw.height) : defaults.height,
+    minimized: typeof raw.minimized === 'boolean' ? raw.minimized : defaults.minimized,
+  };
+}
 
 export const useGmTableStore = defineStore('gmTable', {
   state: () => ({
@@ -81,10 +109,24 @@ export const useGmTableStore = defineStore('gmTable', {
       this.sessionMemo = value;
     },
     updateSessionWindow(partial) {
-      this.sessionWindow = {
-        ...this.sessionWindow,
-        ...partial,
-      };
+      if (!partial || typeof partial !== 'object') return;
+      const next = { ...this.sessionWindow };
+      if (Object.prototype.hasOwnProperty.call(partial, 'orientation')) {
+        const orientation = partial.orientation;
+        if (typeof orientation === 'string' && ORIENTATIONS.includes(orientation)) {
+          next.orientation = orientation;
+        }
+      }
+      if (Object.prototype.hasOwnProperty.call(partial, 'width') && typeof partial.width === 'number') {
+        next.width = Math.max(MIN_WINDOW_WIDTH, partial.width);
+      }
+      if (Object.prototype.hasOwnProperty.call(partial, 'height') && typeof partial.height === 'number') {
+        next.height = Math.max(MIN_WINDOW_HEIGHT, partial.height);
+      }
+      if (Object.prototype.hasOwnProperty.call(partial, 'minimized')) {
+        next.minimized = !!partial.minimized;
+      }
+      this.sessionWindow = next;
     },
     resetWindowState() {
       this.sessionWindow = defaultWindowState();
@@ -115,7 +157,7 @@ export const useGmTableStore = defineStore('gmTable', {
         weaknesses: typeof rowVisibility.weaknesses === 'boolean' ? rowVisibility.weaknesses : false,
       };
       this.skillDetailExpanded = !!skillDetailExpanded;
-      this.sessionWindow = sessionWindow ? { ...defaultWindowState(), ...sessionWindow } : defaultWindowState();
+      this.sessionWindow = sessionWindow ? normalizeWindowState(sessionWindow) : defaultWindowState();
       this.columns = Array.isArray(characters)
         ? characters.map((column) => ({
             id: column.id || createId(),

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -359,6 +359,16 @@ export const messages = {
     session: {
       memoTitle: 'セッション全体メモ',
       defaultFileName: 'gm-session.json',
+      positionToggle: 'メモ表示位置の切り替え',
+      positionLabels: {
+        bottom: 'フッター表示',
+        left: '左サイド表示',
+        right: '右サイド表示',
+      },
+      toggleLabels: {
+        minimize: 'メモを折りたたむ',
+        restore: 'メモを展開する',
+      },
     },
     toasts: {
       added: {


### PR DESCRIPTION
## Summary
- rework the GM session memo UI as a resizable footer/side panel with orientation controls and minimize button
- persist panel orientation and dimensions in the GM table store while normalizing legacy session data
- add Japanese localization strings for the new panel controls

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e616b792888326a95c36a299db04f1