### PR TITLE
Self-host fonts and defer Google Drive scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,16 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>慈悲なきアイオニア　非公式キャラクターシート</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@700&family=Shippori+Mincho:wght@700&family=Noto+Serif+JP:wght@400;700&family=Noto+Sans+JP:wght@400;700&display=swap"
-      rel="stylesheet"
+    <meta
+      name="description"
+      content="慈悲なきアイオニアTRPGのキャラクターシートをオンラインで作成し、保存や共有ができる非公式支援アプリです"
     />
-
-    <script async defer src="https://apis.google.com/js/api.js"></script>
-    <script async defer src="https://accounts.google.com/gsi/client"></script>
+    <title>慈悲なきアイオニア　非公式キャラクターシート</title>
   </head>
   <body>
     <div id="app"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,12 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@fontsource/cinzel-decorative": "^5.2.8",
+        "@fontsource/noto-sans-jp": "^5.2.8",
+        "@fontsource/noto-serif-jp": "^5.2.7",
+        "@fontsource/shippori-mincho": "^5.2.8",
+        "@fontsource/unifrakturmaguntia": "^5.2.8",
+        "@fontsource/zen-kurenaido": "^5.2.8",
         "@noble/hashes": "^1.8.0",
         "@vue/compiler-sfc": "^3.5.16",
         "@vue/test-utils": "^2.4.6",
@@ -2215,6 +2221,60 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource/cinzel-decorative": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/cinzel-decorative/-/cinzel-decorative-5.2.8.tgz",
+      "integrity": "sha512-BtrvcprcCd0DyAcIXZRohfMyh+n/MwNvmhmAZ0kXDe9T1w2XSOodb3RNoD1uHm3TlGw7fjTU0YepgAQbPW0sFw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/noto-sans-jp": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans-jp/-/noto-sans-jp-5.2.8.tgz",
+      "integrity": "sha512-ngWXPtSV3XH8ZmNX9hnfeQ+x/3mCoaAOA3BVDcyS5jQdh4FYqKjf/S9tEUEYDPwGa2pULJVXTO2+oFg42gWvSw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/noto-serif-jp": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-serif-jp/-/noto-serif-jp-5.2.7.tgz",
+      "integrity": "sha512-uC8j75EoZe/s1LR+qzKCi7pXxQgY3Jbb0vpX9UOuzTOewMyPZd6zgQD64uxPo52qPPWkA+U1t4d/27KwKJoOCw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/shippori-mincho": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/shippori-mincho/-/shippori-mincho-5.2.8.tgz",
+      "integrity": "sha512-GoWDgrzVyB1oUufPKN9suBaM+TpliiBcMwEalqqMeO38xdGJzY/ZwhehZsxyOoR56c1l98vwXbj+tXWHyGefJA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/unifrakturmaguntia": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/unifrakturmaguntia/-/unifrakturmaguntia-5.2.8.tgz",
+      "integrity": "sha512-FN6yt2BPasuXuwttsz31qlgcMMx6SZdY9HFv/GPAPonFfF5e4Y11j9mGRGGXY6V0iZzaZnQ4Yx6UPRCE/ECRqA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/zen-kurenaido": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/zen-kurenaido/-/zen-kurenaido-5.2.8.tgz",
+      "integrity": "sha512-BkjDXE0CkZxhDN9xqPFR+0puuR7mDd+61dymVaeAf4g7fttE+WvZVCP6ktlg7mn/0/eQFI6xu6nFUXU/n9PNcg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,12 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@fontsource/cinzel-decorative": "^5.2.8",
+    "@fontsource/noto-sans-jp": "^5.2.8",
+    "@fontsource/noto-serif-jp": "^5.2.7",
+    "@fontsource/shippori-mincho": "^5.2.8",
+    "@fontsource/unifrakturmaguntia": "^5.2.8",
+    "@fontsource/zen-kurenaido": "^5.2.8",
     "@noble/hashes": "^1.8.0",
     "@vue/compiler-sfc": "^3.5.16",
     "@vue/test-utils": "^2.4.6",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -2,6 +2,7 @@ import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import App from './App.vue';
 import { initializeGoogleDriveManager, initializeMockGoogleDriveManager } from '@/infrastructure/google-drive/index.js';
