### PR TITLE
Improve error reporting and localization

### DIFF
--- a/src/app/providers/useAppInitialization.js
+++ b/src/app/providers/useAppInitialization.js
@@ -51,17 +51,42 @@ function buildDriveDownloadUrl(fileId, dataManager) {
   return fallbackUrl.toString();
 }
 
+function createSharedDataParser(dataManager) {
+  return async function parseSharedPayload(buffer) {
+    try {
+      const rawJsonData = await deserializeCharacterPayload(buffer);
+      return dataManager.parseLoadedData(rawJsonData);
+    } catch (error) {
+      const normalized = error instanceof Error ? error : new Error('Failed to parse shared character data.');
+      normalized.code = 'parseFailed';
+      throw normalized;
+    }
+  };
+}
+
+function resolveSharedErrorKey(error) {
+  if (error?.code === 'fetchFailed') {
+    return 'fetchFailed';
+  }
+  if (error?.code === 'parseFailed') {
+    return 'parseFailed';
+  }
+  return 'general';
+}
+
 export function useAppInitialization(dataManager) {
   const characterStore = useCharacterStore();
   const uiStore = useUiStore();
-  const { showToast } = useNotifications();
+  const { logAndToastError } = useNotifications();
+
+  const parseSharedPayload = dataManager && typeof dataManager.parseLoadedData === 'function' ? createSharedDataParser(dataManager) : null;
 
   async function loadSharedCharacter(fileId) {
     if (!fileId) {
       return false;
     }
 
-    if (!dataManager || typeof dataManager.parseLoadedData !== 'function') {
+    if (!parseSharedPayload) {
       console.error('DataManager is required to load shared characters.');
       return false;
     }
@@ -75,22 +100,7 @@ export function useAppInitialization(dataManager) {
       }
 
       const buffer = await response.arrayBuffer();
-
-      let rawJsonData;
-      try {
-        rawJsonData = await deserializeCharacterPayload(buffer);
-      } catch (parseError) {
-        parseError.code = 'parseFailed';
-        throw parseError;
-      }
-
-      let parsedData;
-      try {
-        parsedData = dataManager.parseLoadedData(rawJsonData);
-      } catch (parseError) {
-        parseError.code = 'parseFailed';
-        throw parseError;
-      }
+      const parsedData = await parseSharedPayload(buffer);
 
       Object.assign(characterStore.character, parsedData.character);
       characterStore.skills.splice(0, characterStore.skills.length, ...parsedData.skills);
@@ -102,9 +112,8 @@ export function useAppInitialization(dataManager) {
       uiStore.isViewingShared = true;
       return true;
     } catch (error) {
-      const key = error?.code === 'fetchFailed' ? 'fetchFailed' : error?.code === 'parseFailed' ? 'parseFailed' : 'general';
-      showToast({ type: 'error', ...messages.share.loadError.toast(key) });
-      console.error('Error loading shared character:', error);
+      const key = resolveSharedErrorKey(error);
+      logAndToastError(error, () => messages.share.loadError.toast(key), 'loadSharedCharacter');
       return false;
     }
   }

--- a/src/features/notifications/composables/useNotifications.js
+++ b/src/features/notifications/composables/useNotifications.js
@@ -1,4 +1,5 @@
 import { useNotificationStore } from '../stores/notificationStore.js';
+import { messages } from '@/locales/ja.js';
 
 function normalizeError(error) {
   if (error instanceof Error) {
@@ -10,12 +11,12 @@ function normalizeError(error) {
   }
 
   if (error && typeof error === 'object') {
-    const normalized = new Error(error.message || '予期せぬエラーが発生しました');
+    const normalized = new Error(error.message || messages.errors.unexpected);
     Object.assign(normalized, error);
     return normalized;
   }
 
-  return new Error('予期せぬエラーが発生しました');
+  return new Error(messages.errors.unexpected);
 }
 
 function resolveToastOptions(source, error) {

--- a/src/features/notifications/composables/useNotifications.js
+++ b/src/features/notifications/composables/useNotifications.js
@@ -1,5 +1,38 @@
 import { useNotificationStore } from '../stores/notificationStore.js';
 
+function normalizeError(error) {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  if (typeof error === 'string') {
+    return new Error(error);
+  }
+
+  if (error && typeof error === 'object') {
+    const normalized = new Error(error.message || '予期せぬエラーが発生しました');
+    Object.assign(normalized, error);
+    return normalized;
+  }
+
+  return new Error('予期せぬエラーが発生しました');
+}
+
+function resolveToastOptions(source, error) {
+  if (typeof source === 'function') {
+    return source(error);
+  }
+
+  if (source && typeof source === 'object') {
+    if (!source.message && error?.message) {
+      return { ...source, message: error.message };
+    }
+    return source;
+  }
+
+  return { message: error?.message || '' };
+}
+
 export function useNotifications() {
   const store = useNotificationStore();
 
@@ -7,34 +40,44 @@ export function useNotifications() {
     return store.addToast(options);
   }
 
-  function showAsyncToast(promise, messages) {
+  function logError(error, context = 'notification') {
+    const normalized = normalizeError(error);
+    const label = context ? `[${context}]` : '[notification]';
+    console.error(label, normalized);
+    return normalized;
+  }
+
+  function logAndToastError(error, toastOptions, context) {
+    const normalized = logError(error, context);
+    const resolved = resolveToastOptions(toastOptions, normalized);
+    return showToast({ type: 'error', ...resolved });
+  }
+
+  function showAsyncToast(promise, messages, context = 'async-toast') {
     const id = showToast({
       duration: 0,
       type: 'info',
       ...(messages.loading || {}),
     });
+
     const finalize = (opts, type) => {
       const duration = opts.duration === undefined ? 1000 : opts.duration;
-      console.log(opts.duration, opts.duration === undefined, duration);
-      store.updateToast(id, { duration: duration, type, ...opts });
+      store.updateToast(id, { duration, type, ...opts });
     };
+
     promise
       .then((res) => {
         finalize(messages.success || {}, 'success');
         return res;
       })
       .catch((err) => {
-        const errorOpts =
-          typeof messages.error === 'function'
-            ? messages.error(err)
-            : {
-                ...(messages.error || {}),
-                message: (messages.error && messages.error.message) || err.message,
-              };
+        const normalized = logError(err, context);
+        const errorOpts = resolveToastOptions(messages.error, normalized);
         finalize(errorOpts, 'error');
       });
+
     return promise;
   }
 
-  return { showToast, showAsyncToast };
+  return { showToast, showAsyncToast, logAndToastError };
 }

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -1,5 +1,8 @@
 export const messages = {
   googleDrive: {
+    auth: {
+      connected: () => ({ title: 'Google Drive', message: '接続しました' }),
+    },
     signIn: {
       loading: () => ({
         title: 'Google Drive',
@@ -15,6 +18,7 @@ export const messages = {
       success: () => ({ title: 'サインアウトしました', message: '' }),
     },
     folderPicker: {
+      unavailable: () => ({ title: 'Google Drive', message: 'フォルダピッカーを利用できません' }),
       error: (err) => ({
         title: 'Google Drive',
         message: err?.message || 'フォルダ選択をキャンセルしました',
@@ -38,6 +42,8 @@ export const messages = {
         title: '読み込みエラー',
         message: err.message || '不明なエラー',
       }),
+      noSelection: () => ({ title: '読み込みエラー', message: 'ファイルが選択されていません' }),
+      missingData: () => ({ title: '読み込みエラー', message: 'キャラクターデータを取得できませんでした' }),
     },
     overwriteConfirm: (name) => ({
       title: '上書き確認',
@@ -83,7 +89,7 @@ export const messages = {
         title: '共有失敗',
         message: err?.message || '共有リンクの生成に失敗しました',
       }),
-      clipboardUnavailable: 'クリップボードにアクセスできません',
+      clipboardUnavailable: () => ({ title: '共有リンク', message: 'クリップボードにアクセスできません' }),
     },
     errors: {
       saveFailed: 'Google Drive への保存に失敗しました',
@@ -198,6 +204,7 @@ export const messages = {
             title: 'チャットパレット',
             message: err?.message || 'コピーに失敗しました',
           }),
+          clipboardUnavailable: 'クリップボード機能が利用できません',
         },
       },
     },

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -1,4 +1,7 @@
 export const messages = {
+  errors: {
+    unexpected: '予期せぬエラーが発生しました',
+  },
   googleDrive: {
     auth: {
       connected: () => ({ title: 'Google Drive', message: '接続しました' }),

--- a/tests/unit/composables/useAppInitialization.test.js
+++ b/tests/unit/composables/useAppInitialization.test.js
@@ -1,11 +1,11 @@
-const { mockShowToast, mockDeserialize } = vi.hoisted(() => ({
-  mockShowToast: vi.fn(),
+const { mockLogAndToastError, mockDeserialize } = vi.hoisted(() => ({
+  mockLogAndToastError: vi.fn(),
   mockDeserialize: vi.fn(),
 }));
 
 vi.mock('@/features/notifications/composables/useNotifications.js', () => ({
   useNotifications: () => ({
-    showToast: mockShowToast,
+    logAndToastError: mockLogAndToastError,
   }),
 }));
 
@@ -24,7 +24,7 @@ describe('useAppInitialization', () => {
 
   beforeEach(() => {
     setActivePinia(createPinia());
-    mockShowToast.mockClear();
+    mockLogAndToastError.mockClear();
     mockDeserialize.mockReset();
     window.history.replaceState({}, '', `${window.location.origin}/`);
     import.meta.env.VITE_GOOGLE_API_KEY = originalApiKey;
@@ -51,7 +51,7 @@ describe('useAppInitialization', () => {
     expect(global.fetch).not.toHaveBeenCalled();
     expect(uiStore.isLoading).toBe(false);
     expect(uiStore.isViewingShared).toBe(false);
-    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockLogAndToastError).not.toHaveBeenCalled();
   });
 
   test('loads shared character data when shared id is present', async () => {
@@ -100,7 +100,7 @@ describe('useAppInitialization', () => {
     expect(characterStore.equipments.weapon1).toEqual({ group: 'Blade', name: 'Sword' });
     expect(characterStore.histories).toEqual(['history-a']);
     expect(uiStore.isLoading).toBe(false);
-    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockLogAndToastError).not.toHaveBeenCalled();
   });
 
   test('shows error toast when fetching shared data fails', async () => {
@@ -120,7 +120,7 @@ describe('useAppInitialization', () => {
 
     expect(uiStore.isViewingShared).toBe(false);
     expect(uiStore.isLoading).toBe(false);
-    expect(mockShowToast).toHaveBeenCalled();
+    expect(mockLogAndToastError).toHaveBeenCalled();
   });
 
   test('falls back to googleusercontent host when no API key is configured', async () => {

--- a/tests/unit/composables/useAppModals.test.js
+++ b/tests/unit/composables/useAppModals.test.js
@@ -24,6 +24,7 @@ describe('useAppModals', () => {
   let showModalMock;
   let showToastMock;
   let showAsyncToastMock;
+  let logAndToastErrorMock;
   let clipboardWriteMock;
   let createShareLinkMock;
 
@@ -53,7 +54,12 @@ describe('useAppModals', () => {
     useModal.mockReturnValue({ showModal: showModalMock });
     showToastMock = vi.fn();
     showAsyncToastMock = vi.fn();
-    useNotifications.mockReturnValue({ showToast: showToastMock, showAsyncToast: showAsyncToastMock });
+    logAndToastErrorMock = vi.fn();
+    useNotifications.mockReturnValue({
+      showToast: showToastMock,
+      showAsyncToast: showAsyncToastMock,
+      logAndToastError: logAndToastErrorMock,
+    });
     createShareLinkMock = vi.fn().mockResolvedValue('https://example.com');
     useShare.mockReturnValue({ createShareLink: createShareLinkMock });
     clipboardWriteMock = vi.fn().mockResolvedValue();


### PR DESCRIPTION
## Summary
- add reusable error logging/toast helper so async notifications report failures without hiding console output
- refactor Drive integration and shared character loading to share localization strings and reduce repetitive try/catch logic
- update locale resources and unit tests to cover the new messaging and error pathways

## Testing
- npm run lint
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d746284488326b7deba77eee0612e)