### PR TITLE
Simplify Google Drive save actions

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -41,7 +41,6 @@ const {
   handleSignInClick,
   handleSignOutClick,
   saveCharacterToDrive,
-  saveOrUpdateCurrentCharacterInDrive,
   loadCharacterFromDrive,
   promptForDriveFolder,
   updateDriveFolderPath,
@@ -76,7 +75,7 @@ const handleCreateNewCharacter = async (payload) => {
     const choice = result?.value;
 
     if (choice === 'save') {
-      const saved = await saveOrUpdateCurrentCharacterInDrive();
+      const saved = await saveCharacterToDrive();
       if (!saved) {
         return;
       }
@@ -188,7 +187,7 @@ onMounted(initialize);
     :current-experience-points="currentExperiencePoints"
     :max-experience-points="maxExperiencePoints"
     :current-weight="currentWeight"
-    :save-to-drive="saveOrUpdateCurrentCharacterInDrive"
+    :save-to-drive="saveCharacterToDrive"
     :experience-label="messages.ui.footer.experience"
     :output-label="messages.ui.footer.output"
     :share-label="messages.ui.footer.share"

--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -274,14 +274,6 @@ export function useGoogleDrive(dataManager) {
     return renamed || result;
   }
 
-  function handleSaveToDriveClick() {
-    return saveCharacterToDrive(false);
-  }
-
-  function saveOrUpdateCurrentCharacterInDrive() {
-    return saveCharacterToDrive(false);
-  }
-
   function initializeGoogleDrive() {
     syncGoogleDriveManager();
 
@@ -347,7 +339,5 @@ export function useGoogleDrive(dataManager) {
     updateDriveFolderPath,
     loadCharacterFromDrive,
     saveCharacterToDrive,
-    handleSaveToDriveClick,
-    saveOrUpdateCurrentCharacterInDrive,
   };
 }


### PR DESCRIPTION
## Summary
- remove the unused Google Drive save helpers that simply proxied to `saveCharacterToDrive`
- update `App.vue` to use the core `saveCharacterToDrive` API everywhere so the footer receives the canonical handler

## Testing
- npm run lint
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ddbc9bc608326bbd4e0669f925cad)