### PR TITLE
Add unsaved-change warning and simplify Drive saves

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -71,9 +71,21 @@ async function confirmDiscardingUnsavedChanges() {
 }
 
 const handleCreateNewCharacter = async (payload) => {
-  const confirmed = await confirmDiscardingUnsavedChanges();
-  if (!confirmed) {
-    return;
+  if (hasUnsavedChanges()) {
+    const result = await showModal(messages.ui.confirmations.unsavedChanges);
+    const choice = result?.value;
+
+    if (choice === 'save') {
+      const saved = await saveOrUpdateCurrentCharacterInDrive();
+      if (!saved) {
+        return;
+      }
+    } else if (choice === 'discard') {
+      // 「保存せず続行」: 何もしない
+    } else {
+      // 「キャンセル」またはモーダルを閉じた場合: 中断
+      return;
+    }
   }
   clearLocalDraft();
   characterStore.initializeAll();

--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -11,6 +11,8 @@ import { usePrint } from '@/features/character-sheet/composables/usePrint.js';
 import { messages } from '@/locales/ja.js';
 import { useAppModals } from '@/features/modals/composables/useAppModals.js';
 import { useAppInitialization } from '@/app/providers/useAppInitialization.js';
+import { useModal } from '@/features/modals/composables/useModal.js';
+import { buildSnapshotFromStore } from '@/features/character-sheet/utils/characterSnapshot.js';
 
 import { AioniaGameData } from '@/data/gameData.js';
 import CharacterSheetLayout from '@/features/character-sheet/components/CharacterSheetLayout.vue';
@@ -25,11 +27,13 @@ const helpPanelRef = ref(null);
 
 const characterStore = useCharacterStore();
 const uiStore = useUiStore();
+uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
 const { clearLocalDraft } = useLocalCharacterPersistence(characterStore, uiStore);
 useKeyboardHandling();
 
 const { dataManager, saveData, handleFileUpload, outputToCocofolia } = useDataExport();
 const { printCharacterSheet, openPreviewPage } = usePrint();
+const { showModal } = useModal();
 
 const {
   canSignInToGoogle,
@@ -50,11 +54,32 @@ const { helpState, isHelpVisible, handleHelpIconMouseOver, handleHelpIconMouseLe
 
 const modalStore = useModalStore();
 
+function hasUnsavedChanges() {
+  const currentSnapshot = buildSnapshotFromStore(characterStore);
+  if (!currentSnapshot) {
+    return false;
+  }
+  return uiStore.lastSavedSnapshot ? currentSnapshot !== uiStore.lastSavedSnapshot : true;
+}
+
+async function confirmDiscardingUnsavedChanges() {
+  if (!hasUnsavedChanges()) {
+    return true;
+  }
+  const result = await showModal(messages.ui.confirmations.unsavedChanges);
+  return result?.value === 'confirm';
+}
+
 const handleCreateNewCharacter = async (payload) => {
+  const confirmed = await confirmDiscardingUnsavedChanges();
+  if (!confirmed) {
+    return;
+  }
   clearLocalDraft();
   characterStore.initializeAll();
   uiStore.clearCurrentDriveFileId();
   uiStore.isViewingShared = false;
+  uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
   const shouldCreateCloudFile = payload?.isSignedIn ?? uiStore.isSignedIn;
   if (!shouldCreateCloudFile) {
     return;

--- a/src/app/providers/useAppInitialization.js
+++ b/src/app/providers/useAppInitialization.js
@@ -3,6 +3,7 @@ import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
 import { deserializeCharacterPayload } from '@/shared/utils/characterSerialization.js';
 import { useNotifications } from '@/features/notifications/composables/useNotifications.js';
 import { messages } from '@/locales/ja.js';
+import { buildSnapshotFromStore } from '@/features/character-sheet/utils/characterSnapshot.js';
 
 function getSharedDriveId(location) {
   const params = new URLSearchParams(location.search);
@@ -110,6 +111,7 @@ export function useAppInitialization(dataManager) {
 
       uiStore.clearCurrentDriveFileId();
       uiStore.isViewingShared = true;
+      uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
       return true;
     } catch (error) {
       const key = resolveSharedErrorKey(error);

--- a/src/features/character-sheet/composables/useDataExport.js
+++ b/src/features/character-sheet/composables/useDataExport.js
@@ -5,21 +5,25 @@ import { useCharacterStore } from '@/features/character-sheet/stores/characterSt
 import { useNotifications } from '@/features/notifications/composables/useNotifications.js';
 import { messages } from '@/locales/ja.js';
 import { copyText } from '@/shared/utils/clipboard.js';
+import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
+import { buildSnapshotFromStore } from '@/features/character-sheet/utils/characterSnapshot.js';
 
 export function useDataExport() {
   const characterStore = useCharacterStore();
   const dataManager = new DataManager(AioniaGameData);
   const cocofoliaExporter = new CocofoliaExporter();
   const { showToast } = useNotifications();
+  const uiStore = useUiStore();
 
-  function saveData() {
-    dataManager.saveData(
+  async function saveData() {
+    await dataManager.saveData(
       characterStore.character,
       characterStore.skills,
       characterStore.specialSkills,
       characterStore.equipments,
       characterStore.histories,
     );
+    uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
   }
 
   function handleFileUpload(event) {
@@ -31,6 +35,7 @@ export function useDataExport() {
         characterStore.specialSkills.splice(0, characterStore.specialSkills.length, ...parsedData.specialSkills);
         Object.assign(characterStore.equipments, parsedData.equipments);
         characterStore.histories.splice(0, characterStore.histories.length, ...parsedData.histories);
+        uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
       },
       (errorMessage) =>
         showToast({

--- a/src/features/character-sheet/composables/useDataExport.js
+++ b/src/features/character-sheet/composables/useDataExport.js
@@ -16,6 +16,7 @@ export function useDataExport() {
   const uiStore = useUiStore();
 
   async function saveData() {
+    const snapshot = buildSnapshotFromStore(characterStore);
     await dataManager.saveData(
       characterStore.character,
       characterStore.skills,
@@ -23,7 +24,7 @@ export function useDataExport() {
       characterStore.equipments,
       characterStore.histories,
     );
-    uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
+    uiStore.setLastSavedSnapshot(snapshot);
   }
 
   function handleFileUpload(event) {

--- a/src/features/character-sheet/utils/characterSnapshot.js
+++ b/src/features/character-sheet/utils/characterSnapshot.js
@@ -1,0 +1,29 @@
+import { deepClone } from '@/shared/utils/utils.js';
+
+function normalizeSnapshotPayload(source = {}) {
+  return {
+    character: deepClone(source.character || {}),
+    skills: deepClone(Array.isArray(source.skills) ? source.skills : []),
+    specialSkills: deepClone(Array.isArray(source.specialSkills) ? source.specialSkills : []),
+    equipments: deepClone(source.equipments || {}),
+    histories: deepClone(Array.isArray(source.histories) ? source.histories : []),
+  };
+}
+
+export function buildCharacterStateSnapshot(source) {
+  const normalized = normalizeSnapshotPayload(source);
+  return JSON.stringify(normalized);
+}
+
+export function buildSnapshotFromStore(characterStore) {
+  if (!characterStore) {
+    return null;
+  }
+  return buildCharacterStateSnapshot({
+    character: characterStore.character,
+    skills: characterStore.skills,
+    specialSkills: characterStore.specialSkills,
+    equipments: characterStore.equipments,
+    histories: characterStore.histories,
+  });
+}

--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -220,6 +220,8 @@ export function useGoogleDrive(dataManager) {
       targetFileId = uiStore.currentDriveFileId;
     }
 
+    const snapshotToSave = buildSnapshotFromStore(characterStore);
+
     const savePromise = dataManager
       .saveCharacterToDrive(
         characterStore.character,
@@ -233,7 +235,7 @@ export function useGoogleDrive(dataManager) {
         if (result) {
           uiStore.isCloudSaveSuccess = true;
           uiStore.setCurrentDriveFileId(result.id);
-          uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
+          uiStore.setLastSavedSnapshot(snapshotToSave);
           return renameDriveFileIfNeeded(result);
         }
         return result;

--- a/src/features/cloud-sync/stores/uiStore.js
+++ b/src/features/cloud-sync/stores/uiStore.js
@@ -15,6 +15,7 @@ export const useUiStore = defineStore('ui', {
     showHeader: true,
     showSpecialSkillDescriptions: false,
     showItemDescriptions: false,
+    lastSavedSnapshot: null,
   }),
   getters: {
     experienceStatusClass() {
@@ -42,6 +43,9 @@ export const useUiStore = defineStore('ui', {
     },
     setDriveFolderPath(path) {
       this.driveFolderPath = path;
+    },
+    setLastSavedSnapshot(snapshot) {
+      this.lastSavedSnapshot = snapshot || null;
     },
     registerPendingDriveSave(id) {
       this.pendingDriveSaves[id] = { canceled: false };

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -177,6 +177,16 @@ export const messages = {
       loadLocalTitle: '端末から読込む',
       save: '保存',
     },
+    confirmations: {
+      unsavedChanges: {
+        title: '保存されていない変更があります',
+        message: '現在の内容はまだ保存されていません。新規作成すると変更は失われます。続行しますか？',
+        buttons: [
+          { label: '続行', value: 'confirm', variant: 'primary' },
+          { label: 'キャンセル', value: 'cancel', variant: 'secondary' },
+        ],
+      },
+    },
     prompts: {
       sharedDataPassword: '共有データのパスワードを入力してください',
     },

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -182,7 +182,8 @@ export const messages = {
         title: '保存されていない変更があります',
         message: '現在の内容はまだ保存されていません。新規作成すると変更は失われます。続行しますか？',
         buttons: [
-          { label: '続行', value: 'confirm', variant: 'primary' },
+          { label: '保存して続行', value: 'save', variant: 'primary' },
+          { label: '保存せず続行', value: 'discard', variant: 'secondary' },
           { label: 'キャンセル', value: 'cancel', variant: 'secondary' },
         ],
       },


### PR DESCRIPTION
## Summary
- add a reusable snapshot helper and store state so we can detect unsaved changes in the active character
- prompt before clearing the sheet, stop clearing local drafts until the user confirms, and record snapshots after loads/saves (Drive, local file, shared links)
- remove the Drive filename collision prompt so saves rely on file IDs and update the affected unit tests

## Testing
- npm test -- tests/unit/composables/useGoogleDrive.test.js
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691db2737efc8326b7e1947426755a5a)