### PR TITLE
Refactor Japanese locale to CSV-driven loader

### DIFF
--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -1,298 +1,359 @@
+import messagesCsv from './messages.csv?raw';
+import { createI18nLoader } from '../utils/i18nLoader.js';
+
+const i18n = createI18nLoader(messagesCsv, 'ja');
+const t = (key, variables) => i18n.t(key, variables);
+
+const driveLoadErrorMap = {
+  general: 'share.loadError.message.general',
+  fetchFailed: 'share.loadError.message.fetchFailed',
+  parseFailed: 'share.loadError.message.parseFailed',
+};
+
 export const messages = {
   errors: {
-    unexpected: '予期せぬエラーが発生しました',
+    unexpected: t('errors.unexpected'),
   },
   googleDrive: {
     auth: {
-      connected: () => ({ title: 'Google Drive', message: '接続しました' }),
+      connected: () => ({
+        title: t('googleDrive.auth.connected.title'),
+        message: t('googleDrive.auth.connected.message'),
+      }),
     },
     signOut: {
-      success: () => ({ title: 'サインアウトしました', message: '' }),
+      success: () => ({
+        title: t('googleDrive.signOut.success.title'),
+        message: t('googleDrive.signOut.success.message'),
+      }),
     },
     folderPicker: {
-      unavailable: () => ({ title: 'Google Drive', message: 'フォルダピッカーを利用できません' }),
+      unavailable: () => ({
+        title: t('googleDrive.folderPicker.unavailable.title'),
+        message: t('googleDrive.folderPicker.unavailable.message'),
+      }),
       error: (err) => ({
-        title: 'Google Drive',
-        message: err?.message || 'フォルダ選択をキャンセルしました',
+        title: t('googleDrive.folderPicker.error.title'),
+        message: err?.message || t('googleDrive.folderPicker.error.message'),
       }),
     },
     save: {
-      loading: () => ({ title: 'Google Drive', message: '保存中...' }),
-      newLoading: () => ({ title: '新規キャラクター', message: '新規キャラクターを保存中' }),
-      newSuccess: () => ({ title: '新規キャラクター', message: '新規キャラクターを保存しました' }),
-      success: () => ({ title: '保存完了', message: '' }),
-      error: (err) => ({ title: '保存失敗', message: err.message || '' }),
+      loading: () => ({
+        title: t('googleDrive.save.loading.title'),
+        message: t('googleDrive.save.loading.message'),
+      }),
+      newLoading: () => ({
+        title: t('googleDrive.save.newLoading.title'),
+        message: t('googleDrive.save.newLoading.message'),
+      }),
+      newSuccess: () => ({
+        title: t('googleDrive.save.newSuccess.title'),
+        message: t('googleDrive.save.newSuccess.message'),
+      }),
+      success: () => ({
+        title: t('googleDrive.save.success.title'),
+        message: t('googleDrive.save.success.message'),
+      }),
+      error: (err) => ({
+        title: t('googleDrive.save.error.title'),
+        message: err?.message || t('googleDrive.save.error.message'),
+      }),
     },
     load: {
       loading: (name) => ({
-        title: 'Google Drive',
-        message: `${name} を読み込み中...`,
+        title: t('googleDrive.load.loading.title'),
+        message: t('googleDrive.load.loading.message', { name }),
       }),
       success: (name) => ({
-        title: '読込完了',
-        message: `${name} を読み込みました`,
+        title: t('googleDrive.load.success.title'),
+        message: t('googleDrive.load.success.message', { name }),
       }),
       error: (err) => ({
-        title: '読み込みエラー',
-        message: err.message || '不明なエラー',
+        title: t('googleDrive.load.error.title'),
+        message: err?.message || t('googleDrive.load.error.message'),
       }),
-      noSelection: () => ({ title: '読み込みエラー', message: 'ファイルが選択されていません' }),
-      missingData: () => ({ title: '読み込みエラー', message: 'キャラクターデータを取得できませんでした' }),
+      noSelection: () => ({
+        title: t('googleDrive.load.noSelection.title'),
+        message: t('googleDrive.load.noSelection.message'),
+      }),
+      missingData: () => ({
+        title: t('googleDrive.load.missingData.title'),
+        message: t('googleDrive.load.missingData.message'),
+      }),
     },
     overwriteConfirm: (name) => ({
-      title: '上書き確認',
-      message: `${name} は既に存在します。上書きしますか？`,
+      title: t('googleDrive.overwriteConfirm.title'),
+      message: t('googleDrive.overwriteConfirm.message', { name }),
       buttons: [
-        { label: '上書き', value: 'overwrite', variant: 'primary' },
-        { label: 'キャンセル', value: 'cancel', variant: 'secondary', duration: 1 },
+        { label: t('googleDrive.overwriteConfirm.buttons.overwrite'), value: 'overwrite', variant: 'primary' },
+        {
+          label: t('googleDrive.overwriteConfirm.buttons.cancel'),
+          value: 'cancel',
+          variant: 'secondary',
+          duration: 1,
+        },
       ],
     }),
     apiInitError: () => ({
-      title: 'Google API エラー',
-      message: '初期化に失敗しました',
+      title: t('googleDrive.apiInitError.title'),
+      message: t('googleDrive.apiInitError.message'),
     }),
     initPending: () => ({
-      title: 'Google Drive',
-      message: '初期化が完了するまでお待ちください',
+      title: t('googleDrive.initPending.title'),
+      message: t('googleDrive.initPending.message'),
     }),
     config: {
-      loadError: () => ({ title: '設定読み込み失敗', message: '保存先フォルダの取得に失敗しました' }),
-      requiresSignIn: () => ({ title: 'Google Drive', message: 'Googleにサインインしてください' }),
-      updateSuccess: () => ({ title: '設定更新', message: '保存先フォルダを更新しました' }),
+      loadError: () => ({
+        title: t('googleDrive.config.loadError.title'),
+        message: t('googleDrive.config.loadError.message'),
+      }),
+      requiresSignIn: () => ({
+        title: t('googleDrive.config.requiresSignIn.title'),
+        message: t('googleDrive.config.requiresSignIn.message'),
+      }),
+      updateSuccess: () => ({
+        title: t('googleDrive.config.updateSuccess.title'),
+        message: t('googleDrive.config.updateSuccess.message'),
+      }),
       updateError: (err) => ({
-        title: '設定更新失敗',
-        message: err?.message || '保存先フォルダの更新に失敗しました',
+        title: t('googleDrive.config.updateError.title'),
+        message: err?.message || t('googleDrive.config.updateError.message'),
       }),
     },
   },
   share: {
     needSignIn: () => ({
-      title: 'Google Drive',
-      message: 'サインインしてください',
+      title: t('share.needSignIn.title'),
+      message: t('share.needSignIn.message'),
     }),
     toast: {
-      creating: () => ({ title: '共有リンク', message: '作成中...' }),
-      success: () => ({ title: '共有リンク', message: 'URLをコピーしました' }),
+      creating: () => ({ title: t('share.toast.creating.title'), message: t('share.toast.creating.message') }),
+      success: () => ({ title: t('share.toast.success.title'), message: t('share.toast.success.message') }),
       error: (err) => ({
-        title: '共有失敗',
-        message: err?.message || '共有リンクの生成に失敗しました',
+        title: t('share.toast.error.title'),
+        message: err?.message || t('share.toast.error.message'),
       }),
-      clipboardUnavailable: () => ({ title: '共有リンク', message: 'クリップボードにアクセスできません' }),
+      clipboardUnavailable: () => ({
+        title: t('share.toast.clipboardUnavailable.title'),
+        message: t('share.toast.clipboardUnavailable.message'),
+      }),
     },
     errors: {
-      saveFailed: 'Google Drive への保存に失敗しました',
-      shareFailed: '共有リンクの取得に失敗しました',
-      managerMissing: 'Google Drive マネージャーが設定されていません',
+      saveFailed: t('share.errors.saveFailed'),
+      shareFailed: t('share.errors.shareFailed'),
+      managerMissing: t('share.errors.managerMissing'),
     },
     loadError: {
-      toast: (key = 'general') => {
-        const messagesMap = {
-          general: '共有データの読み込みに失敗しました',
-          fetchFailed: '共有データの取得に失敗しました',
-          parseFailed: '共有データの解析に失敗しました',
-        };
-        return {
-          title: '共有データエラー',
-          message: messagesMap[key] || messagesMap.general,
-        };
-      },
+      toast: (key = 'general') => ({
+        title: t('share.loadError.title'),
+        message: t(driveLoadErrorMap[key] || driveLoadErrorMap.general),
+      }),
     },
   },
   characterHub: {
     driveFolder: {
-      changeButton: '選択',
-      label: '保存先フォルダ',
-      placeholder: '慈悲なきアイオニア',
+      changeButton: t('characterHub.driveFolder.changeButton'),
+      label: t('characterHub.driveFolder.label'),
+      placeholder: t('characterHub.driveFolder.placeholder'),
     },
     buttons: {
-      signIn: 'ログイン／Driveから読み込む',
+      signIn: t('characterHub.buttons.signIn'),
     },
   },
   image: {
-    loadError: (err) => ({ title: '画像読み込み失敗', message: err.message }),
+    loadError: (err) => ({
+      title: t('image.loadError.title'),
+      message: err?.message ?? t('image.loadError.message', { message: '' }),
+    }),
     uploadErrors: {
-      noFile: '画像ファイルが選択されていません。',
-      unsupportedType: '対応していない画像形式です。JPEG、PNG、GIF、WebP、SVG を指定してください。',
-      tooLarge: 'ファイルサイズが大きすぎます（最大10MB）。',
-      readError: '画像の読み込み中にエラーが発生しました。',
+      noFile: t('image.uploadErrors.noFile'),
+      unsupportedType: t('image.uploadErrors.unsupportedType'),
+      tooLarge: t('image.uploadErrors.tooLarge'),
+      readError: t('image.uploadErrors.readError'),
     },
   },
   dataExport: {
-    loadError: (msg) => ({ title: '読み込み失敗', message: msg }),
+    loadError: (msg) => ({
+      title: t('dataExport.loadError.title'),
+      message: msg ?? t('dataExport.loadError.message', { message: '' }),
+    }),
   },
   file: {
-    loadError: 'ファイルの読み込みに失敗しました。JSON形式が正しくない可能性があります。',
-    unsupportedFormat: '対応していないファイル形式です。AioniaCSで保存したデータをご利用ください。',
+    loadError: t('file.loadError'),
+    unsupportedFormat: t('file.unsupportedFormat'),
   },
   ui: {
     header: {
-      defaultTitle: 'Aionia TRPG Character Sheet',
-      helpLabel: '?',
-      newCharacter: '新規',
-      signIn: 'ログイン',
-      signOut: 'ログアウト',
+      defaultTitle: t('ui.header.defaultTitle'),
+      helpLabel: t('ui.header.helpLabel'),
+      newCharacter: t('ui.header.newCharacter'),
+      signIn: t('ui.header.signIn'),
+      signOut: t('ui.header.signOut'),
     },
     footer: {
-      experience: '経験点',
-      output: '出力',
-      share: '共有',
-      copyEdit: '自分用にコピーして編集',
+      experience: t('ui.footer.experience'),
+      output: t('ui.footer.output'),
+      share: t('ui.footer.share'),
+      copyEdit: t('ui.footer.copyEdit'),
     },
-    viewModeBanner: '閲覧モードで表示中',
+    viewModeBanner: t('ui.viewModeBanner'),
     buttons: {
-      saveCloudNew: '新規保存',
-      saveCloudOverwrite: '上書保存',
-      saveCloudTitle: 'Google Driveに保存',
-      loadCloud: 'Drive読込',
-      loadCloudTitle: 'Google Driveから読込む',
-      saveLocal: '端末保存',
-      saveLocalTitle: '端末に保存',
-      loadLocal: '読込',
-      loadLocalTitle: '端末から読込む',
-      save: '保存',
+      saveCloudNew: t('ui.buttons.saveCloudNew'),
+      saveCloudOverwrite: t('ui.buttons.saveCloudOverwrite'),
+      saveCloudTitle: t('ui.buttons.saveCloudTitle'),
+      loadCloud: t('ui.buttons.loadCloud'),
+      loadCloudTitle: t('ui.buttons.loadCloudTitle'),
+      saveLocal: t('ui.buttons.saveLocal'),
+      saveLocalTitle: t('ui.buttons.saveLocalTitle'),
+      loadLocal: t('ui.buttons.loadLocal'),
+      loadLocalTitle: t('ui.buttons.loadLocalTitle'),
+      save: t('ui.buttons.save'),
     },
     confirmations: {
       unsavedChanges: {
-        title: '保存されていない変更があります',
-        message: '現在の内容はまだ保存されていません。新規作成すると変更は失われます。続行しますか？',
+        title: t('ui.confirmations.unsavedChanges.title'),
+        message: t('ui.confirmations.unsavedChanges.message'),
         buttons: [
-          { label: '保存して続行', value: 'save', variant: 'primary' },
-          { label: '保存せず続行', value: 'discard', variant: 'secondary' },
-          { label: 'キャンセル', value: 'cancel', variant: 'secondary' },
+          { label: t('ui.confirmations.unsavedChanges.buttons.save'), value: 'save', variant: 'primary' },
+          { label: t('ui.confirmations.unsavedChanges.buttons.discard'), value: 'discard', variant: 'secondary' },
+          { label: t('ui.confirmations.unsavedChanges.buttons.cancel'), value: 'cancel', variant: 'secondary' },
         ],
       },
     },
     modal: {
       load: {
-        title: '読込',
+        title: t('ui.modal.load.title'),
         buttons: {
-          loadLocal: 'ローカルから読み込む',
-          loadDrive: 'Driveから読み込む',
+          loadLocal: t('ui.modal.load.buttons.loadLocal'),
+          loadDrive: t('ui.modal.load.buttons.loadDrive'),
         },
-        signInMessage: 'Drive機能を使うにはGoogleにサインインしてください。',
+        signInMessage: t('ui.modal.load.signInMessage'),
       },
       io: {
-        title: '入出力',
+        title: t('ui.modal.io.title'),
         buttons: {
-          saveLocal: 'ローカルファイルで出力',
-          print: '印刷',
-          chatPalette: 'チャットパレットを出力',
+          saveLocal: t('ui.modal.io.buttons.saveLocal'),
+          print: t('ui.modal.io.buttons.print'),
+          chatPalette: t('ui.modal.io.buttons.chatPalette'),
         },
         chatPalette: {
-          success: () => ({ title: 'チャットパレット', message: 'クリップボードにコピーしました' }),
-          error: (err) => ({
-            title: 'チャットパレット',
-            message: err?.message || 'コピーに失敗しました',
+          success: () => ({
+            title: t('ui.modal.io.chatPalette.success.title'),
+            message: t('ui.modal.io.chatPalette.success.message'),
           }),
-          clipboardUnavailable: 'クリップボード機能が利用できません',
+          error: (err) => ({
+            title: t('ui.modal.io.chatPalette.error.title'),
+            message: err?.message || t('ui.modal.io.chatPalette.error.message'),
+          }),
+          clipboardUnavailable: t('ui.modal.io.chatPalette.clipboardUnavailable'),
         },
       },
     },
   },
   sheet: {
     loadIndicator: {
-      label: '荷重',
+      label: t('sheet.loadIndicator.label'),
     },
     toggles: {
-      showDescription: '説明を表示',
+      showDescription: t('sheet.toggles.showDescription'),
     },
     images: {
-      alt: 'キャラクター画像',
-      previous: '前の画像',
-      next: '次の画像',
-      add: '画像を追加',
-      delete: '削除',
-      deleteAria: '現在の画像を削除',
-      empty: '画像はありません',
+      alt: t('sheet.images.alt'),
+      previous: t('sheet.images.previous'),
+      next: t('sheet.images.next'),
+      add: t('sheet.images.add'),
+      delete: t('sheet.images.delete'),
+      deleteAria: t('sheet.images.deleteAria'),
+      empty: t('sheet.images.empty'),
     },
     placeholders: {
-      expertSkill: '専門技能',
-      expertSkillDisabled: '専門技能 (技能選択で有効)',
-      specialSkillNote: '詳細',
-      characterMemo: 'キャラクター背景、設定、その他メモを記入',
-      weaponName: '装備名',
-      armorName: '装備名',
-      adventureMemo: 'メモ',
+      expertSkill: t('sheet.placeholders.expertSkill'),
+      expertSkillDisabled: t('sheet.placeholders.expertSkillDisabled'),
+      specialSkillNote: t('sheet.placeholders.specialSkillNote'),
+      characterMemo: t('sheet.placeholders.characterMemo'),
+      weaponName: t('sheet.placeholders.weaponName'),
+      armorName: t('sheet.placeholders.armorName'),
+      adventureMemo: t('sheet.placeholders.adventureMemo'),
     },
     aria: {
-      deleteItem: '項目を削除',
-      removeExpert: '専門技能を削除',
-      addExpert: '専門技能を追加',
-      removeSpecialSkill: '特技を削除',
-      addSpecialSkill: '特技を追加',
-      addAdventureLog: '冒険記録を追加',
+      deleteItem: t('sheet.aria.deleteItem'),
+      removeExpert: t('sheet.aria.removeExpert'),
+      addExpert: t('sheet.aria.addExpert'),
+      removeSpecialSkill: t('sheet.aria.removeSpecialSkill'),
+      addSpecialSkill: t('sheet.aria.addSpecialSkill'),
+      addAdventureLog: t('sheet.aria.addAdventureLog'),
     },
     sections: {
       basicInfo: {
-        title: '基本情報',
+        title: t('sheet.sections.basicInfo.title'),
         fields: {
-          name: 'キャラクター名',
-          playerName: 'プレイヤー名',
-          species: '種族',
-          rareSpecies: '種族名',
-          gender: '性別',
-          age: '年齢',
-          height: '身長',
-          weight: '体重',
-          origin: '出身地',
-          occupation: '職業',
-          faith: '信仰',
+          name: t('sheet.sections.basicInfo.fields.name'),
+          playerName: t('sheet.sections.basicInfo.fields.playerName'),
+          species: t('sheet.sections.basicInfo.fields.species'),
+          rareSpecies: t('sheet.sections.basicInfo.fields.rareSpecies'),
+          gender: t('sheet.sections.basicInfo.fields.gender'),
+          age: t('sheet.sections.basicInfo.fields.age'),
+          height: t('sheet.sections.basicInfo.fields.height'),
+          weight: t('sheet.sections.basicInfo.fields.weight'),
+          origin: t('sheet.sections.basicInfo.fields.origin'),
+          occupation: t('sheet.sections.basicInfo.fields.occupation'),
+          faith: t('sheet.sections.basicInfo.fields.faith'),
         },
       },
       scar: {
-        title: '傷痕',
+        title: t('sheet.sections.scar.title'),
         fields: {
-          initial: '初期値',
-          current: '現在値（初期値+増加分）',
+          initial: t('sheet.sections.scar.fields.initial'),
+          current: t('sheet.sections.scar.fields.current'),
         },
       },
       weakness: {
-        title: '弱点',
+        title: t('sheet.sections.weakness.title'),
         columns: {
-          text: '弱点',
-          acquired: '獲得',
+          text: t('sheet.sections.weakness.columns.text'),
+          acquired: t('sheet.sections.weakness.columns.acquired'),
         },
       },
       skills: {
-        title: '技能',
+        title: t('sheet.sections.skills.title'),
       },
       memo: {
-        title: 'キャラクターメモ',
+        title: t('sheet.sections.memo.title'),
       },
       specialSkills: {
-        title: '特技',
+        title: t('sheet.sections.specialSkills.title'),
         columns: {
-          group: '種類',
-          name: '名称',
-          acquired: '獲得',
+          group: t('sheet.sections.specialSkills.columns.group'),
+          name: t('sheet.sections.specialSkills.columns.name'),
+          acquired: t('sheet.sections.specialSkills.columns.acquired'),
         },
       },
       items: {
-        title: '所持品',
+        title: t('sheet.sections.items.title'),
         labels: {
-          otherItems: 'その他所持品',
+          otherItems: t('sheet.sections.items.labels.otherItems'),
           slots: {
-            weapon1: '武器1',
-            weapon2: '武器2',
-            armor: '防具',
+            weapon1: t('sheet.sections.items.labels.slots.weapon1'),
+            weapon2: t('sheet.sections.items.labels.slots.weapon2'),
+            armor: t('sheet.sections.items.labels.slots.armor'),
           },
         },
       },
       adventureLog: {
-        title: '冒険の記録',
+        title: t('sheet.sections.adventureLog.title'),
         columns: {
-          scenario: 'シナリオ名',
-          experience: '経験点',
-          scar: '傷痕増加',
+          scenario: t('sheet.sections.adventureLog.columns.scenario'),
+          experience: t('sheet.sections.adventureLog.columns.experience'),
+          scar: t('sheet.sections.adventureLog.columns.scar'),
         },
       },
     },
   },
   outputButton: {
-    default: 'ココフォリア駒出力',
-    success: 'コピー完了！',
-    error: 'コピーエラー (fallback)',
-    animating: '冒険が始まる――',
+    default: t('outputButton.default'),
+    success: t('outputButton.success'),
+    error: t('outputButton.error'),
+    animating: t('outputButton.animating'),
     animationTimings: {
       state1_bgFill: 500,
       state2_textHold: 1000,
@@ -301,6 +362,6 @@ export const messages = {
       state5_successHold: 300,
     },
   },
-  weaknessDropdownHelp: '（冒険の記録を追加すると選択肢が増えます）',
-  specialSkillDropdownHelp: '（シナリオ報酬の場合はシナリオ名を選択）',
+  weaknessDropdownHelp: t('weaknessDropdownHelp'),
+  specialSkillDropdownHelp: t('specialSkillDropdownHelp'),
 };

--- a/src/locales/messages.csv
+++ b/src/locales/messages.csv
@@ -60,7 +60,7 @@ share.errors.managerMissing,Google Drive マネージャーが設定されてい
 share.loadError.title,共有データエラー,Share load error title
 share.loadError.message.general,共有データの読み込みに失敗しました,Share load error general message
 share.loadError.message.fetchFailed,共有データの取得に失敗しました,Share load error fetch failed message
-share.loadError.message.parseFailed,共有データの解析に失敗しした,Share load error parse failed message
+share.loadError.message.parseFailed,共有データの解析に失敗しました,Share load error parse failed message
 characterHub.driveFolder.changeButton,選択,Character hub folder change button
 characterHub.driveFolder.label,保存先フォルダ,Character hub folder label
 characterHub.driveFolder.placeholder,慈悲なきアイオニア,Character hub folder placeholder

--- a/src/locales/messages.csv
+++ b/src/locales/messages.csv
@@ -1,0 +1,176 @@
+key,ja,comment
+errors.unexpected,予期せぬエラーが発生しました,General unexpected error message
+googleDrive.auth.connected.title,Google Drive,Drive auth connected title
+googleDrive.auth.connected.message,接続しました,Drive auth connected body
+googleDrive.signOut.success.title,サインアウトしました,Drive sign out success title
+googleDrive.signOut.success.message,,Drive sign out success body (empty)
+googleDrive.folderPicker.unavailable.title,Google Drive,Drive folder picker unavailable title
+googleDrive.folderPicker.unavailable.message,フォルダピッカーを利用できません,Drive folder picker unavailable body
+googleDrive.folderPicker.error.title,Google Drive,Drive folder picker error title
+googleDrive.folderPicker.error.message,フォルダ選択をキャンセルしました,Drive folder picker default error body
+googleDrive.save.loading.title,Google Drive,Drive save loading title
+googleDrive.save.loading.message,保存中...,Drive save loading body
+googleDrive.save.newLoading.title,新規キャラクター,Drive save new character loading title
+googleDrive.save.newLoading.message,新規キャラクターを保存中,Drive save new character loading body
+googleDrive.save.newSuccess.title,新規キャラクター,Drive save new character success title
+googleDrive.save.newSuccess.message,新規キャラクターを保存しました,Drive save new character success body
+googleDrive.save.success.title,保存完了,Drive save success title
+googleDrive.save.success.message,,Drive save success body (empty)
+googleDrive.save.error.title,保存失敗,Drive save error title
+googleDrive.save.error.message,,Drive save default error body (empty)
+googleDrive.load.loading.title,Google Drive,Drive load loading title
+googleDrive.load.loading.message,{name} を読み込み中...,Drive load loading body template
+googleDrive.load.success.title,読込完了,Drive load success title
+googleDrive.load.success.message,{name} を読み込みました,Drive load success body template
+googleDrive.load.error.title,読み込みエラー,Drive load error title
+googleDrive.load.error.message,不明なエラー,Drive load default error body
+googleDrive.load.noSelection.title,読み込みエラー,Drive load no selection title
+googleDrive.load.noSelection.message,ファイルが選択されていません,Drive load no selection body
+googleDrive.load.missingData.title,読み込みエラー,Drive load missing data title
+googleDrive.load.missingData.message,キャラクターデータを取得できませんでした,Drive load missing data body
+googleDrive.overwriteConfirm.title,上書き確認,Drive overwrite confirm title
+googleDrive.overwriteConfirm.message,{name} は既に存在します。上書きしますか？,Drive overwrite confirm body
+googleDrive.overwriteConfirm.buttons.overwrite,上書き,Drive overwrite confirm button label
+googleDrive.overwriteConfirm.buttons.cancel,キャンセル,Drive overwrite confirm cancel label
+googleDrive.apiInitError.title,Google API エラー,Drive API init error title
+googleDrive.apiInitError.message,初期化に失敗しました,Drive API init error body
+googleDrive.initPending.title,Google Drive,Drive init pending title
+googleDrive.initPending.message,初期化が完了するまでお待ちください,Drive init pending body
+googleDrive.config.loadError.title,設定読み込み失敗,Drive config load error title
+googleDrive.config.loadError.message,保存先フォルダの取得に失敗しました,Drive config load error body
+googleDrive.config.requiresSignIn.title,Google Drive,Drive config requires sign in title
+googleDrive.config.requiresSignIn.message,Googleにサインインしてください,Drive config requires sign in body
+googleDrive.config.updateSuccess.title,設定更新,Drive config update success title
+googleDrive.config.updateSuccess.message,保存先フォルダを更新しました,Drive config update success body
+googleDrive.config.updateError.title,設定更新失敗,Drive config update error title
+googleDrive.config.updateError.message,保存先フォルダの更新に失敗しました,Drive config update error body
+share.needSignIn.title,Google Drive,Share sign-in needed title
+share.needSignIn.message,サインインしてください,Share sign-in needed body
+share.toast.creating.title,共有リンク,Share creating toast title
+share.toast.creating.message,作成中...,Share creating toast body
+share.toast.success.title,共有リンク,Share success toast title
+share.toast.success.message,URLをコピーしました,Share success toast body
+share.toast.error.title,共有リンク,Share error toast title
+share.toast.error.message,共有リンクの生成に失敗しました,Share error toast default body
+share.toast.clipboardUnavailable.title,共有リンク,Share clipboard unavailable toast title
+share.toast.clipboardUnavailable.message,クリップボードにアクセスできません,Share clipboard unavailable toast body
+share.errors.saveFailed,Google Drive への保存に失敗しました,Share save failed error
+share.errors.shareFailed,共有リンクの取得に失敗しました,Share retrieval failed error
+share.errors.managerMissing,Google Drive マネージャーが設定されていません,Share manager missing error
+share.loadError.title,共有データエラー,Share load error title
+share.loadError.message.general,共有データの読み込みに失敗しました,Share load error general message
+share.loadError.message.fetchFailed,共有データの取得に失敗しました,Share load error fetch failed message
+share.loadError.message.parseFailed,共有データの解析に失敗しした,Share load error parse failed message
+characterHub.driveFolder.changeButton,選択,Character hub folder change button
+characterHub.driveFolder.label,保存先フォルダ,Character hub folder label
+characterHub.driveFolder.placeholder,慈悲なきアイオニア,Character hub folder placeholder
+characterHub.buttons.signIn,ログイン／Driveから読み込む,Character hub sign in button
+image.loadError.title,画像読み込み失敗,Image load error title
+image.loadError.message,{message},Image load error body template
+image.uploadErrors.noFile,画像ファイルが選択されていません。,Image upload no file error
+image.uploadErrors.unsupportedType,対応していない画像形式です。JPEG、PNG、GIF、WebP、SVG を指定してください。,Image upload unsupported type error
+image.uploadErrors.tooLarge,ファイルサイズが大きすぎます（最大10MB）。,Image upload too large error
+image.uploadErrors.readError,画像の読み込み中にエラーが発生しました。,Image upload read error
+dataExport.loadError.title,読み込み失敗,Data export load error title
+dataExport.loadError.message,{message},Data export load error body template
+file.loadError,ファイルの読み込みに失敗しました。JSON形式が正しくない可能性があります。,File load error
+file.unsupportedFormat,対応していないファイル形式です。AioniaCSで保存したデータをご利用ください。,File unsupported format error
+ui.header.defaultTitle,Aionia TRPG Character Sheet,Header default title
+ui.header.helpLabel,?,Header help label
+ui.header.newCharacter,新規,Header new character label
+ui.header.signIn,ログイン,Header sign in label
+ui.header.signOut,ログアウト,Header sign out label
+ui.footer.experience,経験点,Footer experience label
+ui.footer.output,出力,Footer output label
+ui.footer.share,共有,Footer share label
+ui.footer.copyEdit,自分用にコピーして編集,Footer copy/edit label
+ui.viewModeBanner,閲覧モードで表示中,View mode banner text
+ui.buttons.saveCloudNew,新規保存,UI save to cloud new button
+ui.buttons.saveCloudOverwrite,上書保存,UI save to cloud overwrite button
+ui.buttons.saveCloudTitle,Google Driveに保存,UI save to cloud tooltip
+ui.buttons.loadCloud,Drive読込,UI load from cloud button
+ui.buttons.loadCloudTitle,Google Driveから読込む,UI load from cloud tooltip
+ui.buttons.saveLocal,端末保存,UI save local button
+ui.buttons.saveLocalTitle,端末に保存,UI save local tooltip
+ui.buttons.loadLocal,読込,UI load local button
+ui.buttons.loadLocalTitle,端末から読込む,UI load local tooltip
+ui.buttons.save,保存,UI save button
+ui.confirmations.unsavedChanges.title,保存されていない変更があります,Unsaved changes dialog title
+ui.confirmations.unsavedChanges.message,現在の内容はまだ保存されていません。新規作成すると変更は失われます。続行しますか？,Unsaved changes dialog message
+ui.confirmations.unsavedChanges.buttons.save,保存して続行,Unsaved changes dialog save button
+ui.confirmations.unsavedChanges.buttons.discard,保存せず続行,Unsaved changes dialog discard button
+ui.confirmations.unsavedChanges.buttons.cancel,キャンセル,Unsaved changes dialog cancel button
+ui.modal.load.title,読込,Load modal title
+ui.modal.load.buttons.loadLocal,ローカルから読み込む,Load modal local button
+ui.modal.load.buttons.loadDrive,Driveから読み込む,Load modal drive button
+ui.modal.load.signInMessage,Drive機能を使うにはGoogleにサインインしてください。,Load modal sign-in message
+ui.modal.io.title,入出力,IO modal title
+ui.modal.io.buttons.saveLocal,ローカルファイルで出力,IO modal save local button
+ui.modal.io.buttons.print,印刷,IO modal print button
+ui.modal.io.buttons.chatPalette,チャットパレットを出力,IO modal chat palette button
+ui.modal.io.chatPalette.success.title,チャットパレット,Chat palette success toast title
+ui.modal.io.chatPalette.success.message,クリップボードにコピーしました,Chat palette success toast message
+ui.modal.io.chatPalette.error.title,チャットパレット,Chat palette error toast title
+ui.modal.io.chatPalette.error.message,コピーに失敗しました,Chat palette error toast message
+ui.modal.io.chatPalette.clipboardUnavailable,クリップボード機能が利用できません,Chat palette clipboard unavailable text
+sheet.loadIndicator.label,荷重,Load indicator label
+sheet.toggles.showDescription,説明を表示,Toggle show description label
+sheet.images.alt,キャラクター画像,Sheet image alt text
+sheet.images.previous,前の画像,Sheet image previous button
+sheet.images.next,次の画像,Sheet image next button
+sheet.images.add,画像を追加,Sheet image add button
+sheet.images.delete,削除,Sheet image delete button
+sheet.images.deleteAria,現在の画像を削除,Sheet image delete aria label
+sheet.images.empty,画像はありません,Sheet image empty state
+sheet.placeholders.expertSkill,専門技能,Sheet placeholder expert skill
+sheet.placeholders.expertSkillDisabled,専門技能 (技能選択で有効),Sheet placeholder expert skill disabled
+sheet.placeholders.specialSkillNote,詳細,Sheet placeholder special skill note
+sheet.placeholders.characterMemo,キャラクター背景、設定、その他メモを記入,Sheet placeholder character memo
+sheet.placeholders.weaponName,装備名,Sheet placeholder weapon name
+sheet.placeholders.armorName,装備名,Sheet placeholder armor name
+sheet.placeholders.adventureMemo,メモ,Sheet placeholder adventure memo
+sheet.aria.deleteItem,項目を削除,Sheet aria delete item
+sheet.aria.removeExpert,専門技能を削除,Sheet aria remove expert
+sheet.aria.addExpert,専門技能を追加,Sheet aria add expert
+sheet.aria.removeSpecialSkill,特技を削除,Sheet aria remove special skill
+sheet.aria.addSpecialSkill,特技を追加,Sheet aria add special skill
+sheet.aria.addAdventureLog,冒険記録を追加,Sheet aria add adventure log
+sheet.sections.basicInfo.title,基本情報,Sheet basic info section title
+sheet.sections.basicInfo.fields.name,キャラクター名,Sheet basic info field name
+sheet.sections.basicInfo.fields.playerName,プレイヤー名,Sheet basic info field playerName
+sheet.sections.basicInfo.fields.species,種族,Sheet basic info field species
+sheet.sections.basicInfo.fields.rareSpecies,種族名,Sheet basic info field rare species
+sheet.sections.basicInfo.fields.gender,性別,Sheet basic info field gender
+sheet.sections.basicInfo.fields.age,年齢,Sheet basic info field age
+sheet.sections.basicInfo.fields.height,身長,Sheet basic info field height
+sheet.sections.basicInfo.fields.weight,体重,Sheet basic info field weight
+sheet.sections.basicInfo.fields.origin,出身地,Sheet basic info field origin
+sheet.sections.basicInfo.fields.occupation,職業,Sheet basic info field occupation
+sheet.sections.basicInfo.fields.faith,信仰,Sheet basic info field faith
+sheet.sections.scar.title,傷痕,Sheet scar section title
+sheet.sections.scar.fields.initial,初期値,Sheet scar initial label
+sheet.sections.scar.fields.current,現在値（初期値+増加分）,Sheet scar current label
+sheet.sections.weakness.title,弱点,Sheet weakness section title
+sheet.sections.weakness.columns.text,弱点,Sheet weakness column text
+sheet.sections.weakness.columns.acquired,獲得,Sheet weakness column acquired
+sheet.sections.skills.title,技能,Sheet skills section title
+sheet.sections.memo.title,キャラクターメモ,Sheet memo section title
+sheet.sections.specialSkills.title,特技,Sheet special skills section title
+sheet.sections.specialSkills.columns.group,種類,Sheet special skills column group
+sheet.sections.specialSkills.columns.name,名称,Sheet special skills column name
+sheet.sections.specialSkills.columns.acquired,獲得,Sheet special skills column acquired
+sheet.sections.items.title,所持品,Sheet items section title
+sheet.sections.items.labels.otherItems,その他所持品,Sheet items other items label
+sheet.sections.items.labels.slots.weapon1,武器1,Sheet items slot weapon1
+sheet.sections.items.labels.slots.weapon2,武器2,Sheet items slot weapon2
+sheet.sections.items.labels.slots.armor,防具,Sheet items slot armor
+sheet.sections.adventureLog.title,冒険の記録,Sheet adventure log section title
+sheet.sections.adventureLog.columns.scenario,シナリオ名,Sheet adventure log column scenario
+sheet.sections.adventureLog.columns.experience,経験点,Sheet adventure log column experience
+sheet.sections.adventureLog.columns.scar,傷痕増加,Sheet adventure log column scar
+outputButton.default,ココフォリア駒出力,Output button default label
+outputButton.success,コピー完了！,Output button success label
+outputButton.error,コピーエラー (fallback),Output button error label
+outputButton.animating,冒険が始まる――,Output button animating label
+weaknessDropdownHelp,（冒険の記録を追加すると選択肢が増えます）,Weakness dropdown help
+specialSkillDropdownHelp,（シナリオ報酬の場合はシナリオ名を選択）,Special skill dropdown help

--- a/src/utils/i18nLoader.js
+++ b/src/utils/i18nLoader.js
@@ -1,0 +1,81 @@
+const interpolate = (template, variables = {}) =>
+  String(template).replace(/\{(\w+)\}/g, (match, varName) => {
+    const value = variables[varName];
+    return value === undefined || value === null ? match : value;
+  });
+
+const splitCsvLine = (line) => {
+  const result = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+    const nextChar = line[i + 1];
+
+    if (char === '"') {
+      if (inQuotes && nextChar === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === ',' && !inQuotes) {
+      result.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  result.push(current);
+  return result.map((value) => value.trim());
+};
+
+const parseCsv = (rawCsv) => {
+  const lines = rawCsv.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  if (lines.length === 0) {
+    return { headers: [], records: {} };
+  }
+
+  const headers = splitCsvLine(lines[0]);
+  const records = lines.slice(1).reduce((acc, line) => {
+    const cells = splitCsvLine(line);
+    if (!cells.length) return acc;
+
+    const record = headers.reduce((row, header, index) => {
+      const cell = cells[index] ?? '';
+      return { ...row, [header]: cell };
+    }, {});
+
+    if (record.key) {
+      acc[record.key] = record;
+    }
+
+    return acc;
+  }, {});
+
+  return { headers, records };
+};
+
+export const createI18nLoader = (rawCsv, locale = 'ja', fallbackLocale = 'ja') => {
+  const { records } = parseCsv(rawCsv);
+
+  const getText = (key, variables) => {
+    const entry = records[key];
+    const template = entry?.[locale] ?? entry?.[fallbackLocale] ?? key;
+    return interpolate(template, variables);
+  };
+
+  const hasKey = (key) => Boolean(records[key]);
+
+  const exportToCsv = () => {
+    const headers = ['key', fallbackLocale, 'comment'];
+    const rows = Object.values(records).map((record) => headers.map((header) => record[header] ?? '').join(','));
+    return [headers.join(','), ...rows].join('\n');
+  };
+
+  return { t: getText, hasKey, exportToCsv };
+};
+
+export { interpolate, parseCsv };

--- a/src/utils/i18nLoader.js
+++ b/src/utils/i18nLoader.js
@@ -71,8 +71,15 @@ export const createI18nLoader = (rawCsv, locale = 'ja', fallbackLocale = 'ja') =
 
   const exportToCsv = () => {
     const headers = ['key', fallbackLocale, 'comment'];
-    const rows = Object.values(records).map((record) => headers.map((header) => record[header] ?? '').join(','));
-    return [headers.join(','), ...rows].join('\n');
+    const escape = (val) => {
+      const str = String(val ?? '');
+      if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+        return `"${str.replace(/"/g, '""')}"`;
+      }
+      return str;
+    };
+    const rows = Object.values(records).map((record) => headers.map((header) => escape(record[header])).join(','));
+    return [headers.map(escape).join(','), ...rows].join('\n');
   };
 
   return { t: getText, hasKey, exportToCsv };

--- a/tests/unit/localesJa.test.js
+++ b/tests/unit/localesJa.test.js
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import messagesCsv from '../../src/locales/messages.csv?raw';
+import { createI18nLoader } from '../../src/utils/i18nLoader.js';
+import { messages } from '../../src/locales/ja.js';
+
+describe('i18n CSV loader', () => {
+  const loader = createI18nLoader(messagesCsv);
+
+  it('retrieves plain text values', () => {
+    expect(loader.t('errors.unexpected')).toBe('予期せぬエラーが発生しました');
+  });
+
+  it('supports variable interpolation', () => {
+    expect(loader.t('googleDrive.load.success.message', { name: 'テスト' })).toBe('テスト を読み込みました');
+  });
+
+  it('falls back to key when missing', () => {
+    expect(loader.t('missing.key.example')).toBe('missing.key.example');
+  });
+});
+
+describe('ja locale messages structure', () => {
+  it('keeps overwrite confirmation configuration', () => {
+    expect(messages.googleDrive.overwriteConfirm('テスト')).toEqual({
+      title: '上書き確認',
+      message: 'テスト は既に存在します。上書きしますか？',
+      buttons: [
+        { label: '上書き', value: 'overwrite', variant: 'primary' },
+        { label: 'キャンセル', value: 'cancel', variant: 'secondary', duration: 1 },
+      ],
+    });
+  });
+
+  it('returns load success copy with injected name', () => {
+    expect(messages.googleDrive.load.success('英雄')).toEqual({
+      title: '読込完了',
+      message: '英雄 を読み込みました',
+    });
+  });
+
+  it('preserves static button labels', () => {
+    expect(messages.ui.buttons).toMatchObject({
+      saveCloudNew: '新規保存',
+      saveCloudOverwrite: '上書保存',
+      saveLocal: '端末保存',
+      loadLocal: '読込',
+      save: '保存',
+    });
+  });
+
+  it('keeps share load error mapping intact', () => {
+    expect(messages.share.loadError.toast('fetchFailed')).toEqual({
+      title: '共有データエラー',
+      message: '共有データの取得に失敗しました',
+    });
+    expect(messages.share.loadError.toast('unknown')).toEqual({
+      title: '共有データエラー',
+      message: '共有データの読み込みに失敗しました',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extract all Japanese UI copy into `src/locales/messages.csv` with dot-delimited keys and placeholder support
- update `src/locales/ja.js` to build the locale object from CSV via a lightweight loader while keeping the existing structure intact
- add a reusable CSV-based i18n loader utility and regression tests covering interpolation and message shapes

## Testing
- npm run lint (warnings only)
- npm test *(fails: tests/unit/functions/authApi.test.js missing `hono` import)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b84fdcf7c8326b85cb180476ee7b8)