### PR TITLE
Add server-side Google auth flow for Drive integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ test-results/
 .VSCodeCounter
 stats.html
 .env
+.dev.vars
+.wrangler/*

--- a/functions/api/[[route]].js
+++ b/functions/api/[[route]].js
@@ -1,0 +1,275 @@
+import { Hono } from 'hono';
+import { getCookie, setCookie, deleteCookie } from 'hono/cookie';
+
+const SESSION_COOKIE_NAME = 'aioniacs_session';
+const STATE_COOKIE_NAME = 'aioniacs_oauth_state';
+const AUTH_SCOPE = 'https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive.file openid email profile';
+const SESSION_TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days
+const STATE_TTL_SECONDS = 10 * 60; // 10 minutes
+
+const encoder = new TextEncoder();
+
+function bufferToBase64(buffer) {
+  if (typeof btoa === 'function') {
+    const bytes = Array.from(new Uint8Array(buffer))
+      .map((b) => String.fromCharCode(b))
+      .join('');
+    return btoa(bytes);
+  }
+  return Buffer.from(buffer).toString('base64');
+}
+
+async function signPayload(secret, payload) {
+  const key = await crypto.subtle.importKey('raw', encoder.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(payload));
+  return bufferToBase64(signature);
+}
+
+function constantTimeEqual(a, b) {
+  const aBytes = encoder.encode(a);
+  const bBytes = encoder.encode(b);
+  if (aBytes.length !== bBytes.length) {
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < aBytes.length; i += 1) {
+    diff |= aBytes[i] ^ bBytes[i];
+  }
+  return diff === 0;
+}
+
+async function generateState(secret) {
+  const random = crypto.getRandomValues(new Uint8Array(16));
+  const nonce = Array.from(random)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  const issuedAt = Date.now();
+  const payload = `${nonce}:${issuedAt}`;
+  const signature = await signPayload(secret, payload);
+  return `${payload}:${signature}`;
+}
+
+async function verifyState(secret, state) {
+  if (!state) {
+    return false;
+  }
+  const segments = state.split(':');
+  if (segments.length !== 3) {
+    return false;
+  }
+  const [, issuedAtStr, signature] = segments;
+  const issuedAt = Number(issuedAtStr);
+  if (!Number.isFinite(issuedAt) || Date.now() - issuedAt > STATE_TTL_SECONDS * 1000) {
+    return false;
+  }
+  const payload = segments.slice(0, 2).join(':');
+  const expectedSignature = await signPayload(secret, payload);
+  return constantTimeEqual(signature, expectedSignature);
+}
+
+function buildAuthUrl(clientId, redirectUri, state) {
+  const url = new URL('https://accounts.google.com/o/oauth2/v2/auth');
+  url.searchParams.set('client_id', clientId);
+  url.searchParams.set('redirect_uri', redirectUri);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('scope', AUTH_SCOPE);
+  url.searchParams.set('access_type', 'offline');
+  url.searchParams.set('include_granted_scopes', 'true');
+  url.searchParams.set('prompt', 'consent');
+  url.searchParams.set('state', state);
+  return url.toString();
+}
+
+function getRedirectUri(request) {
+  const url = new URL(request.url);
+  return `${url.origin}/api/auth/callback`;
+}
+
+async function exchangeCodeForTokens(env, code, redirectUri) {
+  const params = new URLSearchParams({
+    code,
+    client_id: env.GOOGLE_CLIENT_ID,
+    client_secret: env.GOOGLE_CLIENT_SECRET,
+    redirect_uri: redirectUri,
+    grant_type: 'authorization_code',
+  });
+
+  const response = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`Failed to exchange code: ${message}`);
+  }
+
+  return response.json();
+}
+
+async function refreshAccessToken(env, refreshToken) {
+  const params = new URLSearchParams({
+    client_id: env.GOOGLE_CLIENT_ID,
+    client_secret: env.GOOGLE_CLIENT_SECRET,
+    refresh_token: refreshToken,
+    grant_type: 'refresh_token',
+  });
+
+  const response = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`Failed to refresh token: ${message}`);
+  }
+
+  return response.json();
+}
+
+async function fetchUserInfo(accessToken) {
+  const response = await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`Failed to fetch user info: ${message}`);
+  }
+
+  return response.json();
+}
+
+function buildCookieOptions(maxAgeSeconds) {
+  return {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'Lax',
+    path: '/',
+    maxAge: maxAgeSeconds,
+  };
+}
+
+function createSessionId() {
+  const random = crypto.getRandomValues(new Uint8Array(16));
+  return Array.from(random)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+const app = new Hono();
+
+app.get('/api/auth/login', async (c) => {
+  const { GOOGLE_CLIENT_ID, SESSION_SECRET } = c.env;
+  if (!GOOGLE_CLIENT_ID || !SESSION_SECRET) {
+    return c.json({ error: 'Missing OAuth configuration.' }, 500);
+  }
+
+  const state = await generateState(SESSION_SECRET);
+  const redirectUri = getRedirectUri(c.req.raw);
+  const authUrl = buildAuthUrl(GOOGLE_CLIENT_ID, redirectUri, state);
+
+  setCookie(c, STATE_COOKIE_NAME, state, buildCookieOptions(STATE_TTL_SECONDS));
+
+  return c.redirect(authUrl, 302);
+});
+
+app.get('/api/auth/callback', async (c) => {
+  const { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, SESSION_SECRET, DB } = c.env;
+  if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET || !SESSION_SECRET) {
+    return c.json({ error: 'Missing OAuth configuration.' }, 500);
+  }
+
+  const url = new URL(c.req.url);
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+  const storedState = getCookie(c, STATE_COOKIE_NAME);
+
+  if (!code || !state || !storedState) {
+    return c.json({ error: 'Invalid authorization response.' }, 400);
+  }
+
+  const stateValid = await verifyState(SESSION_SECRET, state);
+  if (!stateValid || state !== storedState) {
+    deleteCookie(c, STATE_COOKIE_NAME, { path: '/' });
+    return c.json({ error: 'State validation failed.' }, 400);
+  }
+
+  try {
+    const redirectUri = getRedirectUri(c.req.raw);
+    const tokenResult = await exchangeCodeForTokens(c.env, code, redirectUri);
+    const user = await fetchUserInfo(tokenResult.access_token);
+
+    if (!tokenResult.refresh_token) {
+      return c.json({ error: 'Refresh token was not returned by Google.' }, 400);
+    }
+
+    const sessionId = createSessionId();
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const expiresAt = nowSeconds + SESSION_TTL_SECONDS;
+
+    await DB.prepare('INSERT INTO sessions (id, user_id, email, refresh_token, created_at, expires_at) VALUES (?, ?, ?, ?, ?, ?)')
+      .bind(sessionId, user.id || user.sub || 'unknown', user.email || '', tokenResult.refresh_token, nowSeconds, expiresAt)
+      .run();
+
+    setCookie(c, SESSION_COOKIE_NAME, sessionId, buildCookieOptions(SESSION_TTL_SECONDS));
+    deleteCookie(c, STATE_COOKIE_NAME, { path: '/' });
+
+    return c.redirect('/', 302);
+  } catch (error) {
+    console.error('OAuth callback error:', error);
+    return c.json({ error: 'Failed to complete authorization.' }, 500);
+  }
+});
+
+app.get('/api/auth/status', async (c) => {
+  const sessionId = getCookie(c, SESSION_COOKIE_NAME);
+  if (!sessionId) {
+    return c.json({ error: 'Not authenticated.' }, 401);
+  }
+
+  try {
+    const session = await c.env.DB.prepare('SELECT * FROM sessions WHERE id = ?').bind(sessionId).first();
+    const nowSeconds = Math.floor(Date.now() / 1000);
+
+    if (!session || session.expires_at <= nowSeconds) {
+      await c.env.DB.prepare('DELETE FROM sessions WHERE id = ?').bind(sessionId).run();
+      deleteCookie(c, SESSION_COOKIE_NAME, { path: '/' });
+      return c.json({ error: 'Session expired.' }, 401);
+    }
+
+    const refreshed = await refreshAccessToken(c.env, session.refresh_token);
+
+    if (refreshed.refresh_token) {
+      await c.env.DB.prepare('UPDATE sessions SET refresh_token = ?, expires_at = ? WHERE id = ?')
+        .bind(refreshed.refresh_token, nowSeconds + SESSION_TTL_SECONDS, sessionId)
+        .run();
+    } else {
+      await c.env.DB.prepare('UPDATE sessions SET expires_at = ? WHERE id = ?')
+        .bind(nowSeconds + SESSION_TTL_SECONDS, sessionId)
+        .run();
+    }
+
+    return c.json({ access_token: refreshed.access_token, expires_in: refreshed.expires_in });
+  } catch (error) {
+    console.error('Auth status error:', error);
+    return c.json({ error: 'Failed to refresh access token.' }, 500);
+  }
+});
+
+app.post('/api/auth/logout', async (c) => {
+  const sessionId = getCookie(c, SESSION_COOKIE_NAME);
+  if (sessionId) {
+    await c.env.DB.prepare('DELETE FROM sessions WHERE id = ?').bind(sessionId).run();
+  }
+  deleteCookie(c, SESSION_COOKIE_NAME, { path: '/' });
+  return c.json({ success: true });
+});
+
+export default app;
+export { app };
+
+export const onRequest = async (context) => app.fetch(context.request, context.env, context.ctx);

--- a/functions/api/[[route]].js
+++ b/functions/api/[[route]].js
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { getCookie, setCookie, deleteCookie } from 'hono/cookie';
+import { handle } from 'hono/cloudflare-pages';
 
 const SESSION_COOKIE_NAME = 'aioniacs_session';
 const STATE_COOKIE_NAME = 'aioniacs_oauth_state';
@@ -269,7 +270,6 @@ app.post('/api/auth/logout', async (c) => {
   return c.json({ success: true });
 });
 
-export default app;
 export { app };
 
-export const onRequest = async (context) => app.fetch(context.request, context.env, context.ctx);
+export const onRequest = handle(app);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@vue/test-utils": "^2.4.6",
         "dompurify": "^3.2.6",
         "form-data": "^4.0.4",
+        "hono": "^4.10.6",
         "jsdom": "^24.0.0",
         "jszip": "^3.10.1",
         "marked": "^15.0.12",
@@ -4826,6 +4827,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.10.6",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.10.6.tgz",
+      "integrity": "sha512-BIdolzGpDO9MQ4nu3AUuDwHZZ+KViNm+EZ75Ae55eMXMqLVhDFqEMXxtUe9Qh8hjL+pIna/frs2j6Y2yD5Ua/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/hookified": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@vue/test-utils": "^2.4.6",
     "dompurify": "^3.2.6",
     "form-data": "^4.0.4",
+    "hono": "^4.10.6",
     "jsdom": "^24.0.0",
     "jszip": "^3.10.1",
     "marked": "^15.0.12",

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,9 @@
+-- Cloudflare D1 schema for storing Google OAuth sessions
+CREATE TABLE IF NOT EXISTS sessions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT,
+  email TEXT,
+  refresh_token TEXT,
+  created_at INTEGER,
+  expires_at INTEGER
+);

--- a/src/features/character-sheet/components/ui/MainHeader.vue
+++ b/src/features/character-sheet/components/ui/MainHeader.vue
@@ -4,6 +4,12 @@
       <button class="button-base main-header__button" @click="handleNewCharacterClick">
         {{ newCharacterLabel }}
       </button>
+    </div>
+    <div class="main-header__title">{{ titleText }}</div>
+    <div class="main-header__section main-header__section--right">
+      <button class="button-base main-header__button" @click="handleAuthClick">
+        {{ isSignedIn ? signOutLabel : signInLabel }}
+      </button>
       <button
         class="button-base header-help-icon"
         ref="helpIcon"
@@ -14,12 +20,6 @@
         type="button"
       >
         {{ helpLabel }}
-      </button>
-    </div>
-    <div class="main-header__title">{{ titleText }}</div>
-    <div class="main-header__section main-header__section--right">
-      <button class="button-base main-header__button" @click="handleAuthClick">
-        {{ isSignedIn ? signOutLabel : signInLabel }}
       </button>
     </div>
   </header>

--- a/src/features/cloud-sync/stores/uiStore.js
+++ b/src/features/cloud-sync/stores/uiStore.js
@@ -24,7 +24,7 @@ export const useUiStore = defineStore('ui', {
         : 'status-display--experience-ok';
     },
     canSignInToGoogle(state) {
-      return state.isGapiInitialized && state.isGisInitialized && !state.isSignedIn;
+      return !state.isSignedIn;
     },
     canOperateDrive(state) {
       return state.isSignedIn;

--- a/src/features/modals/components/contents/LoadModal.vue
+++ b/src/features/modals/components/contents/LoadModal.vue
@@ -1,13 +1,15 @@
 <template>
   <div class="load-modal">
-    <section class="load-modal__section">
-      <label class="button-base load-modal__button">
-        {{ loadLocalLabel }}
-        <input type="file" class="hidden" accept=".json,.txt,.zip" @change="handleLocalChange" />
-      </label>
+    <section v-if="!isSignedIn" class="load-modal__section">
+      <p class="load-modal__signin-message">{{ signInMessage }}</p>
+      <button class="button-base load-modal__button" :disabled="!canSignIn" data-test="load-modal-signin" @click="$emit('sign-in')">
+        {{ signInLabel }}
+      </button>
     </section>
-
     <section class="load-modal__section load-modal__section--drive">
+      <button class="button-base load-modal__button" v-if="canUseDrive" data-test="load-modal-drive-button" @click="$emit('load-drive')">
+        {{ loadDriveLabel }}
+      </button>
       <div class="load-modal__config">
         <label class="load-modal__label" :for="folderInputId">{{ driveFolderLabel }}</label>
         <div class="load-modal__input-group">
@@ -31,26 +33,12 @@
           </button>
         </div>
       </div>
-      <button
-        class="button-base load-modal__button"
-        :disabled="!canUseDrive"
-        data-test="load-modal-drive-button"
-        @click="$emit('load-drive')"
-      >
-        {{ loadDriveLabel }}
-      </button>
     </section>
-
-    <section v-if="!isSignedIn" class="load-modal__section load-modal__section--signin">
-      <p class="load-modal__signin-message">{{ signInMessage }}</p>
-      <button
-        class="button-base load-modal__button"
-        :disabled="!canSignIn"
-        data-test="load-modal-signin"
-        @click="$emit('sign-in')"
-      >
-        {{ signInLabel }}
-      </button>
+    <section class="load-modal__section load-modal__section--local">
+      <label class="button-base load-modal__button">
+        {{ loadLocalLabel }}
+        <input type="file" class="hidden" accept=".json,.txt,.zip" @change="handleLocalChange" />
+      </label>
     </section>
   </div>
 </template>
@@ -164,7 +152,7 @@ function handleLocalChange(event) {
   padding-inline: 12px;
 }
 
-.load-modal__section--signin {
+.load-modal__section--local {
   border-top: 1px solid var(--color-border-normal);
   padding-top: 12px;
 }

--- a/src/infrastructure/google-drive/mockGoogleDriveManager.js
+++ b/src/infrastructure/google-drive/mockGoogleDriveManager.js
@@ -126,14 +126,14 @@ export class MockGoogleDriveManager {
     return Promise.resolve();
   }
 
-  async onGisLoad() {
-    return Promise.resolve();
+  async restoreSession() {
+    return this.state.signedIn;
   }
 
   handleSignIn(callback) {
     this.state.signedIn = true;
     this._saveState();
-    if (callback) callback(null, { signedIn: true });
+    if (callback) callback(null, { redirected: true });
   }
 
   handleSignOut(callback) {

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -121,7 +121,7 @@ export const messages = {
       placeholder: '慈悲なきアイオニア',
     },
     buttons: {
-      signIn: 'ログイン',
+      signIn: 'ログイン／Driveから読み込む',
     },
   },
   image: {

--- a/tests/unit/composables/useGoogleDrive.test.js
+++ b/tests/unit/composables/useGoogleDrive.test.js
@@ -44,6 +44,7 @@ describe('useGoogleDrive', () => {
     const uiStore = useUiStore();
     uiStore.isGapiInitialized = true;
     uiStore.isGisInitialized = true;
+    uiStore.isSignedIn = true;
     charStore.character.name = 'Hero';
     uiStore.setCurrentDriveFileId('existing-id');
 
@@ -73,6 +74,7 @@ describe('useGoogleDrive', () => {
     const uiStore = useUiStore();
     uiStore.isGapiInitialized = true;
     uiStore.isGisInitialized = true;
+    uiStore.isSignedIn = true;
     charStore.character.name = 'Hero';
     uiStore.clearCurrentDriveFileId();
 
@@ -104,6 +106,7 @@ describe('useGoogleDrive', () => {
     const uiStore = useUiStore();
     uiStore.isGapiInitialized = true;
     uiStore.isGisInitialized = true;
+    uiStore.isSignedIn = true;
 
     const result = await saveCharacterToDrive(true);
 
@@ -134,6 +137,7 @@ describe('useGoogleDrive', () => {
     const uiStore = useUiStore();
     uiStore.isGapiInitialized = true;
     uiStore.isGisInitialized = true;
+    uiStore.isSignedIn = true;
 
     const result = await loadCharacterFromDrive();
 
@@ -188,6 +192,7 @@ describe('useGoogleDrive', () => {
     charStore.character.name = 'Knight';
     uiStore.isGapiInitialized = true;
     uiStore.isGisInitialized = true;
+    uiStore.isSignedIn = true;
     uiStore.setCurrentDriveFileId('existing-id');
 
     const result = await saveCharacterToDrive();

--- a/tests/unit/functions/authApi.test.js
+++ b/tests/unit/functions/authApi.test.js
@@ -1,0 +1,183 @@
+import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
+import app from '../../../functions/api/[[route]].js';
+
+function createMockDb() {
+  const sessions = new Map();
+  return {
+    sessions,
+    prepare(query) {
+      const normalized = query.trim().toLowerCase();
+      return {
+        bind: (...params) => ({
+          async first() {
+            if (normalized.startsWith('select')) {
+              const [id] = params;
+              return sessions.get(id) || null;
+            }
+            return null;
+          },
+          async run() {
+            if (normalized.startsWith('insert')) {
+              const [id, userId, email, refreshToken, createdAt, expiresAt] = params;
+              sessions.set(id, {
+                id,
+                user_id: userId,
+                email,
+                refresh_token: refreshToken,
+                created_at: createdAt,
+                expires_at: expiresAt,
+              });
+              return { success: true };
+            }
+            if (normalized.startsWith('delete')) {
+              const [id] = params;
+              sessions.delete(id);
+              return { success: true };
+            }
+            if (normalized.startsWith('update sessions set refresh_token')) {
+              const [refreshToken, expiresAt, id] = params;
+              const existing = sessions.get(id);
+              if (existing) {
+                existing.refresh_token = refreshToken;
+                existing.expires_at = expiresAt;
+                sessions.set(id, existing);
+              }
+              return { success: true };
+            }
+            if (normalized.startsWith('update sessions set expires_at')) {
+              const [expiresAt, id] = params;
+              const existing = sessions.get(id);
+              if (existing) {
+                existing.expires_at = expiresAt;
+                sessions.set(id, existing);
+              }
+              return { success: true };
+            }
+            return { success: false };
+          },
+        }),
+      };
+    },
+  };
+}
+
+function readCookie(headers, name) {
+  const raw = headers.getSetCookie ? headers.getSetCookie() : [headers.get('set-cookie')].filter(Boolean);
+  const cookieHeader = raw?.find((c) => c && c.startsWith(`${name}=`));
+  if (!cookieHeader) return null;
+  const [pair] = cookieHeader.split(';');
+  return pair.split('=')[1];
+}
+
+describe('Cloudflare auth functions', () => {
+  let env;
+  let db;
+
+  beforeEach(() => {
+    db = createMockDb();
+    env = {
+      GOOGLE_CLIENT_ID: 'client-id',
+      GOOGLE_CLIENT_SECRET: 'client-secret',
+      SESSION_SECRET: 'secret',
+      DB: db,
+    };
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('login endpoint redirects to Google with state cookie', async () => {
+    const res = await app.request('https://example.com/api/auth/login', {}, env);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('accounts.google.com');
+    const state = readCookie(res.headers, 'aioniacs_oauth_state');
+    expect(state).toBeTruthy();
+  });
+
+  test('callback exchanges code, stores session, and sets cookie', async () => {
+    const loginRes = await app.request('https://example.com/api/auth/login', {}, env);
+    const state = readCookie(loginRes.headers, 'aioniacs_oauth_state');
+
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'access', refresh_token: 'refresh', expires_in: 3600 }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 'user-1', email: 'user@example.com' }) });
+
+    const res = await app.request(
+      `https://example.com/api/auth/callback?code=abc&state=${state}`,
+      {
+        headers: { Cookie: `aioniacs_oauth_state=${state}` },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(302);
+    const sessionId = readCookie(res.headers, 'aioniacs_session');
+    expect(sessionId).toBeTruthy();
+    const stored = db.sessions.get(sessionId);
+    expect(stored.refresh_token).toBe('refresh');
+    expect(stored.email).toBe('user@example.com');
+  });
+
+  test('status endpoint refreshes access token using stored session', async () => {
+    const sessionId = 'session-1';
+    const now = Math.floor(Date.now() / 1000);
+    db.sessions.set(sessionId, {
+      id: sessionId,
+      user_id: 'user',
+      email: 'user@example.com',
+      refresh_token: 'refresh-old',
+      created_at: now,
+      expires_at: now + 1000,
+    });
+
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: 'new-access', refresh_token: 'refresh-new', expires_in: 1200 }),
+    });
+
+    const res = await app.request(
+      'https://example.com/api/auth/status',
+      {
+        headers: { Cookie: `aioniacs_session=${sessionId}` },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.access_token).toBe('new-access');
+    expect(db.sessions.get(sessionId).refresh_token).toBe('refresh-new');
+  });
+
+  test('logout endpoint clears session', async () => {
+    const sessionId = 'session-logout';
+    db.sessions.set(sessionId, {
+      id: sessionId,
+      user_id: 'user',
+      email: 'user@example.com',
+      refresh_token: 'refresh-old',
+      created_at: 0,
+      expires_at: 100,
+    });
+
+    const res = await app.request(
+      'https://example.com/api/auth/logout',
+      {
+        method: 'POST',
+        headers: { Cookie: `aioniacs_session=${sessionId}` },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(db.sessions.has(sessionId)).toBe(false);
+    const cleared = readCookie(res.headers, 'aioniacs_session');
+    expect(cleared).toBe('');
+  });
+});

--- a/tests/unit/googleDriveManager.test.js
+++ b/tests/unit/googleDriveManager.test.js
@@ -11,6 +11,7 @@ describe('GoogleDriveManager configuration and folder handling', () => {
 
   beforeEach(() => {
     resetGoogleDriveManagerForTests();
+    global.fetch = vi.fn();
     global.gapi = {
       client: {
         drive: {
@@ -23,9 +24,12 @@ describe('GoogleDriveManager configuration and folder handling', () => {
           },
         },
         request: vi.fn(),
+        getToken: vi.fn(() => ({ access_token: 'cached-token' })),
+        setToken: vi.fn(),
       },
     };
     gdm = initializeGoogleDriveManager('key', 'client');
+    gdm.currentTokenInfo = { accessToken: 'cached-token', expiresAt: Date.now() + 100000 };
   });
 
   afterEach(() => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,4 @@
+[[d1_databases]]
+binding = "DB" # Honoからこの名前でアクセスします
+database_name = "aionia-auth-db"
+database_id = "ad247af3-274f-4e1b-ae6f-3e58ed596ac3"


### PR DESCRIPTION
## Summary
- add Hono-based Cloudflare Pages Functions endpoints for Google OAuth with D1-backed sessions and state verification
- persist session schema for D1 and cover the auth workflow with unit tests
- update Google Drive manager and Vue composables to fetch server-issued tokens instead of GIS

## Testing
- npm test
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c135a95b48326a5748f860f66dd2f)