### PR TITLE
chore: prune unused cloud sync ui state

### DIFF
--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -201,8 +201,6 @@ export function useGoogleDrive(dataManager) {
       return null;
     }
     if (!dataManager.googleDriveManager) return;
-    uiStore.isCloudSaveSuccess = false;
-
     let isNewFile = false;
     let explicitFileId = null;
 
@@ -233,7 +231,6 @@ export function useGoogleDrive(dataManager) {
       )
       .then(async (result) => {
         if (result) {
-          uiStore.isCloudSaveSuccess = true;
           uiStore.setCurrentDriveFileId(result.id);
           uiStore.setLastSavedSnapshot(snapshotToSave);
           return renameDriveFileIfNeeded(result);

--- a/src/features/cloud-sync/stores/uiStore.js
+++ b/src/features/cloud-sync/stores/uiStore.js
@@ -3,16 +3,12 @@ import { useCharacterStore } from '@/features/character-sheet/stores/characterSt
 
 export const useUiStore = defineStore('ui', {
   state: () => ({
-    isCloudSaveSuccess: false,
     isSignedIn: false,
     isGapiInitialized: false,
-    isGisInitialized: false,
     isLoading: false,
     driveFolderPath: '慈悲なきアイオニア',
     currentDriveFileId: null,
     isViewingShared: false,
-    pendingDriveSaves: {},
-    showHeader: true,
     showSpecialSkillDescriptions: false,
     showItemDescriptions: false,
     lastSavedSnapshot: null,
@@ -46,18 +42,6 @@ export const useUiStore = defineStore('ui', {
     },
     setLastSavedSnapshot(snapshot) {
       this.lastSavedSnapshot = snapshot || null;
-    },
-    registerPendingDriveSave(id) {
-      this.pendingDriveSaves[id] = { canceled: false };
-      return this.pendingDriveSaves[id];
-    },
-    cancelPendingDriveSave(id) {
-      if (this.pendingDriveSaves[id]) {
-        this.pendingDriveSaves[id].canceled = true;
-      }
-    },
-    completePendingDriveSave(id) {
-      delete this.pendingDriveSaves[id];
     },
   },
 });

--- a/tests/unit/composables/useGoogleDrive.test.js
+++ b/tests/unit/composables/useGoogleDrive.test.js
@@ -33,7 +33,6 @@ describe('useGoogleDrive', () => {
     const charStore = useCharacterStore();
     const uiStore = useUiStore();
     uiStore.isGapiInitialized = true;
-    uiStore.isGisInitialized = true;
     uiStore.isSignedIn = true;
     charStore.character.name = 'Hero';
     uiStore.setCurrentDriveFileId('existing-id');
@@ -72,7 +71,6 @@ describe('useGoogleDrive', () => {
     const charStore = useCharacterStore();
     const uiStore = useUiStore();
     uiStore.isGapiInitialized = true;
-    uiStore.isGisInitialized = true;
     uiStore.isSignedIn = true;
 
     const result = await loadCharacterFromDrive();
@@ -103,7 +101,6 @@ describe('useGoogleDrive', () => {
     const uiStore = useUiStore();
     uiStore.isSignedIn = true;
     uiStore.isGapiInitialized = true;
-    uiStore.isGisInitialized = true;
     uiStore.setDriveFolderPath('慈悲なきアイオニア');
 
     const selected = await promptForDriveFolder();
@@ -127,7 +124,6 @@ describe('useGoogleDrive', () => {
     const uiStore = useUiStore();
     charStore.character.name = 'Knight';
     uiStore.isGapiInitialized = true;
-    uiStore.isGisInitialized = true;
     uiStore.isSignedIn = true;
     uiStore.setCurrentDriveFileId('existing-id');
 

--- a/tests/unit/stores/uiStoreCharacters.test.js
+++ b/tests/unit/stores/uiStoreCharacters.test.js
@@ -18,14 +18,4 @@ describe('uiStore drive state', () => {
     store.clearCurrentDriveFileId();
     expect(store.currentDriveFileId).toBeNull();
   });
-
-  test('pending drive save lifecycle', () => {
-    const store = useUiStore();
-    const token = store.registerPendingDriveSave('temp-1');
-    expect(store.pendingDriveSaves['temp-1']).toBe(token);
-    store.cancelPendingDriveSave('temp-1');
-    expect(token.canceled).toBe(true);
-    store.completePendingDriveSave('temp-1');
-    expect(store.pendingDriveSaves['temp-1']).toBeUndefined();
-  });
 });


### PR DESCRIPTION
## Summary
- remove unused cloud-sync UI state fields and related actions to simplify the store
- drop the obsolete isCloudSaveSuccess flag handling in the Google Drive composable and clean up the tests
- delete tests that only covered removed APIs and refresh existing suites

## Testing
- `npm run lint`
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ddb715cf48326a4124c0bf8bde258)