+import '@/shared/styles/fonts.css';
 import '@/shared/styles/style.css';
 
 const useMockDrive = import.meta.env.VITE_USE_MOCK_DRIVE === 'true';

--- a/src/features/character-sheet/assets/print/print-template.html
+++ b/src/features/character-sheet/assets/print/print-template.html
@@ -4,11 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>A4印刷用レイアウト - Aionia TRPG Character Sheet</title>
-    <link
-      href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400&family=Shippori+Mincho:wght@400;500;700&family=UnifrakturMaguntia&family=Zen+Kurenaido&display=swap"
-      rel="stylesheet"
-    />
-    <link href="./css/print-styles.css" rel="stylesheet" />
+    <link href="{{fonts-styles-href}}" rel="stylesheet" />
+    <link href="{{print-styles-href}}" rel="stylesheet" />
   </head>
 
   <body>

--- a/src/features/character-sheet/components/ui/MainHeader.vue
+++ b/src/features/character-sheet/components/ui/MainHeader.vue
@@ -108,6 +108,7 @@ defineExpose({ headerEl, helpIcon });
   font-family: 'Cinzel Decorative', 'Shippori Mincho', serif;
   color: var(--color-accent);
   font-size: clamp(2px, 3vw, 28px);
+  font-weight: 700;
   flex: 1.5;
   min-width: 0;
   padding: 0 10px;

--- a/src/features/character-sheet/composables/usePrint.js
+++ b/src/features/character-sheet/composables/usePrint.js
@@ -37,13 +37,17 @@ export function usePrint() {
 
   async function buildHtml() {
     const { default: printTemplate } = await import('@/features/character-sheet/assets/print/print-template.html?raw');
-    const { default: printStyles } = await import('@/features/character-sheet/assets/print/print-styles.css?raw');
+    const { default: printStylesUrl } = await import('@/features/character-sheet/assets/print/print-styles.css?url');
+    const { default: fontStylesUrl } = await import('@/shared/styles/fonts.css?url');
     const ch = characterStore.character;
     let html = printTemplate;
 
     const replace = (key, val = '') => {
       html = html.replace(new RegExp(`{{${key}}}`, 'g'), val);
     };
+
+    replace('fonts-styles-href', fontStylesUrl);
+    replace('print-styles-href', printStylesUrl);
 
     // --- 基本情報の置換 ---
     replace('character-name', ch.name || '');
@@ -102,9 +106,8 @@ export function usePrint() {
       replace(`adventure-experience-${i}`, h.gotExperiments != null ? String(h.gotExperiments) : '');
     }
 
-    // --- 残りのプレースホルダをクリア & CSSを注入 ---
+    // --- 残りのプレースホルダをクリア ---
     html = html.replace(/{{[^}]+}}/g, '');
-    html = html.replace('</head>', `<style>${printStyles}</style></head>`);
 
     return html;
   }

