### PR TITLE
Add Auth0 routing and debug console

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 
 最新版は [GitHub Pages](https://ktakahiro1729.github.io/AioniaCS/) で公開しています。
 
+## Google Cloud API 利用箇所
+
+- Google Drive 連携の初期化は `src/app/main.js` で行い、`VITE_GOOGLE_API_KEY` と `VITE_GOOGLE_CLIENT_ID` を使って本番用またはモック用のドライブマネージャーを構築します。
+- クラウド同期のフロントロジックは `src/features/cloud-sync/composables/useGoogleDrive.js` にあり、`https://apis.google.com/js/api.js` で提供される Google API クライアント（Drive/Picker）と `https://accounts.google.com/gsi/client` で提供される Google Identity Services を読み込み、GAPI クライアントと GIS トークンクライアントを初期化します。
+- Drive API への具体的なリクエスト（フォルダー作成、ファイル一覧取得、マルチパートでのアップロード、Picker を使ったファイル／フォルダー選択など）は `src/infrastructure/google-drive/googleDriveManager.js` で実装されています。
+- Auth0 経由のログイン・トークン配布を行う場合、`VITE_AUTH0_DOMAIN`、`VITE_AUTH0_CLIENT_ID`、`VITE_AUTH0_AUDIENCE`（および Auth0 から Google アクセストークンを受け取るための `VITE_AUTH0_DRIVE_TOKEN_URL`）を設定し、`/debug` ルートのデバッグページからセッション状態や Drive トークンの適用状況を確認できます。
+
 ## クレジット
 
 本サイトは [TRPG **「慈悲なきアイオニア」**](https://www.aioniatrpg.com/)（作者: **イチ（フシギ製作所）**）の二次創作であり、**あろすてりっく** が作成したものです。

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@auth0/auth0-vue": "^2.4.0",
         "@noble/hashes": "^1.8.0",
         "@vue/compiler-sfc": "^3.5.16",
         "@vue/test-utils": "^2.4.6",
@@ -19,7 +20,8 @@
         "marked": "^15.0.12",
         "pako": "^2.1.0",
         "pinia": "^2.1.7",
-        "vue": "^3.5.13"
+        "vue": "^3.5.13",
+        "vue-router": "^4.6.3"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.24.7",
@@ -72,6 +74,35 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+    },
+    "node_modules/@auth0/auth0-spa-js": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.8.0.tgz",
+      "integrity": "sha512-Lu3dBius0CMRHNAWtw/RyIZH0b5B4jV9ZlVjpp5s7A11AO/XyABkNl0VW7Cz5ZHpAkXEba1CMnkxDG1/9LNIqg==",
+      "license": "MIT",
+      "dependencies": {
+        "browser-tabs-lock": "^1.2.15",
+        "dpop": "^2.1.1",
+        "es-cookie": "~1.3.2"
+      }
+    },
+    "node_modules/@auth0/auth0-vue": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-vue/-/auth0-vue-2.4.0.tgz",
+      "integrity": "sha512-12iLvojP8Pvxqu2Abxzksp0HqlSovGiAUhWrppnOaJP02MZEBQo+c/IwM6VbM0edNk+eqqjX5u96iw5peaCPSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@auth0/auth0-spa-js": "^2.1.3",
+        "vue": "^3.2.41"
+      },
+      "peerDependencies": {
+        "vue-router": "^4.0.12"
+      },
+      "peerDependenciesMeta": {
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -3334,6 +3365,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-tabs-lock": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-tabs-lock/-/browser-tabs-lock-1.3.0.tgz",
+      "integrity": "sha512-g6nHaobTiT0eMZ7jh16YpD2kcjAp+PInbiVq3M1x6KKaEIVhT4v9oURNIpZLOZ3LQbQ3XYfNhMAb/9hzNLIWrw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": ">=4.17.21"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.25.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
@@ -3915,6 +3956,15 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
+    "node_modules/dpop": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dpop/-/dpop-2.1.1.tgz",
+      "integrity": "sha512-J0Of2JTiM4h5si0tlbPQ/lkqfZ5wAEVkKYBhkwyyANnPJfWH4VsR5uIkZ+T+OSPIwDYUg1fbd5Mmodd25HjY1w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4038,6 +4088,12 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "node_modules/es-cookie": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-cookie/-/es-cookie-1.3.2.tgz",
+      "integrity": "sha512-UTlYYhXGLOy05P/vKVT2Ui7WtC7NiRzGtJyAKKn32g5Gvcjn7KAClLPWlipCtxIus934dFg9o9jXiBL0nP+t9Q==",
+      "license": "MIT"
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -5546,9 +5602,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -9132,6 +9186,21 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.3.tgz",
+      "integrity": "sha512-ARBedLm9YlbvQomnmq91Os7ck6efydTSpRP3nuOKCvgJOHNrhRoJDSKtee8kcL1Vf7nz6U+PMBL+hTvR3bTVQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@auth0/auth0-vue": "^2.4.0",
     "@noble/hashes": "^1.8.0",
     "@vue/compiler-sfc": "^3.5.16",
     "@vue/test-utils": "^2.4.6",
@@ -29,7 +30,8 @@
     "marked": "^15.0.12",
     "pako": "^2.1.0",
     "pinia": "^2.1.7",
-    "vue": "^3.5.13"
+    "vue": "^3.5.13",
+    "vue-router": "^4.6.3"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.24.7",

--- a/src/app/RootApp.vue
+++ b/src/app/RootApp.vue
@@ -1,0 +1,3 @@
+<template>
+  <RouterView />
+</template>

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -1,6 +1,8 @@
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
-import App from './App.vue';
+import { createAuth0 } from '@auth0/auth0-vue';
+import RootApp from './RootApp.vue';
+import { router } from './router/index.js';
 import { initializeGoogleDriveManager, initializeMockGoogleDriveManager } from '@/infrastructure/google-drive/index.js';
 import '@/shared/styles/style.css';
 
@@ -11,6 +13,18 @@ if (useMockDrive) {
   initializeGoogleDriveManager(import.meta.env.VITE_GOOGLE_API_KEY, import.meta.env.VITE_GOOGLE_CLIENT_ID);
 }
 
-const app = createApp(App);
+const app = createApp(RootApp);
 app.use(createPinia());
+app.use(
+  createAuth0({
+    domain: import.meta.env.VITE_AUTH0_DOMAIN,
+    clientId: import.meta.env.VITE_AUTH0_CLIENT_ID,
+    authorizationParams: {
+      audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+      scope: 'openid profile email offline_access',
+      redirect_uri: window.location.origin,
+    },
+  }),
+);
+app.use(router);
 app.mount('#app');

--- a/src/app/providers/useAuth0Client.js
+++ b/src/app/providers/useAuth0Client.js
@@ -1,0 +1,37 @@
+import { computed } from 'vue';
+import { useAuth0 } from '@auth0/auth0-vue';
+
+export function useAuth0Client() {
+  const auth0 = useAuth0();
+  const isAuthenticated = computed(() => auth0.isAuthenticated.value);
+  const user = computed(() => auth0.user.value);
+  const isLoading = computed(() => auth0.isLoading.value);
+
+  async function ensureLogin(options = {}) {
+    if (isAuthenticated.value) {
+      return true;
+    }
+    await auth0.loginWithRedirect(options);
+    return true;
+  }
+
+  async function logout(options = {}) {
+    await auth0.logout({
+      logoutParams: { returnTo: window.location.origin, ...options.logoutParams },
+    });
+  }
+
+  async function getAccessToken(options = {}) {
+    return auth0.getAccessTokenSilently(options);
+  }
+
+  return {
+    isAuthenticated,
+    isLoading,
+    user,
+    ensureLogin,
+    logout,
+    getAccessToken,
+    loginWithRedirect: auth0.loginWithRedirect,
+  };
+}

--- a/src/app/router/index.js
+++ b/src/app/router/index.js
@@ -1,0 +1,20 @@
+import { createRouter, createWebHistory } from 'vue-router';
+import App from '@/app/App.vue';
+
+const AuthDebugPage = () => import('@/features/debug/pages/AuthDebugPage.vue');
+
+const routes = [
+  {
+    path: '/',
+    component: App,
+  },
+  {
+    path: '/debug',
+    component: AuthDebugPage,
+  },
+];
+
+export const router = createRouter({
+  history: createWebHistory(),
+  routes,
+});

--- a/src/features/cloud-sync/services/auth0DriveTokenClient.js
+++ b/src/features/cloud-sync/services/auth0DriveTokenClient.js
@@ -1,0 +1,26 @@
+export async function fetchDriveAccessTokenFromAuth0(getAccessTokenSilently) {
+  const tokenExchangeUrl = import.meta.env.VITE_AUTH0_DRIVE_TOKEN_URL;
+  if (!tokenExchangeUrl || typeof getAccessTokenSilently !== 'function') {
+    return null;
+  }
+
+  const auth0Token = await getAccessTokenSilently({
+    authorizationParams: {
+      audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+      scope: 'openid profile email offline_access',
+    },
+  });
+
+  const response = await fetch(tokenExchangeUrl, {
+    headers: {
+      Authorization: `Bearer ${auth0Token}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch Drive access token via Auth0.');
+  }
+
+  const payload = await response.json();
+  return payload?.access_token || payload?.googleAccessToken || null;
+}

--- a/src/features/cloud-sync/stores/uiStore.js
+++ b/src/features/cloud-sync/stores/uiStore.js
@@ -10,6 +10,7 @@ export const useUiStore = defineStore('ui', {
     isLoading: false,
     driveFolderPath: '慈悲なきアイオニア',
     currentDriveFileId: null,
+    driveAccessToken: null,
     isViewingShared: false,
     pendingDriveSaves: {},
     showHeader: true,
@@ -39,6 +40,10 @@ export const useUiStore = defineStore('ui', {
     },
     clearCurrentDriveFileId() {
       this.currentDriveFileId = null;
+    },
+    setDriveAccessToken(token) {
+      this.driveAccessToken = token;
+      this.isSignedIn = !!token;
     },
     setDriveFolderPath(path) {
       this.driveFolderPath = path;

--- a/src/features/debug/pages/AuthDebugPage.vue
+++ b/src/features/debug/pages/AuthDebugPage.vue
@@ -1,0 +1,340 @@
+<script setup>
+import { computed, ref } from 'vue';
+import { useAuth0Client } from '@/app/providers/useAuth0Client.js';
+import { useGoogleDrive } from '@/features/cloud-sync/composables/useGoogleDrive.js';
+import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
+import { useDataExport } from '@/features/character-sheet/composables/useDataExport.js';
+import { getGoogleDriveManagerInstance } from '@/infrastructure/google-drive/googleDriveManager.js';
+import { fetchDriveAccessTokenFromAuth0 } from '@/features/cloud-sync/services/auth0DriveTokenClient.js';
+
+const { dataManager } = useDataExport();
+const uiStore = useUiStore();
+const {
+  canSignInToGoogle,
+  isDriveReady,
+  handleSignInClick,
+  handleSignOutClick,
+  refreshDriveFolderPath,
+} = useGoogleDrive(dataManager);
+const auth0Client = useAuth0Client();
+const tokenPreview = ref(null);
+const tokenError = ref(null);
+
+const driveManager = computed(() => {
+  try {
+    return getGoogleDriveManagerInstance();
+  } catch (error) {
+    console.warn('Drive manager not initialized yet:', error);
+    return null;
+  }
+});
+
+const authUser = computed(() => auth0Client.user.value || {});
+const isAuthenticated = computed(() => auth0Client.isAuthenticated.value);
+const isAuthLoading = computed(() => auth0Client.isLoading.value);
+
+const driveState = computed(() => ({
+  isGapiInitialized: uiStore.isGapiInitialized,
+  isGisInitialized: uiStore.isGisInitialized,
+  driveFolderPath: uiStore.driveFolderPath,
+  currentDriveFileId: uiStore.currentDriveFileId,
+  hasDriveToken: !!uiStore.driveAccessToken,
+  isSignedIn: uiStore.isSignedIn,
+  pickerReady: !!driveManager.value?.pickerApiLoaded,
+}));
+
+async function fetchAuth0AccessToken() {
+  tokenError.value = null;
+  tokenPreview.value = null;
+  try {
+    tokenPreview.value = await auth0Client.getAccessToken({
+      authorizationParams: {
+        audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+        scope: 'openid profile email offline_access',
+      },
+    });
+  } catch (error) {
+    tokenError.value = error?.message || 'Failed to fetch Auth0 token.';
+  }
+}
+
+async function refreshDriveTokenViaAuth0() {
+  tokenError.value = null;
+  try {
+    const driveToken = await fetchDriveAccessTokenFromAuth0(auth0Client.getAccessToken);
+    if (driveToken && driveManager.value) {
+      await driveManager.value.applyExternalAccessToken(driveToken);
+    }
+    uiStore.setDriveAccessToken(driveToken || null);
+    tokenPreview.value = driveToken;
+  } catch (error) {
+    tokenError.value = error?.message || 'Failed to refresh Drive token via Auth0.';
+  }
+}
+
+async function reapplyStoredToken() {
+  if (driveManager.value && uiStore.driveAccessToken) {
+    await driveManager.value.applyExternalAccessToken(uiStore.driveAccessToken);
+  }
+}
+</script>
+
+<template>
+  <div class="debug-page">
+    <h1>Auth0 / Drive Debug Console</h1>
+    <p class="hint">App 本体は App.vue に触れず、ルーター経由でこのページにアクセスできます。</p>
+
+    <section class="panel">
+      <header class="panel__header">
+        <div>
+          <p class="panel__title">Auth0 セッション</p>
+          <p class="panel__subtitle">ログイン/ログアウト、アクセストークン取得の確認</p>
+        </div>
+        <div class="panel__actions">
+          <button type="button" class="button" :disabled="isAuthLoading" @click="auth0Client.loginWithRedirect">
+            Auth0 でログイン
+          </button>
+          <button type="button" class="button button--ghost" :disabled="!isAuthenticated" @click="auth0Client.logout">
+            Auth0 からログアウト
+          </button>
+          <button type="button" class="button" :disabled="isAuthLoading" @click="fetchAuth0AccessToken">
+            アクセストークン取得
+          </button>
+        </div>
+      </header>
+      <div class="panel__content">
+        <div class="grid grid--two">
+          <div>
+            <p class="label">状態</p>
+            <p class="value">{{ isAuthLoading ? 'loading...' : isAuthenticated ? 'authenticated' : 'anonymous' }}</p>
+          </div>
+          <div>
+            <p class="label">ユーザー</p>
+            <p class="value">
+              <span v-if="authUser?.email">{{ authUser.email }}</span>
+              <span v-else class="muted">未ログイン</span>
+            </p>
+          </div>
+        </div>
+        <div class="token-box" v-if="tokenPreview">
+          <p class="label">取得済みトークン</p>
+          <pre>{{ tokenPreview }}</pre>
+        </div>
+        <p v-if="tokenError" class="error">{{ tokenError }}</p>
+      </div>
+    </section>
+
+    <section class="panel">
+      <header class="panel__header">
+        <div>
+          <p class="panel__title">Drive / Picker ステータス</p>
+          <p class="panel__subtitle">Auth0 セッションを前提に GAPI/GIS・Picker の準備状況を確認</p>
+        </div>
+        <div class="panel__actions">
+          <button type="button" class="button" :disabled="!canSignInToGoogle" @click="handleSignInClick">
+            Drive を Auth0 経由で初期化
+          </button>
+          <button type="button" class="button button--ghost" :disabled="!driveState.isSignedIn" @click="handleSignOutClick">
+            Drive からサインアウト
+          </button>
+          <button type="button" class="button" :disabled="!driveState.hasDriveToken" @click="refreshDriveFolderPath">
+            フォルダ設定を再読込
+          </button>
+        </div>
+      </header>
+      <div class="panel__content">
+        <div class="grid grid--three">
+          <div>
+            <p class="label">GAPI</p>
+            <p class="value" :class="{ 'value--ok': driveState.isGapiInitialized }">
+              {{ driveState.isGapiInitialized ? 'initialized' : 'pending' }}
+            </p>
+          </div>
+          <div>
+            <p class="label">GIS</p>
+            <p class="value" :class="{ 'value--ok': driveState.isGisInitialized }">
+              {{ driveState.isGisInitialized ? 'initialized' : 'pending' }}
+            </p>
+          </div>
+          <div>
+            <p class="label">Picker</p>
+            <p class="value" :class="{ 'value--ok': driveState.pickerReady }">
+              {{ driveState.pickerReady ? 'ready' : 'pending' }}
+            </p>
+          </div>
+        </div>
+        <div class="grid grid--two">
+          <div>
+            <p class="label">Drive トークン</p>
+            <p class="value" :class="{ 'value--ok': driveState.hasDriveToken }">
+              {{ driveState.hasDriveToken ? 'available' : 'missing' }}
+            </p>
+          </div>
+          <div>
+            <p class="label">サインイン状態</p>
+            <p class="value">{{ driveState.isSignedIn ? 'signed-in' : 'signed-out' }}</p>
+          </div>
+        </div>
+        <div class="grid grid--two">
+          <div>
+            <p class="label">キャラクターフォルダ</p>
+            <p class="value">{{ driveState.driveFolderPath }}</p>
+          </div>
+          <div>
+            <p class="label">カレントファイル</p>
+            <p class="value">{{ driveState.currentDriveFileId || '---' }}</p>
+          </div>
+        </div>
+        <div class="panel__actions">
+          <button type="button" class="button" :disabled="!isDriveReady" @click="reapplyStoredToken">
+            Drive トークンを GAPI に再適用
+          </button>
+          <button type="button" class="button" :disabled="!isAuthenticated" @click="refreshDriveTokenViaAuth0">
+            Auth0 M2M 経由で Drive トークン再取得
+          </button>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.debug-page {
+  color: #f5f5f5;
+  background: #0f1115;
+  min-height: 100vh;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  letter-spacing: 0.02em;
+}
+
+.hint {
+  margin: 0;
+  color: #b5b7c0;
+  font-size: 0.95rem;
+}
+
+.panel {
+  border: 1px solid #1f2430;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #131722, #0f1118);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.panel__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #1f2430;
+  align-items: center;
+}
+
+.panel__title {
+  margin: 0;
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.panel__subtitle {
+  margin: 0.1rem 0 0;
+  color: #9ca3af;
+  font-size: 0.95rem;
+}
+
+.panel__content {
+  padding: 1.25rem 1.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.panel__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.button {
+  background: #36406a;
+  color: #f7f9fb;
+  border: none;
+  padding: 0.6rem 0.9rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 700;
+  transition: background 0.2s ease;
+}
+
+.button:hover:not(:disabled) {
+  background: #46528a;
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.button--ghost {
+  background: transparent;
+  border: 1px solid #36406a;
+}
+
+.grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.grid--two {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.grid--three {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.label {
+  margin: 0;
+  color: #b1b5c4;
+  font-size: 0.9rem;
+}
+
+.value {
+  margin: 0.15rem 0 0;
+  font-weight: 700;
+}
+
+.value--ok {
+  color: #8ef4c1;
+}
+
+.muted {
+  color: #7a7f8c;
+}
+
+.token-box {
+  border: 1px solid #1f2430;
+  border-radius: 8px;
+  padding: 0.75rem;
+  background: #0c0e12;
+}
+
+.token-box pre {
+  margin: 0.25rem 0 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.error {
+  color: #f4a6a6;
+  margin: 0;
+}
+</style>

--- a/src/infrastructure/google-drive/mockGoogleDriveManager.js
+++ b/src/infrastructure/google-drive/mockGoogleDriveManager.js
@@ -17,6 +17,7 @@ export class MockGoogleDriveManager {
     this.storageKey = 'mockGoogleDriveData';
     this.configFileId = 'mock-config';
     this.pickerApiLoaded = true;
+    this.driveAccessToken = null;
     this._loadState();
     singletonInstance = this;
   }
@@ -46,6 +47,7 @@ export class MockGoogleDriveManager {
 
     this.configuredFolderId = null;
     this.cachedFolderPath = null;
+    this.driveAccessToken = null;
     this._saveState();
   }
 
@@ -65,6 +67,7 @@ export class MockGoogleDriveManager {
     };
     this.configuredFolderId = null;
     this.cachedFolderPath = null;
+    this.driveAccessToken = null;
     this._saveState();
   }
 
@@ -132,14 +135,34 @@ export class MockGoogleDriveManager {
 
   handleSignIn(callback) {
     this.state.signedIn = true;
+    this.driveAccessToken = 'mock-access-token';
     this._saveState();
-    if (callback) callback(null, { signedIn: true });
+    if (callback) callback(null, { signedIn: true, accessToken: this.driveAccessToken });
   }
 
   handleSignOut(callback) {
     this.state.signedIn = false;
+    this.driveAccessToken = null;
     this._saveState();
     if (callback) callback();
+  }
+
+  setAccessToken(accessToken) {
+    this.driveAccessToken = accessToken;
+  }
+
+  requestDriveAccessToken() {
+    this.driveAccessToken = 'mock-access-token';
+    return Promise.resolve(this.driveAccessToken);
+  }
+
+  async applyExternalAccessToken(accessToken) {
+    this.setAccessToken(accessToken);
+    return accessToken;
+  }
+
+  async revokeAccessToken() {
+    this.driveAccessToken = null;
   }
 
   async loadConfig() {

--- a/tests/unit/composables/useGoogleDrive.test.js
+++ b/tests/unit/composables/useGoogleDrive.test.js
@@ -1,3 +1,4 @@
+import { vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { useGoogleDrive } from '@/features/cloud-sync/composables/useGoogleDrive.js';
 import { useCharacterStore } from '@/features/character-sheet/stores/characterStore.js';
@@ -5,6 +6,17 @@ import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
 
 vi.mock('@/features/modals/composables/useModal.js', () => ({
   useModal: vi.fn(),
+}));
+
+vi.mock('@auth0/auth0-vue', () => ({
+  useAuth0: () => ({
+    isAuthenticated: { value: true },
+    isLoading: { value: false },
+    user: { value: { email: 'tester@example.com' } },
+    loginWithRedirect: vi.fn(),
+    logout: vi.fn(),
+    getAccessTokenSilently: vi.fn().mockResolvedValue('auth0-token'),
+  }),
 }));
 
 import { useModal } from '@/features/modals/composables/useModal.js';
@@ -43,6 +55,7 @@ describe('useGoogleDrive', () => {
     const uiStore = useUiStore();
     uiStore.isGapiInitialized = true;
     uiStore.isGisInitialized = true;
+    uiStore.setDriveAccessToken('token');
     charStore.character.name = 'Hero';
     uiStore.setCurrentDriveFileId('existing-id');
 
@@ -71,6 +84,7 @@ describe('useGoogleDrive', () => {
     const uiStore = useUiStore();
     uiStore.isGapiInitialized = true;
     uiStore.isGisInitialized = true;
+    uiStore.setDriveAccessToken('token');
     charStore.character.name = 'Hero';
     uiStore.clearCurrentDriveFileId();
 
@@ -101,6 +115,7 @@ describe('useGoogleDrive', () => {
     const uiStore = useUiStore();
     uiStore.isGapiInitialized = true;
     uiStore.isGisInitialized = true;
+    uiStore.setDriveAccessToken('token');
 
     const result = await saveCharacterToDrive(true);
 
@@ -130,6 +145,7 @@ describe('useGoogleDrive', () => {
     const uiStore = useUiStore();
     uiStore.isGapiInitialized = true;
     uiStore.isGisInitialized = true;
+    uiStore.setDriveAccessToken('token');
 
     const result = await loadCharacterFromDrive();
 

--- a/tests/unit/googleDriveAuth.test.js
+++ b/tests/unit/googleDriveAuth.test.js
@@ -32,12 +32,12 @@ describe('GoogleDriveManager auth', () => {
     });
   });
 
-  test('handleSignOut revokes token and clears gapi token', () => {
+  test('handleSignOut revokes token and clears gapi token', async () => {
     const gdm = initializeGoogleDriveManager('k', 'c');
     gdm.tokenClient = { requestAccessToken: vi.fn() };
     gapi.client.getToken.mockReturnValue({ access_token: 't' });
     const cb = vi.fn();
-    gdm.handleSignOut(cb);
+    await gdm.handleSignOut(cb);
     expect(google.accounts.oauth2.revoke).toHaveBeenCalledWith('t', expect.any(Function));
     expect(gapi.client.setToken).toHaveBeenCalledWith('');
     expect(cb).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- add a router wrapper and mount Auth0 plugin while keeping the existing App.vue intact
- refactor Drive auth flows to accept Auth0-provided tokens and offline GIS tokens, plus a debug page at /debug to inspect state
- document new Auth0 environment variables and token bridge endpoint

## Testing
- npm run lint
- npm run test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a7e7fe84c83269b80bdb3ff60ba02)