### PR TITLE
Anchor GM session memo alongside table

### DIFF
--- a/src/features/gm-table/components/SessionMemoWindow.css
+++ b/src/features/gm-table/components/SessionMemoWindow.css
@@ -1,89 +1,202 @@
 .session-memo-window {
-  position: fixed;
+  position: relative;
   display: flex;
   flex-direction: column;
   background: var(--color-panel-body);
   border: 1px solid var(--color-border-normal);
-  box-shadow: 0 12px 32px rgb(0 0 0 / 70%);
-  border-radius: 12px;
-  backdrop-filter: blur(6px);
-  overflow: hidden;
-  z-index: 240;
+  border-radius: 20px;
+  color: var(--color-text-normal);
+  box-shadow: 0 16px 40px rgb(0 0 0 / 45%);
+  overflow: visible;
+  min-width: 0;
+  align-self: stretch;
+  flex: none;
+}
+
+.session-memo-window--bottom {
+  width: 100%;
+  max-height: min(60vh, 520px);
+  padding-bottom: env(safe-area-inset-bottom, 0);
+}
+
+.session-memo-window--left,
+.session-memo-window--right {
+  max-width: min(520px, 40vw);
+}
+
+.session-memo-window--left {
+  border-radius: 20px 0 0 20px;
+}
+
+.session-memo-window--right {
+  border-radius: 0 20px 20px 0;
 }
 
 .session-memo-window__header {
-  cursor: move;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.5rem 0.75rem;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
   background: var(--color-panel-header);
-  color: var(--color-text-normal);
+  border-bottom: 1px solid var(--color-border-normal);
   font-family: 'Cinzel Decorative', 'Shippori Mincho', serif;
   user-select: none;
 }
 
 .session-memo-window__title {
   font-size: 1rem;
+  letter-spacing: 0.04em;
 }
 
 .session-memo-window__actions {
   display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.session-memo-window__orientation {
+  display: inline-flex;
+  align-items: center;
   gap: 0.25rem;
+  padding: 0.25rem;
+  border-radius: 999px;
+  background: var(--color-panel-sub-header);
+  border: 1px solid var(--color-border-normal);
 }
 
 .session-memo-window__button {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
   border: 1px solid var(--color-border-normal);
   background: var(--color-panel-sub-header);
   color: var(--color-text-normal);
-  font-size: 0.9rem;
-  display: flex;
+  font-size: 0.85rem;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   transition:
     background-color 0.2s ease,
+    box-shadow 0.2s ease,
     transform 0.2s ease;
 }
 
 .session-memo-window__button:hover {
   background: var(--color-accent);
+  color: var(--color-text-strong);
   transform: translateY(-1px);
+}
+
+.session-memo-window__button--toggle {
+  width: 36px;
+  height: 32px;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.session-memo-window__button--toggle.is-active {
+  background: var(--color-accent);
+  color: var(--color-text-strong);
+  box-shadow: 0 0 0 1px var(--color-border-strong);
 }
 
 .session-memo-window__body {
   flex: 1;
-  padding: 0.75rem;
+  padding: 0.75rem 1rem 1rem;
+  display: flex;
+  min-height: 0;
 }
 
 .session-memo-window__textarea {
+  flex: 1;
+  min-height: 160px;
   width: 100%;
-  height: 100%;
   background: var(--color-input-bg);
   border: 1px solid var(--color-border-normal);
-  border-radius: 8px;
+  border-radius: 12px;
   color: var(--color-text-normal);
-  padding: 0.75rem;
+  padding: 0.75rem 1rem;
   resize: none;
   font-family: 'Shippori Mincho', serif;
   font-size: 0.95rem;
-  line-height: 1.5;
+  line-height: 1.6;
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 6%);
+}
+
+.session-memo-window__textarea:focus {
+  outline: none;
+  box-shadow:
+    inset 0 0 0 1px var(--color-border-strong),
+    0 0 16px rgb(120 160 255 / 25%);
+}
+
+.session-memo-window--bottom .session-memo-window__body {
+  overflow-y: auto;
 }
 
 .session-memo-window__resize-handle {
-  width: 18px;
-  height: 18px;
   position: absolute;
-  right: 8px;
-  bottom: 8px;
-  cursor: se-resize;
-  border-right: 2px solid var(--color-border-normal);
-  border-bottom: 2px solid var(--color-border-normal);
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
 }
 
-.is-minimized {
-  height: auto !important;
+.session-memo-window__resize-handle--bottom {
+  top: -10px;
+  left: 0;
+  right: 0;
+  height: 16px;
+  cursor: ns-resize;
+}
+
+.session-memo-window__resize-handle--left {
+  top: 0;
+  bottom: 0;
+  right: -10px;
+  width: 16px;
+  cursor: ew-resize;
+}
+
+.session-memo-window__resize-handle--right {
+  top: 0;
+  bottom: 0;
+  left: -10px;
+  width: 16px;
+  cursor: ew-resize;
+}
+
+.session-memo-window__resize-grip {
+  display: block;
+  background: var(--color-border-normal);
+  border-radius: 999px;
+  opacity: 0.65;
+  transition: opacity 0.2s ease;
+}
+
+.session-memo-window__resize-handle--bottom .session-memo-window__resize-grip {
+  width: 64px;
+  height: 4px;
+}
+
+.session-memo-window__resize-handle--left .session-memo-window__resize-grip,
+.session-memo-window__resize-handle--right .session-memo-window__resize-grip {
+  width: 4px;
+  height: 64px;
+}
+
+.session-memo-window__resize-handle:hover .session-memo-window__resize-grip {
+  opacity: 1;
+}
+
+@media (max-width: 768px) {
+  .session-memo-window--left,
+  .session-memo-window--right {
+    max-width: 92vw;
+  }
+
+  .session-memo-window__actions {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
 }

--- a/src/features/gm-table/components/SessionMemoWindow.vue
+++ b/src/features/gm-table/components/SessionMemoWindow.vue
@@ -1,52 +1,69 @@
 <template>
-  <div class="session-memo-window" :class="{ 'is-minimized': minimized }" :style="windowStyle">
-    <header class="session-memo-window__header" @pointerdown="startDrag">
+  <div class="session-memo-window" :class="panelClasses" :style="panelStyle">
+    <div
+      :class="['session-memo-window__resize-handle', `session-memo-window__resize-handle--${orientation}`]"
+      @pointerdown="startResize"
+    >
+      <span class="session-memo-window__resize-grip"></span>
+    </div>
+    <header class="session-memo-window__header">
       <span class="session-memo-window__title">{{ title }}</span>
       <div class="session-memo-window__actions">
-        <button class="session-memo-window__button" type="button" @click="$emit('toggle-minimize')">
-          {{ minimized ? '▶' : '▼' }}
-        </button>
+        <div class="session-memo-window__orientation" role="group" :aria-label="positionToggleLabel">
+          <button
+            v-for="option in orientationOptions"
+            :key="option.value"
+            class="session-memo-window__button session-memo-window__button--toggle"
+            type="button"
+            :class="{ 'is-active': option.value === orientation }"
+            :title="option.label"
+            :aria-pressed="option.value === orientation"
+            @click="setOrientation(option.value)"
+          >
+            {{ option.display }}
+          </button>
+        </div>
       </div>
     </header>
-    <section v-show="!minimized" class="session-memo-window__body">
+    <section class="session-memo-window__body">
       <textarea
         class="session-memo-window__textarea"
         :value="memo"
         @input="$emit('update:memo', $event.target.value)"
       ></textarea>
     </section>
-    <div v-show="!minimized" class="session-memo-window__resize-handle" @pointerdown="startResize"></div>
   </div>
 </template>
 
 <script setup>
 import { computed, onBeforeUnmount, onMounted, reactive } from 'vue';
 
+const MIN_HEIGHT = 180;
+const MIN_WIDTH = 260;
+const ORIENTATION_SET = new Set(['bottom', 'left', 'right']);
+
 const props = defineProps({
   memo: { type: String, default: '' },
   title: { type: String, default: 'セッションメモ' },
-  position: {
+  orientation: { type: String, default: 'bottom' },
+  width: { type: Number, default: 360 },
+  height: { type: Number, default: 320 },
+  orientationLabels: {
     type: Object,
-    default: () => ({ top: 120, left: 40 }),
+    default: () => ({
+      bottom: 'フッター表示',
+      left: '左サイド表示',
+      right: '右サイド表示',
+    }),
   },
-  size: {
-    type: Object,
-    default: () => ({ width: 320, height: 420 }),
+  positionToggleLabel: {
+    type: String,
+    default: 'メモ表示位置の切り替え',
   },
-  minimized: { type: Boolean, default: false },
 });
 
-const emit = defineEmits(['update:memo', 'update:position', 'update:size', 'toggle-minimize']);
+const emit = defineEmits(['update:memo', 'update:size', 'update:orientation']);
 
-const dragState = reactive({
-  active: false,
-  pointerId: null,
-  startX: 0,
-  startY: 0,
-  baseTop: 0,
-  baseLeft: 0,
-  target: null,
-});
 const resizeState = reactive({
   active: false,
   pointerId: null,
@@ -54,59 +71,51 @@ const resizeState = reactive({
   startY: 0,
   baseWidth: 0,
   baseHeight: 0,
+  mode: 'bottom',
   target: null,
 });
 
-const windowStyle = computed(() => ({
-  top: `${props.position.top}px`,
-  left: `${props.position.left}px`,
-  width: `${props.size.width}px`,
-  height: props.minimized ? 'auto' : `${props.size.height}px`,
+const normalizedOrientationLabels = computed(() => ({
+  bottom: props.orientationLabels?.bottom ?? 'フッター表示',
+  left: props.orientationLabels?.left ?? '左サイド表示',
+  right: props.orientationLabels?.right ?? '右サイド表示',
 }));
 
-function startDrag(event) {
-  if (resizeState.active) return;
-  dragState.active = true;
-  dragState.pointerId = event.pointerId;
-  dragState.startX = event.clientX;
-  dragState.startY = event.clientY;
-  dragState.baseTop = props.position.top;
-  dragState.baseLeft = props.position.left;
-  dragState.target = event.currentTarget;
-  if (dragState.target?.setPointerCapture) {
-    dragState.target.setPointerCapture(event.pointerId);
-  }
-  event.preventDefault();
-}
+const orientationOptions = computed(() => [
+  { value: 'bottom', label: normalizedOrientationLabels.value.bottom, display: '下' },
+  { value: 'left', label: normalizedOrientationLabels.value.left, display: '左' },
+  { value: 'right', label: normalizedOrientationLabels.value.right, display: '右' },
+]);
 
-function onDrag(event) {
-  if (!dragState.active || event.pointerId !== dragState.pointerId) return;
-  const deltaX = event.clientX - dragState.startX;
-  const deltaY = event.clientY - dragState.startY;
-  emit('update:position', {
-    top: dragState.baseTop + deltaY,
-    left: dragState.baseLeft + deltaX,
-  });
-}
+const panelClasses = computed(() => ({
+  'session-memo-window--bottom': props.orientation === 'bottom',
+  'session-memo-window--left': props.orientation === 'left',
+  'session-memo-window--right': props.orientation === 'right',
+}));
 
-function endDrag(event) {
-  if (!dragState.active || event.pointerId !== dragState.pointerId) return;
-  dragState.active = false;
-  if (dragState.target?.releasePointerCapture) {
-    dragState.target.releasePointerCapture(event.pointerId);
+const panelStyle = computed(() => {
+  const style = {};
+  if (props.orientation === 'bottom') {
+    style.height = `${Math.max(MIN_HEIGHT, props.height)}px`;
+  } else {
+    style.width = `${Math.max(MIN_WIDTH, props.width)}px`;
   }
-  dragState.pointerId = null;
-  dragState.target = null;
+  return style;
+});
+
+function setOrientation(value) {
+  if (!ORIENTATION_SET.has(value) || value === props.orientation) return;
+  emit('update:orientation', value);
 }
 
 function startResize(event) {
-  if (dragState.active) return;
   resizeState.active = true;
   resizeState.pointerId = event.pointerId;
   resizeState.startX = event.clientX;
   resizeState.startY = event.clientY;
-  resizeState.baseWidth = props.size.width;
-  resizeState.baseHeight = props.size.height;
+  resizeState.baseWidth = props.width;
+  resizeState.baseHeight = props.height;
+  resizeState.mode = props.orientation;
   resizeState.target = event.currentTarget;
   if (resizeState.target?.setPointerCapture) {
     resizeState.target.setPointerCapture(event.pointerId);
@@ -116,11 +125,19 @@ function startResize(event) {
 
 function onResize(event) {
   if (!resizeState.active || event.pointerId !== resizeState.pointerId) return;
-  const deltaX = event.clientX - resizeState.startX;
-  const deltaY = event.clientY - resizeState.startY;
-  const width = Math.max(240, resizeState.baseWidth + deltaX);
-  const height = Math.max(200, resizeState.baseHeight + deltaY);
-  emit('update:size', { width, height });
+  if (resizeState.mode === 'bottom') {
+    const delta = resizeState.startY - event.clientY;
+    const height = Math.max(MIN_HEIGHT, resizeState.baseHeight + delta);
+    emit('update:size', { height });
+  } else if (resizeState.mode === 'left') {
+    const delta = event.clientX - resizeState.startX;
+    const width = Math.max(MIN_WIDTH, resizeState.baseWidth + delta);
+    emit('update:size', { width });
+  } else if (resizeState.mode === 'right') {
+    const delta = resizeState.startX - event.clientX;
+    const width = Math.max(MIN_WIDTH, resizeState.baseWidth + delta);
+    emit('update:size', { width });
+  }
 }
 
 function endResize(event) {
@@ -134,12 +151,10 @@ function endResize(event) {
 }
 
 function onPointerMove(event) {
-  onDrag(event);
   onResize(event);
 }
 
 function onPointerUp(event) {
-  endDrag(event);
   endResize(event);
 }
 
@@ -156,6 +171,7 @@ function removeGlobalListeners() {
 }
 
 onMounted(addGlobalListeners);
+
 onBeforeUnmount(removeGlobalListeners);
 
 if (import.meta.hot) {
@@ -166,4 +182,3 @@ if (import.meta.hot) {
 </script>
 
 <style scoped src="./SessionMemoWindow.css"></style>
-

--- a/src/features/gm-table/pages/GmTablePage.css
+++ b/src/features/gm-table/pages/GmTablePage.css
@@ -5,6 +5,30 @@
   color: var(--color-text-normal);
 }
 
+.gm-table-page__workspace {
+  display: flex;
+  gap: 24px;
+  margin-top: 24px;
+  align-items: stretch;
+}
+
+.gm-table-page__workspace--bottom {
+  flex-direction: column;
+}
+
+.gm-table-page__workspace--left {
+  flex-direction: row;
+}
+
+.gm-table-page__workspace--right {
+  flex-direction: row-reverse;
+}
+
+.gm-table-page__main {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .gm-file-input {
   display: none;
 }
@@ -12,5 +36,15 @@
 @media (max-width: 960px) {
   .gm-table-page {
     padding: 96px 12px 48px;
+  }
+
+  .gm-table-page__workspace {
+    gap: 16px;
+    margin-top: 16px;
+  }
+
+  .gm-table-page__workspace--left,
+  .gm-table-page__workspace--right {
+    flex-direction: column;
   }
 }

--- a/src/features/gm-table/pages/GmTablePage.vue
+++ b/src/features/gm-table/pages/GmTablePage.vue
@@ -162,24 +162,22 @@ function saveSession() {
   showToast({ type: 'success', title: gmMessages.toasts.sessionSaved.title, message: gmMessages.toasts.sessionSaved.message });
 }
 
-const memoWindowPosition = computed(() => ({ top: gmStore.sessionWindow.top, left: gmStore.sessionWindow.left }));
-const memoWindowSize = computed(() => ({ width: gmStore.sessionWindow.width, height: gmStore.sessionWindow.height }));
-
-function updateMemoPosition(position) {
-  gmStore.updateSessionWindow(position);
-}
-
 function updateMemoSize(size) {
   gmStore.updateSessionWindow(size);
 }
 
-function toggleMemoWindow() {
-  gmStore.updateSessionWindow({ minimized: !gmStore.sessionWindow.minimized });
+function updateMemoOrientation(orientation) {
+  gmStore.updateSessionWindow({ orientation });
 }
 
 function goToSheet() {
   router.push({ name: 'character-sheet' });
 }
+
+const workspaceClasses = computed(() => [
+  'gm-table-page__workspace',
+  `gm-table-page__workspace--${gmStore.sessionWindow.orientation}`,
+]);
 </script>
 
 <template>
@@ -195,36 +193,41 @@ function goToSheet() {
       @save="saveSession"
       @load="triggerSessionLoad"
     />
-    <GmTableLayout
-      :columns="gmStore.columns"
-      :gm-messages="gmMessages"
-      :row-visibility="gmStore.rowVisibility"
-      :skill-detail-expanded="gmStore.skillDetailExpanded"
-      :active-menu-id="activeMenuId"
-      @toggle-memo-row="toggleMemoRow"
-      @toggle-weakness-row="toggleWeaknessRow"
-      @toggle-skill-detail="toggleSkillDetail"
-      @open-menu="openMenu"
-      @edit-character="editCharacter"
-      @reload-character="reloadCharacter"
-      @delete-character="deleteCharacter"
-      @set-character-memo="(id, value) => gmStore.setCharacterMemo(id, value)"
-      @add-character="triggerAddCharacter"
-    />
+    <div :class="workspaceClasses">
+      <div class="gm-table-page__main">
+        <GmTableLayout
+          :columns="gmStore.columns"
+          :gm-messages="gmMessages"
+          :row-visibility="gmStore.rowVisibility"
+          :skill-detail-expanded="gmStore.skillDetailExpanded"
+          :active-menu-id="activeMenuId"
+          @toggle-memo-row="toggleMemoRow"
+          @toggle-weakness-row="toggleWeaknessRow"
+          @toggle-skill-detail="toggleSkillDetail"
+          @open-menu="openMenu"
+          @edit-character="editCharacter"
+          @reload-character="reloadCharacter"
+          @delete-character="deleteCharacter"
+          @set-character-memo="(id, value) => gmStore.setCharacterMemo(id, value)"
+          @add-character="triggerAddCharacter"
+        />
+      </div>
+      <SessionMemoWindow
+        :memo="gmStore.sessionMemo"
+        :width="gmStore.sessionWindow.width"
+        :height="gmStore.sessionWindow.height"
+        :orientation="gmStore.sessionWindow.orientation"
+        :title="gmMessages.session.memoTitle"
+        :orientation-labels="gmMessages.session.positionLabels"
+        :position-toggle-label="gmMessages.session.positionToggle"
+        @update:memo="gmStore.updateSessionMemo"
+        @update:size="updateMemoSize"
+        @update:orientation="updateMemoOrientation"
+      />
+    </div>
     <input ref="characterFileInput" type="file" class="gm-file-input" accept=".json,.zip" @change="handleCharacterFileChange" />
     <input ref="reloadFileInput" type="file" class="gm-file-input" accept=".json,.zip" @change="handleReloadFileChange" />
     <input ref="sessionFileInput" type="file" class="gm-file-input" accept=".json" @change="handleSessionFileChange" />
-    <SessionMemoWindow
-      :memo="gmStore.sessionMemo"
-      :position="memoWindowPosition"
-      :size="memoWindowSize"
-      :minimized="gmStore.sessionWindow.minimized"
-      :title="gmMessages.session.memoTitle"
-      @update:memo="gmStore.updateSessionMemo"
-      @update:position="updateMemoPosition"
-      @update:size="updateMemoSize"
-      @toggle-minimize="toggleMemoWindow"
-    />
   </div>
 </template>
 

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -359,6 +359,12 @@ export const messages = {
     session: {
       memoTitle: 'セッション全体メモ',
       defaultFileName: 'gm-session.json',
+      positionToggle: 'メモ表示位置の切り替え',
+      positionLabels: {
+        bottom: 'フッター表示',
+        left: '左サイド表示',
+        right: '右サイド表示',
+      },
     },
     toasts: {
       added: {


### PR DESCRIPTION
## Summary
- embed the GM session memo panel directly into the GM table workspace with orientation-aware flex layout and resize handles
- simplify the SessionMemoWindow component to remove the obsolete minimize mode and adjust its styling for docked display
- update the GM table store persistence and Japanese locale strings to reflect the streamlined panel behavior

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e616b792888326a95c36a299db04f1