### PR TITLE
Format document title with app name

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -138,10 +138,12 @@ watch(
   { immediate: true },
 );
 
+const baseDocumentTitle = messages.ui.header.defaultTitle;
+
 watch(
   () => characterStore.character.name,
   (name) => {
-    document.title = name || messages.ui.header.defaultTitle;
+    document.title = name ? `${name} | ${baseDocumentTitle}` : baseDocumentTitle;
   },
   { immediate: true },
 );


### PR DESCRIPTION
## Summary
- format the document title to always include the application name when a character name is present

## Testing
- npm run lint
- npm run test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd2162d008326934b933769df33b0)