### PR TITLE
Remove unused copyLink helper

### DIFF
--- a/src/features/cloud-sync/composables/useShare.js
+++ b/src/features/cloud-sync/composables/useShare.js
@@ -1,12 +1,10 @@
 import { useCharacterStore } from '@/features/character-sheet/stores/characterStore.js';
 import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
-import { useNotifications } from '@/features/notifications/composables/useNotifications.js';
 import { messages } from '@/locales/ja.js';
 
 export function useShare(dataManager) {
   const characterStore = useCharacterStore();
   const uiStore = useUiStore();
-  const { showToast } = useNotifications();
 
   async function createShareLink() {
     if (!uiStore.isSignedIn) {
@@ -52,14 +50,5 @@ export function useShare(dataManager) {
     return shareUrl.toString();
   }
 
-  async function copyLink(link) {
-    try {
-      await navigator.clipboard.writeText(link);
-      showToast({ type: 'success', ...messages.share.copied(link) });
-    } catch (err) {
-      showToast({ type: 'error', ...messages.share.copyFailed(err) });
-    }
-  }
-
-  return { createShareLink, copyLink };
+  return { createShareLink };
 }

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -64,8 +64,6 @@ export const messages = {
     },
   },
   share: {
-    copied: (link) => ({ title: '共有リンクをコピーしました', message: link }),
-    copyFailed: (err) => ({ title: 'コピー失敗', message: err.message }),
     needSignIn: () => ({
       title: 'Google Drive',
       message: 'サインインしてください',


### PR DESCRIPTION
## Summary
- remove the unused `copyLink` helper from the share composable so the share modal handles clipboard logic itself
- clean up the unused `messages.share.copied` and `messages.share.copyFailed` translation entries

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ddbbe9a408326b72b4d52b4fbd386)