### PR TITLE
Make character image display flexible

### DIFF
--- a/src/features/character-sheet/components/sections/CharacterBasicInfo.vue
+++ b/src/features/character-sheet/components/sections/CharacterBasicInfo.vue
@@ -80,4 +80,18 @@ const handleSpeciesChange = () => {
 };
 </script>
 
-<style scoped></style>
+<style scoped>
+@media (min-width: 769px) {
+  .character-info {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .character-info .box-content {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    height: 100%;
+  }
+}
+</style>

--- a/src/features/character-sheet/components/ui/CharacterImageDisplay.vue
+++ b/src/features/character-sheet/components/ui/CharacterImageDisplay.vue
@@ -156,7 +156,8 @@ const handleImageUpload = async (event) => {
   justify-content: center;
   margin-bottom: 0;
   width: 100%;
-  height: 350px;
+  min-height: 300px;
+  flex: 1;
   background-color: var(--color-background);
   border: 1px solid var(--color-border-normal);
   border-radius: 2px;
@@ -286,5 +287,13 @@ const handleImageUpload = async (event) => {
   border-color: var(--color-border-normal);
   box-shadow: none;
   text-shadow: none;
+}
+
+@media (min-width: 769px) {
+  .character-image-container {
+    flex: 1;
+    height: 100%;
+    width: 100%;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- let the character info section use flex to stretch its content with the grid row on desktop layouts
- allow the character image display area to grow with available height while keeping a 300px minimum

## Testing
- npm run lint (warnings only)
- npm test (fails: tests/unit/functions/authApi.test.js missing hono import)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b913d46bc8326a59d0abd80b5accc)