### PR TITLE
Add chat palette export

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -31,7 +31,7 @@ uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
 const { clearLocalDraft } = useLocalCharacterPersistence(characterStore, uiStore);
 useKeyboardHandling();
 
-const { dataManager, saveData, handleFileUpload, outputToCocofolia } = useDataExport();
+const { dataManager, saveData, handleFileUpload, outputToCocofolia, getChatPaletteText } = useDataExport();
 const { printCharacterSheet, openPreviewPage } = usePrint();
 const { showModal } = useModal();
 
@@ -112,6 +112,7 @@ const { openLoadModal, openIoModal, openShareModal } = useAppModals({
   saveData,
   handleFileUpload,
   outputToCocofolia,
+  getChatPaletteText,
   printCharacterSheet,
   openPreviewPage,
   copyEditCallback: () => {

--- a/src/features/character-sheet/composables/useDataExport.js
+++ b/src/features/character-sheet/composables/useDataExport.js
@@ -60,8 +60,8 @@ export function useDataExport() {
     }
   }
 
-  function outputToCocofolia() {
-    const exportData = {
+  function buildExportData() {
+    return {
       character: characterStore.character,
       skills: characterStore.skills,
       specialSkills: characterStore.specialSkills,
@@ -73,9 +73,18 @@ export function useDataExport() {
       specialSkillsRequiringNote: AioniaGameData.specialSkillsRequiringNote,
       weaponDamage: AioniaGameData.weaponDamage,
     };
+  }
+
+  function outputToCocofolia() {
+    const exportData = buildExportData();
     const cocofoliaCharacter = cocofoliaExporter.generateCocofoliaData(exportData);
     const textToCopy = JSON.stringify(cocofoliaCharacter, null, 2);
     copyToClipboard(textToCopy);
+  }
+
+  function getChatPaletteText() {
+    const exportData = buildExportData();
+    return cocofoliaExporter.generateCocofoliaData(exportData)?.data?.commands || '';
   }
 
   return {
@@ -83,5 +92,6 @@ export function useDataExport() {
     saveData,
     handleFileUpload,
     outputToCocofolia,
+    getChatPaletteText,
   };
 }

--- a/src/features/modals/composables/useAppModals.js
+++ b/src/features/modals/composables/useAppModals.js
@@ -20,6 +20,7 @@ export function useAppModals(options) {
     saveData,
     handleFileUpload,
     outputToCocofolia,
+    getChatPaletteText,
     printCharacterSheet,
     openPreviewPage,
     copyEditCallback,
@@ -82,21 +83,24 @@ export function useAppModals(options) {
   }
 
   async function handleOutputChatPalette() {
-    const paletteText = 'チャットパレット\nチャットパレット2';
     if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
       const clipboardError = new Error(messages.ui.modal.io.chatPalette.clipboardUnavailable);
       logAndToastError(clipboardError, messages.ui.modal.io.chatPalette.error, 'handleOutputChatPalette');
       return;
     }
+    if (typeof getChatPaletteText !== 'function') {
+      const missingGeneratorError = new Error('チャットパレットのデータを取得できません');
+      logAndToastError(missingGeneratorError, messages.ui.modal.io.chatPalette.error, 'handleOutputChatPalette');
+      return;
+    }
 
-    return navigator.clipboard
-      .writeText(paletteText)
-      .then(() => {
-        showToast({ type: 'success', ...messages.ui.modal.io.chatPalette.success() });
-      })
-      .catch((error) => {
-        logAndToastError(error, messages.ui.modal.io.chatPalette.error, 'handleOutputChatPalette');
-      });
+    try {
+      const paletteText = (await getChatPaletteText()) ?? '';
+      await navigator.clipboard.writeText(paletteText);
+      showToast({ type: 'success', ...messages.ui.modal.io.chatPalette.success() });
+    } catch (error) {
+      logAndToastError(error, messages.ui.modal.io.chatPalette.error, 'handleOutputChatPalette');
+    }
   }
 
   async function openIoModal() {

--- a/tests/unit/composables/useAppModals.test.js
+++ b/tests/unit/composables/useAppModals.test.js
@@ -35,6 +35,7 @@ describe('useAppModals', () => {
       saveData: vi.fn(),
       handleFileUpload: vi.fn(),
       outputToCocofolia: vi.fn(),
+      getChatPaletteText: vi.fn().mockResolvedValue('モックされたチャットパレット'),
       printCharacterSheet: vi.fn(),
       openPreviewPage: vi.fn(),
       copyEditCallback: vi.fn(),
@@ -96,12 +97,14 @@ describe('useAppModals', () => {
     expect(args.on.print).toBe(openPreviewPage);
   });
 
-  test('chat palette output copies text', async () => {
-    const { openIoModal } = useAppModals(createOptions());
+  test('chat palette output copies text from provided getter', async () => {
+    const getChatPaletteText = vi.fn().mockResolvedValue('チャットパレット\nダイナミック');
+    const { openIoModal } = useAppModals(createOptions({ getChatPaletteText }));
     await openIoModal();
     const args = showModalMock.mock.calls[0][0];
     await args.on['output-chat-palette']();
-    expect(clipboardWriteMock).toHaveBeenCalledWith('チャットパレット\nチャットパレット2');
+    expect(getChatPaletteText).toHaveBeenCalled();
+    expect(clipboardWriteMock).toHaveBeenCalledWith('チャットパレット\nダイナミック');
     expect(showToastMock).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- add a helper to reuse the Cocofolia export payload and expose a new chat palette text getter
- pass the getter through the app modal options and have the modal compose clipboard text dynamically with error handling
- refresh the unit test to mock the getter and verify that its output is copied

## Testing
- npm test -- useAppModals

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dc590518083269da59790af483828)