### PR TITLE
Adjust new character creation flow

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -27,6 +27,7 @@ const helpPanelRef = ref(null);
 
 const characterStore = useCharacterStore();
 const uiStore = useUiStore();
+const emptyCharacterSnapshot = buildSnapshotFromStore(characterStore);
 uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
 const { clearLocalDraft } = useLocalCharacterPersistence(characterStore, uiStore);
 useKeyboardHandling();
@@ -69,7 +70,9 @@ async function confirmDiscardingUnsavedChanges() {
   return result?.value === 'confirm';
 }
 
-const handleCreateNewCharacter = async (payload) => {
+const isCharacterSheetEmpty = computed(() => buildSnapshotFromStore(characterStore) === emptyCharacterSnapshot);
+
+const handleCreateNewCharacter = async () => {
   if (hasUnsavedChanges()) {
     const result = await showModal(messages.ui.confirmations.unsavedChanges);
     const choice = result?.value;
@@ -90,19 +93,7 @@ const handleCreateNewCharacter = async (payload) => {
   characterStore.initializeAll();
   uiStore.clearCurrentDriveFileId();
   uiStore.isViewingShared = false;
-  uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
-  const shouldCreateCloudFile = payload?.isSignedIn ?? uiStore.isSignedIn;
-  if (!shouldCreateCloudFile) {
-    return;
-  }
-  try {
-    const result = await saveCharacterToDrive(true);
-    if (result?.id) {
-      uiStore.setCurrentDriveFileId(result.id);
-    }
-  } catch (error) {
-    console.error('Failed to create Drive file for new character:', error);
-  }
+  uiStore.setLastSavedSnapshot(null);
 };
 
 const { openLoadModal, openIoModal, openShareModal } = useAppModals({
@@ -171,6 +162,7 @@ onMounted(initialize);
     :new-character-label="messages.ui.header.newCharacter"
     :sign-in-label="messages.ui.header.signIn"
     :sign-out-label="messages.ui.header.signOut"
+    :is-new-button-disabled="isCharacterSheetEmpty"
     @new-character="handleCreateNewCharacter"
     @sign-in="handleSignInClick"
     @sign-out="handleSignOutClick"

--- a/src/features/character-sheet/components/ui/MainHeader.vue
+++ b/src/features/character-sheet/components/ui/MainHeader.vue
@@ -1,7 +1,12 @@
 <template>
   <header class="main-header" ref="headerEl">
     <div class="main-header__section main-header__section--left">
-      <button class="button-base main-header__button" @click="handleNewCharacterClick">
+      <button
+        class="button-base main-header__button"
+        :class="{ 'main-header__button--disabled': isNewButtonDisabled }"
+        :disabled="isNewButtonDisabled"
+        @click="handleNewCharacterClick"
+      >
         {{ newCharacterLabel }}
       </button>
     </div>
@@ -38,6 +43,10 @@ const props = defineProps({
   newCharacterLabel: String,
   signInLabel: String,
   signOutLabel: String,
+  isNewButtonDisabled: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const emit = defineEmits(['new-character', 'help-mouseover', 'help-mouseleave', 'help-click', 'sign-in', 'sign-out']);
@@ -54,6 +63,9 @@ const titleText = computed(() => characterStore.character.name || props.defaultT
 const isSignedIn = computed(() => uiStore.isSignedIn);
 
 function handleNewCharacterClick() {
+  if (props.isNewButtonDisabled) {
+    return;
+  }
   emit('new-character', { isSignedIn: isSignedIn.value });
 }
 
@@ -101,6 +113,12 @@ defineExpose({ headerEl, helpIcon });
   min-width: 50px;
   height: 50px;
   justify-content: center;
+}
+
+.main-header__button:disabled,
+.main-header__button--disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 
 .main-header__title {


### PR DESCRIPTION
## Summary
- remove automatic Google Drive file creation during new character setup so new sheets start as local drafts
- detect empty sheets in the app shell and pass a disabled flag to the header new button
- style and guard the new button in MainHeader when disabled to prevent accidental actions

## Testing
- npm run lint
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a68066d988326bdd471636f2034d4)