### PR TITLE
Refine basic character info layout

### DIFF
--- a/src/data/gameData.js
+++ b/src/data/gameData.js
@@ -666,8 +666,6 @@ export const AioniaGameData = {
     gender: '',
     height: '',
     weight: '',
-    origin: '',
-    faith: '',
     otherItems: '',
     currentScar: 0,
     initialScar: 0,

--- a/src/features/character-sheet/components/sections/CharacterBasicInfo.vue
+++ b/src/features/character-sheet/components/sections/CharacterBasicInfo.vue
@@ -10,15 +10,20 @@
         </div>
         <div class="info-item info-item--double">
           <label for="player_name">{{ basicInfoTexts.fields.playerName }}</label>
-          <input type="text" id="player_name" v-model="characterStore.character.playerName" :disabled="uiStore.isViewingShared" />
+          <input
+            type="text"
+            id="player_name"
+            v-model="characterStore.character.playerName"
+            :disabled="uiStore.isViewingShared"
+          />
         </div>
       </div>
       <div class="info-row">
         <div
           class="info-item"
           :class="{
-            'info-item--full': characterStore.character.species !== 'other',
-            'info-item--double': characterStore.character.species === 'other',
+            'info-item--double': characterStore.character.species !== 'other',
+            'info-item--quadruple': characterStore.character.species === 'other',
           }"
         >
           <label for="species">{{ basicInfoTexts.fields.species }}</label>
@@ -28,9 +33,13 @@
             </option>
           </select>
         </div>
-        <div class="info-item info-item--double" v-if="characterStore.character.species === 'other'">
+        <div class="info-item info-item--quadruple" v-if="characterStore.character.species === 'other'">
           <label for="rare_species">{{ basicInfoTexts.fields.rareSpecies }}</label>
           <input type="text" id="rare_species" v-model="characterStore.character.rareSpecies" :disabled="uiStore.isViewingShared" />
+        </div>
+        <div class="info-item info-item--double">
+          <label for="occupation">{{ basicInfoTexts.fields.occupation }}</label>
+          <input type="text" id="occupation" v-model="characterStore.character.occupation" :disabled="uiStore.isViewingShared" />
         </div>
       </div>
       <div class="info-row">
@@ -49,20 +58,6 @@
         <div class="info-item info-item--quadruple">
           <label for="weight_char">{{ basicInfoTexts.fields.weight }}</label>
           <input type="text" id="weight_char" v-model="characterStore.character.weight" :disabled="uiStore.isViewingShared" />
-        </div>
-      </div>
-      <div class="info-row">
-        <div class="info-item info-item--triple">
-          <label for="origin">{{ basicInfoTexts.fields.origin }}</label>
-          <input type="text" id="origin" v-model="characterStore.character.origin" :disabled="uiStore.isViewingShared" />
-        </div>
-        <div class="info-item info-item--triple">
-          <label for="occupation">{{ basicInfoTexts.fields.occupation }}</label>
-          <input type="text" id="occupation" v-model="characterStore.character.occupation" :disabled="uiStore.isViewingShared" />
-        </div>
-        <div class="info-item info-item--triple">
-          <label for="faith">{{ basicInfoTexts.fields.faith }}</label>
-          <input type="text" id="faith" v-model="characterStore.character.faith" :disabled="uiStore.isViewingShared" />
         </div>
       </div>
     </div>

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -229,7 +229,7 @@ export const messages = {
           name: 'キャラクター名',
           playerName: 'プレイヤー名',
           species: '種族',
-          rareSpecies: '種族名（希少人種）',
+          rareSpecies: '種族名',
           gender: '性別',
           age: '年齢',
           height: '身長',

--- a/src/shared/styles/_layout.css
+++ b/src/shared/styles/_layout.css
@@ -97,17 +97,17 @@
 }
 
 .info-item--double {
-  flex: 1 1 calc(50% - 7.5px);
+  flex: 1 1 calc(50% - 2.5px);
   min-width: 80px;
 }
 
 .info-item--triple {
-  flex: 1 1 calc(33.333% - 10px);
+  flex: 1 1 calc(33.333% - 3.33px);
   min-width: 90px;
 }
 
 .info-item--quadruple {
-  flex: 1 1 calc(25% - 12.5px);
+  flex: 1 1 calc(25% - 3.75px);
   min-width: 65px;
 }
 


### PR DESCRIPTION
## Summary
- remove origin and faith fields from default character data
- restructure basic info layout to emphasize species and occupation fields with responsive widths

## Testing
- npm run lint
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b74e131608326808ca27e85892f1e)