### PR TITLE
Add shared muted text color token

### DIFF
--- a/src/features/modals/components/contents/LoadModal.vue
+++ b/src/features/modals/components/contents/LoadModal.vue
@@ -159,7 +159,7 @@ function handleLocalChange(event) {
 
 .load-modal__signin-message {
   margin: 0;
-  color: var(--color-text-muted, #ccc);
+  color: var(--color-text-muted);
 }
 
 .button-base:disabled {

--- a/src/shared/styles/_variables.css
+++ b/src/shared/styles/_variables.css
@@ -12,6 +12,7 @@
   --color-input-bg: var(--color-background);
   --color-input-disabled-bg: var(--color-panel-body);
   --color-text-normal: #d7d7d7;
+  --color-text-muted: #ccc;
   --color-text-input-disabled: #bbb;
   --color-link: #ccc;
   --color-link-hover: var(--color-accent);

--- a/src/shared/styles/_variables.css
+++ b/src/shared/styles/_variables.css
@@ -14,6 +14,7 @@
   --color-text-normal: #d7d7d7;
   --color-text-muted: var(--color-grey-light);
   --color-text-input-disabled: #bbb;
+  --color-link: var(--color-grey-light);
   --color-link-hover: var(--color-accent);
   --color-delete-text: #c05a5a;
   --color-delete-text-light: #eb8787;

--- a/src/shared/styles/_variables.css
+++ b/src/shared/styles/_variables.css
@@ -12,9 +12,8 @@
   --color-input-bg: var(--color-background);
   --color-input-disabled-bg: var(--color-panel-body);
   --color-text-normal: #d7d7d7;
-  --color-text-muted: #ccc;
+  --color-text-muted: var(--color-grey-light);
   --color-text-input-disabled: #bbb;
-  --color-link: #ccc;
   --color-link-hover: var(--color-accent);
   --color-delete-text: #c05a5a;
   --color-delete-text-light: #eb8787;


### PR DESCRIPTION
## Summary
- add a shared `--color-text-muted` variable alongside other text color tokens
- update LoadModal to rely on the centralized muted text color variable instead of ad-hoc fallbacks
- ensure muted text consumers draw from the shared token for consistent styling

## Testing
- npm run lint
- npm test *(fails: unable to resolve import "hono" in tests/unit/functions/authApi.test.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b758fb08c83268d573cfaa6aaa0ce)