### PR TITLE
Remove unused modal global actions

### DIFF
--- a/src/features/modals/components/BaseModal.vue
+++ b/src/features/modals/components/BaseModal.vue
@@ -9,9 +9,6 @@
             <div class="modal-title">{{ modal.title }}</div>
           </div>
         </div>
-        <div class="modal-global-actions sub-box-title" v-if="modal.globalActions">
-          <component :is="modal.globalActions.component" v-bind="modal.globalActions.props" v-on="modal.globalActions.on" />
-        </div>
         <div class="modal-content box-content">
           <div class="modal-message" v-if="modal.message">
             {{ modal.message }}
@@ -51,9 +48,5 @@ function resolve(value) {
 .box-content {
   border: none;
   padding: 14px;
-}
-
-.sub-box-title {
-  margin: 0;
 }
 </style>

--- a/src/features/modals/stores/modalStore.js
+++ b/src/features/modals/stores/modalStore.js
@@ -10,7 +10,6 @@ export const useModalStore = defineStore('modal', {
     props: {},
     buttons: [],
     events: {},
-    globalActions: null,
     resolvePromise: null,
     rejectPromise: null,
   }),
@@ -24,7 +23,6 @@ export const useModalStore = defineStore('modal', {
         this.props = options.props || {};
         this.buttons = options.buttons || [];
         this.events = options.on || {};
-        this.globalActions = options.globalActions || null;
         this.resolvePromise = resolve;
         this.rejectPromise = reject;
       });
@@ -37,7 +35,6 @@ export const useModalStore = defineStore('modal', {
       this.props = {};
       this.buttons = [];
       this.events = {};
-      this.globalActions = null;
       this.resolvePromise = null;
       this.rejectPromise = null;
     },


### PR DESCRIPTION
## Summary
- remove the unused `globalActions` state from the modal store and its associated reset logic
- delete the `modal-global-actions` block and redundant scoped styles from `BaseModal`

## Testing
- npm run lint
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ddb6c10588326a8589fbf95bdda8f)