### PR TITLE
Refactor notification palette variables

### DIFF
--- a/src/shared/styles/_notifications.css
+++ b/src/shared/styles/_notifications.css
@@ -1,23 +1,6 @@
 /* stylelint-disable */
 
-:root {
-  /* --- 通知カラーパレット --- */
-  --color-success: #2d5a3d;
-  --color-success-light: #4a7c5a;
-  --color-success-glow: #6bb77b;
-  --color-warning: #8b5a2b;
-  --color-warning-light: #b8783d;
-  --color-warning-glow: #d4955a;
-  --color-error: #5a2d2d;
-  --color-error-light: #7a3d3d;
-  --color-error-glow: #a85555;
-  --color-info: #2d3d5a;
-  --color-info-light: #3d4f7a;
-  --color-info-glow: #5577a8;
-  --color-critical: #4a1a1a;
-  --color-critical-light: #6b2d2d;
-  --color-critical-glow: #8b4444;
-}
+@import url('_variables.css');
 
 /* Toast通知 */
 .toast-container {

--- a/src/shared/styles/_variables.css
+++ b/src/shared/styles/_variables.css
@@ -1,20 +1,35 @@
+/*
+Token categories for shared CSS variables:
+- Base surface: backgrounds and neutral surfaces
+- Text: text and link colors
+- Border: outlines and dividers
+- Feedback/Status: accents, statuses, and notification palettes
+*/
+
 :root {
-  --color-accent-light: #dbc19d;
-  --color-accent: #d3a76e;
-  --color-accent-middle: #726452;
-  --color-accent-dark: #3b332a;
+  /* Base surface */
   --color-background: #171717;
   --color-panel-header: #333;
   --color-panel-sub-header: #2e2e2e;
   --color-panel-body: #222;
   --color-panel-specialskill: #1d1d1d;
-  --color-border-normal: #444;
   --color-input-bg: var(--color-background);
   --color-input-disabled-bg: var(--color-panel-body);
+
+  /* Text */
   --color-text-normal: #d7d7d7;
   --color-text-input-disabled: #bbb;
   --color-link: #ccc;
   --color-link-hover: var(--color-accent);
+
+  /* Border */
+  --color-border-normal: #444;
+
+  /* Feedback/Status */
+  --color-accent-light: #dbc19d;
+  --color-accent: #d3a76e;
+  --color-accent-middle: #726452;
+  --color-accent-dark: #3b332a;
   --color-delete-text: #c05a5a;
   --color-delete-text-light: #eb8787;
   --color-delete-border: #7f5454;
@@ -34,4 +49,19 @@
   --color-load-ghost-normal: #5e5e5e;
   --color-load-ghost-light: #665c36;
   --color-load-ghost-heavy: #663f3f;
+  --color-success: #2d5a3d;
+  --color-success-light: #4a7c5a;
+  --color-success-glow: #6bb77b;
+  --color-warning: #8b5a2b;
+  --color-warning-light: #b8783d;
+  --color-warning-glow: #d4955a;
+  --color-error: #5a2d2d;
+  --color-error-light: #7a3d3d;
+  --color-error-glow: #a85555;
+  --color-info: #2d3d5a;
+  --color-info-light: #3d4f7a;
+  --color-info-glow: #5577a8;
+  --color-critical: #4a1a1a;
+  --color-critical-light: #6b2d2d;
+  --color-critical-glow: #8b4444;
 }

--- a/src/shared/styles/_variables.css
+++ b/src/shared/styles/_variables.css
@@ -49,6 +49,7 @@ Token categories for shared CSS variables:
   --color-load-ghost-normal: #5e5e5e;
   --color-load-ghost-light: #665c36;
   --color-load-ghost-heavy: #663f3f;
+  /* Notification palette */
   --color-success: #2d5a3d;
   --color-success-light: #4a7c5a;
   --color-success-glow: #6bb77b;

--- a/src/shared/styles/_variables.css
+++ b/src/shared/styles/_variables.css
@@ -49,6 +49,7 @@ Token categories for shared CSS variables:
   --color-load-ghost-normal: #5e5e5e;
   --color-load-ghost-light: #665c36;
   --color-load-ghost-heavy: #663f3f;
+
   /* Notification palette */
   --color-success: #2d5a3d;
   --color-success-light: #4a7c5a;


### PR DESCRIPTION
## Summary
- document shared color token categories and consolidate notification palette into `_variables.css`
- update notification styles to import shared tokens and focus on component rules

## Testing
- npm run lint
- npm run test *(fails: tests/unit/functions/authApi.test.js missing hono import from functions/api/[[route]].js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b7591d11083269134a1ae9e631882)