--- a/src/features/character-sheet/composables/usePrint.js
+++ b/src/features/character-sheet/composables/usePrint.js
@@ -130,10 +130,14 @@ export function usePrint() {
       iframe.style.border = '0';
       iframe.style.visibility = 'hidden';
 
-      iframe.onload = () => {
+      iframe.onload = async () => {
         try {
-          iframe.contentWindow?.focus();
-          iframe.contentWindow?.print();
+          const win = iframe.contentWindow;
+          if (!win) return;
+
+          await win.document.fonts.ready;
+          win.focus();
+          win.print();
         } catch (e) {
           console.error('印刷実行中にエラーが発生しました:', e);
         } finally {

--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -4,6 +4,7 @@ import {
   getMockGoogleDriveManagerInstance,
   initializeMockGoogleDriveManager,
 } from '@/infrastructure/google-drive/mockGoogleDriveManager.js';
+import { loadGoogleDriveScripts } from '@/infrastructure/google-drive/scriptLoader.js';
 import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
 import { useCharacterStore } from '@/features/character-sheet/stores/characterStore.js';
 import { removeStoredCharacterDraft } from '@/features/character-sheet/composables/useLocalCharacterPersistence.js';
@@ -310,23 +311,7 @@ export function useGoogleDrive(dataManager) {
       }
     };
 
-    function waitForScript(selector, check) {
-      return new Promise((resolve, reject) => {
-        if (check()) {
-          resolve();
-          return;
-        }
-        const script = document.querySelector(selector);
-        if (!script) {
-          reject(new Error('Script not found'));
-          return;
-        }
-        script.addEventListener('load', resolve, { once: true });
-        script.addEventListener('error', () => reject(new Error('Script load failed')), { once: true });
-      });
-    }
-
-    waitForScript('script[src="https://apis.google.com/js/api.js"]', () => window.gapi && window.gapi.load)
+    loadGoogleDriveScripts()
       .then(handleGapiLoaded)
       .catch((error) => logAndToastError(error, messages.googleDrive.apiInitError, 'initializeGoogleDrive'));
   }

--- a/src/infrastructure/google-drive/scriptLoader.js
+++ b/src/infrastructure/google-drive/scriptLoader.js
@@ -1,0 +1,73 @@
+const SCRIPT_CONFIGS = [
+  {
+    src: 'https://accounts.google.com/gsi/client',
+    check: () => typeof window !== 'undefined' && window.google && window.google.accounts,
+  },
+  {
+    src: 'https://apis.google.com/js/api.js',
+    check: () => typeof window !== 'undefined' && window.gapi && typeof window.gapi.load === 'function',
+  },
+];
+
+const scriptPromises = new Map();
+let combinedLoadPromise = null;
+
+function loadScript({ src, check }) {
+  if (check()) {
+    return Promise.resolve();
+  }
+
+  if (scriptPromises.has(src)) {
+    return scriptPromises.get(src);
+  }
+
+  const promise = new Promise((resolve, reject) => {
+    const existing = document.querySelector(`script[src="${src}"]`);
+    const target = existing || document.createElement('script');
+
+    const cleanup = () => {
+      target.removeEventListener('load', handleLoad);
+      target.removeEventListener('error', handleError);
+    };
+
+    const handleLoad = () => {
+      target.dataset.loaded = 'true';
+      cleanup();
+      resolve();
+    };
+
+    const handleError = () => {
+      cleanup();
+      reject(new Error(`Failed to load script: ${src}`));
+    };
+
+    if (!existing) {
+      target.src = src;
+      target.async = true;
+      target.defer = true;
+      target.addEventListener('load', handleLoad, { once: true });
+      target.addEventListener('error', handleError, { once: true });
+      document.head.appendChild(target);
+    } else if (existing.dataset.loaded === 'true') {
+      resolve();
+      return;
+    } else {
+      existing.addEventListener('load', handleLoad, { once: true });
+      existing.addEventListener('error', handleError, { once: true });
+    }
+  }).finally(() => {
+    scriptPromises.delete(src);
+  });
+
+  scriptPromises.set(src, promise);
+  return promise;
+}
+
+export function loadGoogleDriveScripts() {
+  if (combinedLoadPromise) {
+    return combinedLoadPromise;
+  }
+
+  combinedLoadPromise = Promise.all(SCRIPT_CONFIGS.map((config) => loadScript(config))).then(() => undefined);
+  return combinedLoadPromise;
+}

--- a/src/shared/composables/useHeaderVisibility.js
+++ b/src/shared/composables/useHeaderVisibility.js
@@ -3,32 +3,92 @@ import { onMounted, onUnmounted } from 'vue';
 export function useHeaderVisibility(targetRef) {
   let lastScrollY = 0;
   let currentTranslateY = 0;
+  let appliedTranslateY = 0;
   let headerHeight = 0;
+  let rafId = null;
+  let frameRequested = false;
+  let resizeObserver = null;
+
+  function clampTranslate(delta) {
+    currentTranslateY = Math.min(0, Math.max(currentTranslateY - delta, -headerHeight));
+  }
+
+  function applyTransform() {
+    frameRequested = false;
+    rafId = null;
+    const target = targetRef.value;
+    if (!target) {
+      return;
+    }
+
+    const scrollY = window.scrollY;
+    const delta = scrollY - lastScrollY;
+    lastScrollY = scrollY;
+    if (!delta && currentTranslateY === appliedTranslateY) {
+      return;
+    }
+
+    clampTranslate(delta);
+    if (appliedTranslateY !== currentTranslateY) {
+      target.style.transform = `translateY(${currentTranslateY}px)`;
+      appliedTranslateY = currentTranslateY;
+    }
+  }
+
+  function scheduleTransform() {
+    if (frameRequested) {
+      return;
+    }
+    frameRequested = true;
+    rafId = requestAnimationFrame(applyTransform);
+  }
+
+  function observeHeaderHeight() {
+    if (!targetRef.value || typeof ResizeObserver === 'undefined') {
+      headerHeight = targetRef.value?.offsetHeight ?? 0;
+      return;
+    }
+
+    if (resizeObserver) {
+      resizeObserver.disconnect();
+    }
+
+    resizeObserver = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      headerHeight = entry.contentRect.height;
+      if (currentTranslateY < -headerHeight) {
+        currentTranslateY = -headerHeight;
+        scheduleTransform();
+      }
+    });
+    resizeObserver.observe(targetRef.value);
+  }
 
   function handleScroll() {
-    requestAnimationFrame(() => {
-      const y = window.scrollY;
-      const delta = y - lastScrollY;
-      currentTranslateY -= delta;
-      if (currentTranslateY > 0) currentTranslateY = 0;
-      if (currentTranslateY < -headerHeight) currentTranslateY = -headerHeight;
-      if (targetRef.value) {
-        targetRef.value.style.transform = `translateY(${currentTranslateY}px)`;
-      }
-      lastScrollY = y;
-    });
+    scheduleTransform();
   }
 
   onMounted(() => {
-    if (targetRef.value) {
-      headerHeight = targetRef.value.offsetHeight;
-      targetRef.value.style.transform = 'translateY(0px)';
+    const target = targetRef.value;
+    if (target) {
+      target.style.willChange = 'transform';
+      target.style.transform = 'translateY(0px)';
     }
+    observeHeaderHeight();
     lastScrollY = window.scrollY;
     window.addEventListener('scroll', handleScroll, { passive: true });
   });
 
   onUnmounted(() => {
     window.removeEventListener('scroll', handleScroll);
+    if (resizeObserver) {
+      resizeObserver.disconnect();
+    }
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+    frameRequested = false;
   });
 }

--- a/src/shared/styles/fonts.css
+++ b/src/shared/styles/fonts.css
@@ -1,0 +1,11 @@
+@import url('@fontsource/cinzel-decorative/400.css');
+@import url('@fontsource/cinzel-decorative/700.css');
+@import url('@fontsource/shippori-mincho/400.css');
+@import url('@fontsource/shippori-mincho/500.css');
+@import url('@fontsource/shippori-mincho/700.css');
+@import url('@fontsource/noto-serif-jp/400.css');
+@import url('@fontsource/noto-serif-jp/700.css');
+@import url('@fontsource/noto-sans-jp/400.css');
+@import url('@fontsource/noto-sans-jp/700.css');
+@import url('@fontsource/zen-kurenaido/400.css');
+@import url('@fontsource/unifrakturmaguntia/400.css');


### PR DESCRIPTION
## Summary
- self-host the Cinzel Decorative, Shippori Mincho, Noto Serif JP, Noto Sans JP, Zen Kurenaido, and UnifrakturMaguntia fonts via @fontsource, add a descriptive meta tag, and publish robots.txt for crawlability
- lazy-load the Google API/GIS scripts with a new loader, wire up the print template to emitted CSS assets, and keep the UI font styling consistent across the SPA and print views
- reduce forced reflows by batching header scroll updates with requestAnimationFrame and ResizeObserver

## Testing
- npm run lint
- npm run test
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dca06c08c8326acb4506b0e037439)