### PR TITLE
Remove auto Drive creation and disable new on empty sheet

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -27,7 +27,8 @@ const helpPanelRef = ref(null);
 
 const characterStore = useCharacterStore();
 const uiStore = useUiStore();
-uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
+const initialCharacterSnapshot = ref(buildSnapshotFromStore(characterStore));
+uiStore.setLastSavedSnapshot(initialCharacterSnapshot.value);
 const { clearLocalDraft } = useLocalCharacterPersistence(characterStore, uiStore);
 useKeyboardHandling();
 
@@ -61,6 +62,14 @@ function hasUnsavedChanges() {
   return uiStore.lastSavedSnapshot ? currentSnapshot !== uiStore.lastSavedSnapshot : true;
 }
 
+const isCharacterSheetEmpty = computed(() => {
+  const currentSnapshot = buildSnapshotFromStore(characterStore);
+  if (!currentSnapshot || !initialCharacterSnapshot.value) {
+    return false;
+  }
+  return currentSnapshot === initialCharacterSnapshot.value;
+});
+
 async function confirmDiscardingUnsavedChanges() {
   if (!hasUnsavedChanges()) {
     return true;
@@ -69,7 +78,7 @@ async function confirmDiscardingUnsavedChanges() {
   return result?.value === 'confirm';
 }
 
-const handleCreateNewCharacter = async (payload) => {
+const handleCreateNewCharacter = async () => {
   if (hasUnsavedChanges()) {
     const result = await showModal(messages.ui.confirmations.unsavedChanges);
     const choice = result?.value;
@@ -90,19 +99,7 @@ const handleCreateNewCharacter = async (payload) => {
   characterStore.initializeAll();
   uiStore.clearCurrentDriveFileId();
   uiStore.isViewingShared = false;
-  uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
-  const shouldCreateCloudFile = payload?.isSignedIn ?? uiStore.isSignedIn;
-  if (!shouldCreateCloudFile) {
-    return;
-  }
-  try {
-    const result = await saveCharacterToDrive(true);
-    if (result?.id) {
-      uiStore.setCurrentDriveFileId(result.id);
-    }
-  } catch (error) {
-    console.error('Failed to create Drive file for new character:', error);
-  }
+  uiStore.setLastSavedSnapshot(null);
 };
 
 const { openLoadModal, openIoModal, openShareModal } = useAppModals({
@@ -169,6 +166,7 @@ onMounted(initialize);
     :default-title="messages.ui.header.defaultTitle"
     :help-label="messages.ui.header.helpLabel"
     :new-character-label="messages.ui.header.newCharacter"
+    :is-new-button-disabled="isCharacterSheetEmpty"
     :sign-in-label="messages.ui.header.signIn"
     :sign-out-label="messages.ui.header.signOut"
     @new-character="handleCreateNewCharacter"

--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -99,7 +99,7 @@ const handleCreateNewCharacter = async () => {
   characterStore.initializeAll();
   uiStore.clearCurrentDriveFileId();
   uiStore.isViewingShared = false;
-  uiStore.setLastSavedSnapshot(null);
+  uiStore.setLastSavedSnapshot(initialCharacterSnapshot.value);
 };
 
 const { openLoadModal, openIoModal, openShareModal } = useAppModals({

--- a/src/features/character-sheet/components/ui/MainHeader.vue
+++ b/src/features/character-sheet/components/ui/MainHeader.vue
@@ -1,7 +1,12 @@
 <template>
   <header class="main-header" ref="headerEl">
     <div class="main-header__section main-header__section--left">
-      <button class="button-base main-header__button" @click="handleNewCharacterClick">
+      <button
+        class="button-base main-header__button"
+        :class="{ 'main-header__button--disabled': isNewButtonDisabled }"
+        :disabled="isNewButtonDisabled"
+        @click="handleNewCharacterClick"
+      >
         {{ newCharacterLabel }}
       </button>
     </div>
@@ -38,6 +43,7 @@ const props = defineProps({
   newCharacterLabel: String,
   signInLabel: String,
   signOutLabel: String,
+  isNewButtonDisabled: Boolean,
 });
 
 const emit = defineEmits(['new-character', 'help-mouseover', 'help-mouseleave', 'help-click', 'sign-in', 'sign-out']);
@@ -54,6 +60,9 @@ const titleText = computed(() => characterStore.character.name || props.defaultT
 const isSignedIn = computed(() => uiStore.isSignedIn);
 
 function handleNewCharacterClick() {
+  if (props.isNewButtonDisabled) {
+    return;
+  }
   emit('new-character', { isSignedIn: isSignedIn.value });
 }
 
@@ -101,6 +110,13 @@ defineExpose({ headerEl, helpIcon });
   min-width: 50px;
   height: 50px;
   justify-content: center;
+}
+
+.main-header__button--disabled,
+.main-header__button:disabled {
+  background-color: var(--color-border-weak);
+  color: var(--color-text-muted);
+  cursor: not-allowed;
 }
 
 .main-header__title {


### PR DESCRIPTION
## Summary
- stop creating new Google Drive files automatically when starting a new character
- add empty-sheet detection to expose a disabled state for the New button
- style and disable the header New button when the sheet is in its initial empty state

## Testing
- npm run lint
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a68066d988326bdd471636f2034d4)