### PR TITLE
Add dedicated Google Drive toast for new saves

### DIFF
--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -244,7 +244,7 @@ export function useGoogleDrive(dataManager) {
     showAsyncToast(
       savePromise,
       {
-        loading: messages.googleDrive.save.loading(),
+        loading: isNewFile ? messages.googleDrive.save.newLoading() : messages.googleDrive.save.loading(),
         success: isNewFile ? messages.googleDrive.save.newSuccess() : messages.googleDrive.save.success(),
         error: (err) => messages.googleDrive.save.error(err),
       },

--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -245,7 +245,7 @@ export function useGoogleDrive(dataManager) {
       savePromise,
       {
         loading: messages.googleDrive.save.loading(),
-        success: messages.googleDrive.save.success(),
+        success: isNewFile ? messages.googleDrive.save.newSuccess() : messages.googleDrive.save.success(),
         error: (err) => messages.googleDrive.save.error(err),
       },
       'saveCharacterToDrive',

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -18,6 +18,7 @@ export const messages = {
     },
     save: {
       loading: () => ({ title: 'Google Drive', message: '保存中...' }),
+      newSuccess: () => ({ title: '保存完了', message: '新規キャラクターを保存しました' }),
       success: () => ({ title: '保存完了', message: '' }),
       error: (err) => ({ title: '保存失敗', message: err.message || '' }),
     },

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -18,6 +18,7 @@ export const messages = {
     },
     save: {
       loading: () => ({ title: 'Google Drive', message: '保存中...' }),
+      newLoading: () => ({ title: 'Google Drive', message: '新規キャラクターを保存中' }),
       newSuccess: () => ({ title: '保存完了', message: '新規キャラクターを保存しました' }),
       success: () => ({ title: '保存完了', message: '' }),
       error: (err) => ({ title: '保存失敗', message: err.message || '' }),

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -18,8 +18,8 @@ export const messages = {
     },
     save: {
       loading: () => ({ title: 'Google Drive', message: '保存中...' }),
-      newLoading: () => ({ title: 'Google Drive', message: '新規キャラクターを保存中' }),
-      newSuccess: () => ({ title: '保存完了', message: '新規キャラクターを保存しました' }),
+      newLoading: () => ({ title: '新規キャラクター', message: '新規キャラクターを保存中' }),
+      newSuccess: () => ({ title: '新規キャラクター', message: '新規キャラクターを保存しました' }),
       success: () => ({ title: '保存完了', message: '' }),
       error: (err) => ({ title: '保存失敗', message: err.message || '' }),
     },

--- a/tests/unit/composables/useGoogleDrive.test.js
+++ b/tests/unit/composables/useGoogleDrive.test.js
@@ -167,6 +167,7 @@ describe('useGoogleDrive', () => {
 
     expect(showAsyncToastMock).toHaveBeenCalled();
     const toastOptions = showAsyncToastMock.mock.calls[showAsyncToastMock.mock.calls.length - 1][1];
+    expect(toastOptions.loading).toEqual(messages.googleDrive.save.newLoading());
     expect(toastOptions.success).toEqual(messages.googleDrive.save.newSuccess());
   });
 
@@ -187,6 +188,7 @@ describe('useGoogleDrive', () => {
 
     expect(showAsyncToastMock).toHaveBeenCalled();
     const toastOptions = showAsyncToastMock.mock.calls[showAsyncToastMock.mock.calls.length - 1][1];
+    expect(toastOptions.loading).toEqual(messages.googleDrive.save.loading());
     expect(toastOptions.success).toEqual(messages.googleDrive.save.success());
   });
 });

--- a/tests/unit/composables/useGoogleDrive.test.js
+++ b/tests/unit/composables/useGoogleDrive.test.js
@@ -3,6 +3,19 @@ import { useGoogleDrive } from '@/features/cloud-sync/composables/useGoogleDrive
 import { useCharacterStore } from '@/features/character-sheet/stores/characterStore.js';
 import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
 import { buildSnapshotFromStore } from '@/features/character-sheet/utils/characterSnapshot.js';
+import { messages } from '@/locales/ja.js';
+
+const showToastMock = vi.fn();
+const showAsyncToastMock = vi.fn();
+const logAndToastErrorMock = vi.fn();
+
+vi.mock('@/features/notifications/composables/useNotifications.js', () => ({
+  useNotifications: () => ({
+    showToast: showToastMock,
+    showAsyncToast: showAsyncToastMock,
+    logAndToastError: logAndToastErrorMock,
+  }),
+}));
 
 function createDriveManagerStub(normalizedPath = '慈悲なきアイオニア/PC/第一キャンペーン') {
   const showFolderPicker = vi.fn();
@@ -21,6 +34,7 @@ function createDriveManagerStub(normalizedPath = '慈悲なきアイオニア/PC
 describe('useGoogleDrive', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    vi.clearAllMocks();
   });
 
   test('saveCharacterToDrive updates an existing file when current id is set', async () => {
@@ -135,5 +149,44 @@ describe('useGoogleDrive', () => {
 
     expect(renameFile).toHaveBeenCalledWith('existing-id', 'Knight.zip');
     expect(result).toEqual({ id: 'existing-id', name: 'Knight.zip' });
+  });
+
+  test('saveCharacterToDrive uses new success message for brand-new files', async () => {
+    const dataManager = {
+      saveCharacterToDrive: vi.fn().mockResolvedValue({ id: 'new-id', name: 'Rookie.zip' }),
+      googleDriveManager: {},
+      getDriveFileName: vi.fn().mockReturnValue('Rookie.zip'),
+    };
+    const { saveCharacterToDrive } = useGoogleDrive(dataManager);
+    const uiStore = useUiStore();
+    uiStore.isGapiInitialized = true;
+    uiStore.isGisInitialized = true;
+    uiStore.isSignedIn = true;
+
+    await saveCharacterToDrive(true);
+
+    expect(showAsyncToastMock).toHaveBeenCalled();
+    const toastOptions = showAsyncToastMock.mock.calls[showAsyncToastMock.mock.calls.length - 1][1];
+    expect(toastOptions.success).toEqual(messages.googleDrive.save.newSuccess());
+  });
+
+  test('saveCharacterToDrive keeps default success message when updating existing files', async () => {
+    const dataManager = {
+      saveCharacterToDrive: vi.fn().mockResolvedValue({ id: 'existing-id', name: 'Veteran.zip' }),
+      googleDriveManager: {},
+      getDriveFileName: vi.fn().mockReturnValue('Veteran.zip'),
+    };
+    const { saveCharacterToDrive } = useGoogleDrive(dataManager);
+    const uiStore = useUiStore();
+    uiStore.isGapiInitialized = true;
+    uiStore.isGisInitialized = true;
+    uiStore.isSignedIn = true;
+    uiStore.setCurrentDriveFileId('existing-id');
+
+    await saveCharacterToDrive(false);
+
+    expect(showAsyncToastMock).toHaveBeenCalled();
+    const toastOptions = showAsyncToastMock.mock.calls[showAsyncToastMock.mock.calls.length - 1][1];
+    expect(toastOptions.success).toEqual(messages.googleDrive.save.success());
   });
 });


### PR DESCRIPTION
## Summary
- add a new locale toast message for new Google Drive saves and use it whenever saveCharacterToDrive runs for a brand-new file
- mock the notifications composable inside the useGoogleDrive tests to capture showAsyncToast calls and verify both the new and existing success states

## Testing
- npm run lint
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd68d2720832695d07a701647c2d8)