### PR TITLE
Prune unused Japanese locale entries

### DIFF
--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -6,17 +6,6 @@ export const messages = {
     auth: {
       connected: () => ({ title: 'Google Drive', message: '接続しました' }),
     },
-    signIn: {
-      loading: () => ({
-        title: 'Google Drive',
-        message: 'サインインしています...',
-      }),
-      success: () => ({ title: 'サインイン完了', message: '' }),
-      error: (err) => ({
-        title: 'サインイン失敗',
-        message: err.message || err.details || 'もう一度お試しください。',
-      }),
-    },
     signOut: {
       success: () => ({ title: 'サインアウトしました', message: '' }),
     },
@@ -58,10 +47,6 @@ export const messages = {
     }),
     apiInitError: () => ({
       title: 'Google API エラー',
-      message: '初期化に失敗しました',
-    }),
-    signInInitError: () => ({
-      title: 'Google サインインエラー',
       message: '初期化に失敗しました',
     }),
     initPending: () => ({
@@ -112,16 +97,6 @@ export const messages = {
         };
       },
     },
-    modal: {
-      signInMessage: '共有リンクを作成するには Google Drive にサインインしてください。',
-      signInButton: 'Google Drive にサインイン',
-      instructions: '共有リンクをコピーして相手に送ってください。リンクを開くと閲覧モードでキャラシを表示します。',
-      generating: '共有リンクを作成しています…',
-      ready: '共有リンクが作成されました。',
-      retry: '再試行',
-      copy: 'コピー',
-      errorDefault: '共有リンクの作成に失敗しました。時間をおいて再度お試しください。',
-    },
   },
   characterHub: {
     driveFolder: {
@@ -165,7 +140,6 @@ export const messages = {
     },
     viewModeBanner: '閲覧モードで表示中',
     buttons: {
-      saveCloud: 'Drive保存',
       saveCloudNew: '新規保存',
       saveCloudOverwrite: '上書保存',
       saveCloudTitle: 'Google Driveに保存',
@@ -177,13 +151,7 @@ export const messages = {
       loadLocalTitle: '端末から読込む',
       save: '保存',
     },
-    prompts: {
-      sharedDataPassword: '共有データのパスワードを入力してください',
-    },
     modal: {
-      hubTitle: 'クラウド連携',
-      shareTitle: '共有リンク',
-      cancel: 'キャンセル',
       load: {
         title: '読込',
         buttons: {
@@ -196,9 +164,7 @@ export const messages = {
         title: '入出力',
         buttons: {
           saveLocal: 'ローカルファイルで出力',
-          output: '駒出力',
           print: '印刷',
-          driveFolder: 'フォルダ変更',
           chatPalette: 'チャットパレットを出力',
         },
         chatPalette: {
@@ -307,7 +273,6 @@ export const messages = {
           scenario: 'シナリオ名',
           experience: '経験点',
           scar: '傷痕増加',
-          memo: 'メモ',
         },
       },
     },
@@ -315,8 +280,6 @@ export const messages = {
   outputButton: {
     default: 'ココフォリア駒出力',
     success: 'コピー完了！',
-    successFallback: 'コピー完了！ (fallback)',
-    failed: 'コピー失敗 (fallback)',
     error: 'コピーエラー (fallback)',
     animating: '冒険が始まる――',
     animationTimings: {


### PR DESCRIPTION
## Summary
- remove unused Google Drive and share modal translations from the Japanese locale
- trim stale UI/modal button entries and adventure log labels
- drop unused fallback strings from the output button messages

## Testing
- npm run lint
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d802f1d408326aaf81318fdf058d5)