### PR TITLE
Add sub memo management to character memos

### DIFF
--- a/src/contents/ui_messages.csv
+++ b/src/contents/ui_messages.csv
@@ -155,6 +155,19 @@ sheet.sections.weakness.columns.text,弱点,,Sheet weakness column text
 sheet.sections.weakness.columns.acquired,獲得,,Sheet weakness column acquired
 sheet.sections.skills.title,技能,,Sheet skills section title
 sheet.sections.memo.title,キャラクターメモ,,Sheet memo section title
+sheet.sections.memo.subMemo.titlePlaceholder,サブメモタイトル,,Sub memo title placeholder
+sheet.sections.memo.subMemo.contentPlaceholder,サブメモ内容,,Sub memo content placeholder
+sheet.sections.memo.subMemo.spoilerLabel,ネタバレ,,Sub memo spoiler toggle label
+sheet.sections.memo.subMemo.spoilerNotice,※ネタバレを含む内容です,,Sub memo spoiler guard notice
+sheet.sections.memo.subMemo.readButton,読む,,Sub memo reveal button label
+sheet.sections.memo.subMemo.addButton,サブメモを追加,,Sub memo add button label
+sheet.sections.memo.subMemo.deleteLabel,削除,,Sub memo delete button label
+sheet.sections.memo.subMemo.toggle.expand,表示,,Sub memo expand label
+sheet.sections.memo.subMemo.toggle.collapse,折りたたむ,,Sub memo collapse label
+sheet.sections.memo.subMemo.deleteConfirm.title,サブメモの削除,,Sub memo delete confirm title
+sheet.sections.memo.subMemo.deleteConfirm.message,このサブメモを削除しますか？,,Sub memo delete confirm message
+sheet.sections.memo.subMemo.deleteConfirm.delete,削除,,Sub memo delete confirm delete
+sheet.sections.memo.subMemo.deleteConfirm.cancel,キャンセル,,Sub memo delete confirm cancel
 sheet.sections.specialSkills.title,特技,,Sheet special skills section title
 sheet.sections.specialSkills.columns.group,種類,,Sheet special skills column group
 sheet.sections.specialSkills.columns.name,名称,,Sheet special skills column name

--- a/src/features/character-sheet/components/sections/CharacterMemoSection.vue
+++ b/src/features/character-sheet/components/sections/CharacterMemoSection.vue
@@ -56,20 +56,20 @@ const localValue = computed({
   },
 });
 const subMemos = computed(() => characterStore.character.subMemos || []);
-const collapsedIds = ref(new Set());
+const expandedIds = ref(new Set());
 const revealedIds = ref(new Set());
 
 function loadUiState() {
   try {
     const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
-    if (!raw) return { collapsed: new Set(), revealed: new Set() };
+    if (!raw) return { expanded: new Set(), revealed: new Set() };
     const parsed = JSON.parse(raw);
     return {
-      collapsed: new Set(parsed?.collapsedIds || []),
+      expanded: new Set(parsed?.expandedIds || []),
       revealed: new Set(parsed?.revealedIds || []),
     };
   } catch (e) {
-    return { collapsed: new Set(), revealed: new Set() };
+    return { expanded: new Set(), revealed: new Set() };
   }
 }
 
@@ -77,7 +77,7 @@ function persistUiState() {
   try {
     localStorage.setItem(
       LOCAL_STORAGE_KEY,
-      JSON.stringify({ collapsedIds: [...collapsedIds.value], revealedIds: [...revealedIds.value] }),
+      JSON.stringify({ expandedIds: [...expandedIds.value], revealedIds: [...revealedIds.value] }),
     );
   } catch (e) {
     // do nothing when storage is unavailable
@@ -86,36 +86,33 @@ function persistUiState() {
 
 function syncUiStateWithSubMemos(list) {
   const ids = new Set(list.map((memo) => memo.id));
-  const nextCollapsed = new Set([...collapsedIds.value].filter((id) => ids.has(id)));
+  const nextExpanded = new Set([...expandedIds.value].filter((id) => ids.has(id)));
   const nextRevealed = new Set([...revealedIds.value].filter((id) => ids.has(id)));
 
   list.forEach((memo) => {
-    if (!nextCollapsed.has(memo.id)) {
-      nextCollapsed.add(memo.id);
-    }
     if (!memo.isSpoiler && nextRevealed.has(memo.id)) {
       nextRevealed.delete(memo.id);
     }
   });
 
-  const collapsedChanged =
-    nextCollapsed.size !== collapsedIds.value.size || [...nextCollapsed].some((id) => !collapsedIds.value.has(id));
+  const expandedChanged =
+    nextExpanded.size !== expandedIds.value.size || [...nextExpanded].some((id) => !expandedIds.value.has(id));
   const revealedChanged =
     nextRevealed.size !== revealedIds.value.size || [...nextRevealed].some((id) => !revealedIds.value.has(id));
 
-  if (collapsedChanged) {
-    collapsedIds.value = nextCollapsed;
+  if (expandedChanged) {
+    expandedIds.value = nextExpanded;
   }
   if (revealedChanged) {
     revealedIds.value = nextRevealed;
   }
-  if (collapsedChanged || revealedChanged) {
+  if (expandedChanged || revealedChanged) {
     persistUiState();
   }
 }
 
 const storedUiState = loadUiState();
-collapsedIds.value = storedUiState.collapsed;
+expandedIds.value = storedUiState.expanded;
 revealedIds.value = storedUiState.revealed;
 syncUiStateWithSubMemos(subMemos.value);
 
@@ -128,17 +125,17 @@ watch(
 );
 
 function isCollapsed(id) {
-  return collapsedIds.value.has(id);
+  return !expandedIds.value.has(id);
 }
 
 function toggleCollapse(id) {
-  const next = new Set(collapsedIds.value);
+  const next = new Set(expandedIds.value);
   if (next.has(id)) {
     next.delete(id);
   } else {
     next.add(id);
   }
-  collapsedIds.value = next;
+  expandedIds.value = next;
   persistUiState();
 }
 

--- a/src/features/character-sheet/components/sections/CharacterMemoSection.vue
+++ b/src/features/character-sheet/components/sections/CharacterMemoSection.vue
@@ -10,27 +10,34 @@
         :readonly="uiStore.isViewingShared"
       ></textarea>
     </div>
-    <div class="submemo-list" v-if="subMemos.length">
-      <SubMemoItem
-        v-for="subMemo in subMemos"
-        :key="subMemo.id"
-        :sub-memo="subMemo"
-        :messages="subMemoMessages"
-        :collapsed="isCollapsed(subMemo.id)"
-        :revealed="isRevealed(subMemo)"
-        :readonly="uiStore.isViewingShared"
-        @toggle-collapse="() => toggleCollapse(subMemo.id)"
-        @update-title="(value) => handleUpdateTitle(subMemo.id, value)"
-        @update-content="(value) => handleUpdateContent(subMemo.id, value)"
-        @update-spoiler="(value) => handleUpdateSpoiler(subMemo.id, value)"
-        @reveal="() => revealSubMemo(subMemo.id)"
-        @request-remove="() => confirmRemoval(subMemo.id)"
-      />
-    </div>
-    <div class="submemo-actions">
-      <button class="button-base" type="button" :disabled="uiStore.isViewingShared" @click="handleAddSubMemo">
-        {{ subMemoMessages.addButton }}
-      </button>
+    <div class="box-content submemo-container">
+      <div class="submemo-list" v-if="subMemos.length">
+        <SubMemoItem
+          v-for="subMemo in subMemos"
+          :key="subMemo.id"
+          :sub-memo="subMemo"
+          :messages="subMemoMessages"
+          :collapsed="isCollapsed(subMemo.id)"
+          :revealed="isRevealed(subMemo)"
+          :readonly="uiStore.isViewingShared"
+          @toggle-collapse="() => toggleCollapse(subMemo.id)"
+          @update-title="(value) => handleUpdateTitle(subMemo.id, value)"
+          @update-content="(value) => handleUpdateContent(subMemo.id, value)"
+          @update-spoiler="(value) => handleUpdateSpoiler(subMemo.id, value)"
+          @reveal="() => revealSubMemo(subMemo.id)"
+          @request-remove="() => confirmRemoval(subMemo.id)"
+        />
+      </div>
+      <div class="add-button-container-left" v-if="!uiStore.isViewingShared">
+        <button
+          class="button-base list-button list-button--add"
+          type="button"
+          :aria-label="subMemoMessages.addButton"
+          @click="handleAddSubMemo"
+        >
+          ＋
+        </button>
+      </div>
     </div>
   </div>
 </template>
@@ -193,21 +200,13 @@ async function confirmRemoval(id) {
   resize: vertical;
 }
 
-.submemo-actions {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 8px;
+.submemo-container {
+  margin-top: 16px;
 }
 
 .submemo-list {
-  margin-top: 16px;
   display: flex;
   flex-direction: column;
   gap: 12px;
-}
-
-.button-base:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
 }
 </style>

--- a/src/features/character-sheet/components/sections/CharacterMemoSection.vue
+++ b/src/features/character-sheet/components/sections/CharacterMemoSection.vue
@@ -9,34 +9,34 @@
         v-model.lazy="localValue"
         :readonly="uiStore.isViewingShared"
       ></textarea>
-    </div>
-    <div class="box-content submemo-container">
-      <div class="submemo-list" v-if="subMemos.length">
-        <SubMemoItem
-          v-for="subMemo in subMemos"
-          :key="subMemo.id"
-          :sub-memo="subMemo"
-          :messages="subMemoMessages"
-          :collapsed="isCollapsed(subMemo.id)"
-          :revealed="isRevealed(subMemo)"
-          :readonly="uiStore.isViewingShared"
-          @toggle-collapse="() => toggleCollapse(subMemo.id)"
-          @update-title="(value) => handleUpdateTitle(subMemo.id, value)"
-          @update-content="(value) => handleUpdateContent(subMemo.id, value)"
-          @update-spoiler="(value) => handleUpdateSpoiler(subMemo.id, value)"
-          @reveal="() => revealSubMemo(subMemo.id)"
-          @request-remove="() => confirmRemoval(subMemo.id)"
-        />
-      </div>
-      <div class="add-button-container-left" v-if="!uiStore.isViewingShared">
-        <button
-          class="button-base list-button list-button--add"
-          type="button"
-          :aria-label="subMemoMessages.addButton"
-          @click="handleAddSubMemo"
-        >
-          ＋
-        </button>
+      <div class="submemo-section">
+        <div class="submemo-list" v-if="subMemos.length">
+          <SubMemoItem
+            v-for="subMemo in subMemos"
+            :key="subMemo.id"
+            :sub-memo="subMemo"
+            :messages="subMemoMessages"
+            :collapsed="isCollapsed(subMemo.id)"
+            :revealed="isRevealed(subMemo)"
+            :readonly="uiStore.isViewingShared"
+            @toggle-collapse="() => toggleCollapse(subMemo.id)"
+            @update-title="(value) => handleUpdateTitle(subMemo.id, value)"
+            @update-content="(value) => handleUpdateContent(subMemo.id, value)"
+            @update-spoiler="(value) => handleUpdateSpoiler(subMemo.id, value)"
+            @reveal="() => revealSubMemo(subMemo.id)"
+            @request-remove="() => confirmRemoval(subMemo.id)"
+          />
+        </div>
+        <div class="add-button-container-left" v-if="!uiStore.isViewingShared">
+          <button
+            class="button-base list-button list-button--add"
+            type="button"
+            :aria-label="subMemoMessages.addButton"
+            @click="handleAddSubMemo"
+          >
+            ＋
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -200,7 +200,7 @@ async function confirmRemoval(id) {
   resize: vertical;
 }
 
-.submemo-container {
+.submemo-section {
   margin-top: 16px;
 }
 

--- a/src/features/character-sheet/components/sections/CharacterMemoSection.vue
+++ b/src/features/character-sheet/components/sections/CharacterMemoSection.vue
@@ -36,7 +36,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useCharacterStore } from '@/features/character-sheet/stores/characterStore.js';
 import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
 import { messages } from '@/i18n/index.js';
@@ -114,12 +114,10 @@ function syncUiStateWithSubMemos(list) {
   }
 }
 
-onMounted(() => {
-  const stored = loadUiState();
-  collapsedIds.value = stored.collapsed;
-  revealedIds.value = stored.revealed;
-  syncUiStateWithSubMemos(subMemos.value);
-});
+const storedUiState = loadUiState();
+collapsedIds.value = storedUiState.collapsed;
+revealedIds.value = storedUiState.revealed;
+syncUiStateWithSubMemos(subMemos.value);
 
 watch(
   () => subMemos.value.map((memo) => `${memo.id}:${memo.isSpoiler}`),

--- a/src/features/character-sheet/components/sections/CharacterMemoSection.vue
+++ b/src/features/character-sheet/components/sections/CharacterMemoSection.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="character_memo" class="character-memo">
     <div class="box-title">{{ sheetMessages.sections.memo.title }}</div>
-    <div class="box-content">
+    <div class="box-content memo-layout-container">
       <textarea
         id="character_text"
         class="character-memo-textarea"
@@ -9,34 +9,32 @@
         v-model.lazy="localValue"
         :readonly="uiStore.isViewingShared"
       ></textarea>
-      <div class="submemo-section">
-        <div class="submemo-list" v-if="subMemos.length">
-          <SubMemoItem
-            v-for="subMemo in subMemos"
-            :key="subMemo.id"
-            :sub-memo="subMemo"
-            :messages="subMemoMessages"
-            :collapsed="isCollapsed(subMemo.id)"
-            :revealed="isRevealed(subMemo)"
-            :readonly="uiStore.isViewingShared"
-            @toggle-collapse="() => toggleCollapse(subMemo.id)"
-            @update-title="(value) => handleUpdateTitle(subMemo.id, value)"
-            @update-content="(value) => handleUpdateContent(subMemo.id, value)"
-            @update-spoiler="(value) => handleUpdateSpoiler(subMemo.id, value)"
-            @reveal="() => revealSubMemo(subMemo.id)"
-            @request-remove="() => confirmRemoval(subMemo.id)"
-          />
-        </div>
-        <div class="add-button-container-left" v-if="!uiStore.isViewingShared">
-          <button
-            class="button-base list-button list-button--add"
-            type="button"
-            :aria-label="subMemoMessages.addButton"
-            @click="handleAddSubMemo"
-          >
-            ＋
-          </button>
-        </div>
+      <div class="submemo-list" v-if="subMemos.length">
+        <SubMemoItem
+          v-for="subMemo in subMemos"
+          :key="subMemo.id"
+          :sub-memo="subMemo"
+          :messages="subMemoMessages"
+          :collapsed="isCollapsed(subMemo.id)"
+          :revealed="isRevealed(subMemo)"
+          :readonly="uiStore.isViewingShared"
+          @toggle-collapse="() => toggleCollapse(subMemo.id)"
+          @update-title="(value) => handleUpdateTitle(subMemo.id, value)"
+          @update-content="(value) => handleUpdateContent(subMemo.id, value)"
+          @update-spoiler="(value) => handleUpdateSpoiler(subMemo.id, value)"
+          @reveal="() => revealSubMemo(subMemo.id)"
+          @request-remove="() => confirmRemoval(subMemo.id)"
+        />
+      </div>
+      <div class="add-button-row" v-if="!uiStore.isViewingShared">
+        <button
+          class="button-base list-button list-button--add"
+          type="button"
+          :aria-label="subMemoMessages.addButton"
+          @click="handleAddSubMemo"
+        >
+          ＋
+        </button>
       </div>
     </div>
   </div>
@@ -200,13 +198,19 @@ async function confirmRemoval(id) {
   resize: vertical;
 }
 
-.submemo-section {
-  margin-top: 16px;
+.memo-layout-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .submemo-list {
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.add-button-row {
+  display: flex;
 }
 </style>

--- a/src/features/character-sheet/components/sections/CharacterMemoSection.vue
+++ b/src/features/character-sheet/components/sections/CharacterMemoSection.vue
@@ -10,24 +10,215 @@
         :readonly="uiStore.isViewingShared"
       ></textarea>
     </div>
+    <div class="submemo-list" v-if="subMemos.length">
+      <SubMemoItem
+        v-for="subMemo in subMemos"
+        :key="subMemo.id"
+        :sub-memo="subMemo"
+        :messages="subMemoMessages"
+        :collapsed="isCollapsed(subMemo.id)"
+        :revealed="isRevealed(subMemo)"
+        :readonly="uiStore.isViewingShared"
+        @toggle-collapse="() => toggleCollapse(subMemo.id)"
+        @update-title="(value) => handleUpdateTitle(subMemo.id, value)"
+        @update-content="(value) => handleUpdateContent(subMemo.id, value)"
+        @update-spoiler="(value) => handleUpdateSpoiler(subMemo.id, value)"
+        @reveal="() => revealSubMemo(subMemo.id)"
+        @request-remove="() => confirmRemoval(subMemo.id)"
+      />
+    </div>
+    <div class="submemo-actions">
+      <button class="button-base" type="button" :disabled="uiStore.isViewingShared" @click="handleAddSubMemo">
+        {{ subMemoMessages.addButton }}
+      </button>
+    </div>
   </div>
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { useCharacterStore } from '@/features/character-sheet/stores/characterStore.js';
 import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
 import { messages } from '@/i18n/index.js';
+import { useModal } from '@/features/modals/composables/useModal.js';
+import SubMemoItem from './SubMemoItem.vue';
 
 const characterStore = useCharacterStore();
 const uiStore = useUiStore();
+const { showModal } = useModal();
 const sheetMessages = messages.sheet;
+const subMemoMessages = sheetMessages.sections.memo.subMemo;
+const LOCAL_STORAGE_KEY = 'aioniacs_ui_submemos_state';
 const localValue = computed({
   get: () => characterStore.character.memo,
   set: (val) => {
     characterStore.character.memo = val;
   },
 });
+const subMemos = computed(() => characterStore.character.subMemos || []);
+const collapsedIds = ref(new Set());
+const revealedIds = ref(new Set());
+
+function loadUiState() {
+  try {
+    const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (!raw) return { collapsed: new Set(), revealed: new Set() };
+    const parsed = JSON.parse(raw);
+    return {
+      collapsed: new Set(parsed?.collapsedIds || []),
+      revealed: new Set(parsed?.revealedIds || []),
+    };
+  } catch (e) {
+    return { collapsed: new Set(), revealed: new Set() };
+  }
+}
+
+function persistUiState() {
+  try {
+    localStorage.setItem(
+      LOCAL_STORAGE_KEY,
+      JSON.stringify({ collapsedIds: [...collapsedIds.value], revealedIds: [...revealedIds.value] }),
+    );
+  } catch (e) {
+    // do nothing when storage is unavailable
+  }
+}
+
+function syncUiStateWithSubMemos(list) {
+  const ids = new Set(list.map((memo) => memo.id));
+  const nextCollapsed = new Set([...collapsedIds.value].filter((id) => ids.has(id)));
+  const nextRevealed = new Set([...revealedIds.value].filter((id) => ids.has(id)));
+
+  list.forEach((memo) => {
+    if (!nextCollapsed.has(memo.id)) {
+      nextCollapsed.add(memo.id);
+    }
+    if (!memo.isSpoiler && nextRevealed.has(memo.id)) {
+      nextRevealed.delete(memo.id);
+    }
+  });
+
+  const collapsedChanged =
+    nextCollapsed.size !== collapsedIds.value.size || [...nextCollapsed].some((id) => !collapsedIds.value.has(id));
+  const revealedChanged =
+    nextRevealed.size !== revealedIds.value.size || [...nextRevealed].some((id) => !revealedIds.value.has(id));
+
+  if (collapsedChanged) {
+    collapsedIds.value = nextCollapsed;
+  }
+  if (revealedChanged) {
+    revealedIds.value = nextRevealed;
+  }
+  if (collapsedChanged || revealedChanged) {
+    persistUiState();
+  }
+}
+
+onMounted(() => {
+  const stored = loadUiState();
+  collapsedIds.value = stored.collapsed;
+  revealedIds.value = stored.revealed;
+  syncUiStateWithSubMemos(subMemos.value);
+});
+
+watch(
+  () => subMemos.value.map((memo) => memo.id),
+  () => {
+    syncUiStateWithSubMemos(subMemos.value);
+  },
+  { immediate: true },
+);
+
+watch(
+  () => subMemos.value.map((memo) => `${memo.id}:${memo.isSpoiler}`),
+  () => {
+    const updatedRevealed = new Set(revealedIds.value);
+    let changed = false;
+    subMemos.value.forEach((memo) => {
+      if (!memo.isSpoiler && updatedRevealed.has(memo.id)) {
+        updatedRevealed.delete(memo.id);
+        changed = true;
+      }
+    });
+    if (changed) {
+      revealedIds.value = updatedRevealed;
+      persistUiState();
+    }
+  },
+);
+
+function isCollapsed(id) {
+  return collapsedIds.value.has(id);
+}
+
+function toggleCollapse(id) {
+  const next = new Set(collapsedIds.value);
+  if (next.has(id)) {
+    next.delete(id);
+  } else {
+    next.add(id);
+  }
+  collapsedIds.value = next;
+  persistUiState();
+}
+
+function isRevealed(subMemo) {
+  return revealedIds.value.has(subMemo.id) || !subMemo.isSpoiler;
+}
+
+function revealSubMemo(id) {
+  if (revealedIds.value.has(id)) return;
+  const next = new Set(revealedIds.value);
+  next.add(id);
+  revealedIds.value = next;
+  persistUiState();
+}
+
+function handleAddSubMemo() {
+  const newMemo = characterStore.addSubMemo();
+  collapsedIds.value = new Set([...collapsedIds.value, newMemo.id]);
+  revealedIds.value = new Set([...revealedIds.value].filter((id) => id !== newMemo.id));
+  persistUiState();
+}
+
+function handleUpdateTitle(id, value) {
+  characterStore.updateSubMemo(id, { title: value });
+}
+
+function handleUpdateContent(id, value) {
+  characterStore.updateSubMemo(id, { content: value });
+}
+
+function handleUpdateSpoiler(id, value) {
+  characterStore.updateSubMemo(id, { isSpoiler: value });
+  if (!value && revealedIds.value.has(id)) {
+    const next = new Set(revealedIds.value);
+    next.delete(id);
+    revealedIds.value = next;
+    persistUiState();
+  }
+}
+
+async function confirmRemoval(id) {
+  const result = await showModal({
+    title: subMemoMessages.deleteConfirm.title,
+    message: subMemoMessages.deleteConfirm.message,
+    buttons: [
+      { label: subMemoMessages.deleteConfirm.delete, value: 'delete', variant: 'primary' },
+      { label: subMemoMessages.deleteConfirm.cancel, value: 'cancel', variant: 'secondary' },
+    ],
+  });
+  if (result?.value === 'delete') {
+    characterStore.removeSubMemo(id);
+    const nextCollapsed = new Set(collapsedIds.value);
+    const nextRevealed = new Set(revealedIds.value);
+    nextCollapsed.delete(id);
+    nextRevealed.delete(id);
+    collapsedIds.value = nextCollapsed;
+    revealedIds.value = nextRevealed;
+    persistUiState();
+  }
+}
 </script>
 
 <style scoped>
@@ -39,5 +230,23 @@ const localValue = computed({
   width: 100%;
   min-height: 180px;
   resize: vertical;
+}
+
+.submemo-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+.submemo-list {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.button-base:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 </style>

--- a/src/features/character-sheet/components/sections/CharacterMemoSection.vue
+++ b/src/features/character-sheet/components/sections/CharacterMemoSection.vue
@@ -6,7 +6,7 @@
         id="character_text"
         class="character-memo-textarea"
         :placeholder="sheetMessages.placeholders.characterMemo"
-        v-model="localValue"
+        v-model.lazy="localValue"
         :readonly="uiStore.isViewingShared"
       ></textarea>
     </div>

--- a/src/features/character-sheet/components/sections/CharacterMemoSection.vue
+++ b/src/features/character-sheet/components/sections/CharacterMemoSection.vue
@@ -122,29 +122,11 @@ onMounted(() => {
 });
 
 watch(
-  () => subMemos.value.map((memo) => memo.id),
+  () => subMemos.value.map((memo) => `${memo.id}:${memo.isSpoiler}`),
   () => {
     syncUiStateWithSubMemos(subMemos.value);
   },
   { immediate: true },
-);
-
-watch(
-  () => subMemos.value.map((memo) => `${memo.id}:${memo.isSpoiler}`),
-  () => {
-    const updatedRevealed = new Set(revealedIds.value);
-    let changed = false;
-    subMemos.value.forEach((memo) => {
-      if (!memo.isSpoiler && updatedRevealed.has(memo.id)) {
-        updatedRevealed.delete(memo.id);
-        changed = true;
-      }
-    });
-    if (changed) {
-      revealedIds.value = updatedRevealed;
-      persistUiState();
-    }
-  },
 );
 
 function isCollapsed(id) {
@@ -175,10 +157,7 @@ function revealSubMemo(id) {
 }
 
 function handleAddSubMemo() {
-  const newMemo = characterStore.addSubMemo();
-  collapsedIds.value = new Set([...collapsedIds.value, newMemo.id]);
-  revealedIds.value = new Set([...revealedIds.value].filter((id) => id !== newMemo.id));
-  persistUiState();
+  characterStore.addSubMemo();
 }
 
 function handleUpdateTitle(id, value) {
@@ -191,12 +170,6 @@ function handleUpdateContent(id, value) {
 
 function handleUpdateSpoiler(id, value) {
   characterStore.updateSubMemo(id, { isSpoiler: value });
-  if (!value && revealedIds.value.has(id)) {
-    const next = new Set(revealedIds.value);
-    next.delete(id);
-    revealedIds.value = next;
-    persistUiState();
-  }
 }
 
 async function confirmRemoval(id) {
@@ -210,13 +183,6 @@ async function confirmRemoval(id) {
   });
   if (result?.value === 'delete') {
     characterStore.removeSubMemo(id);
-    const nextCollapsed = new Set(collapsedIds.value);
-    const nextRevealed = new Set(revealedIds.value);
-    nextCollapsed.delete(id);
-    nextRevealed.delete(id);
-    collapsedIds.value = nextCollapsed;
-    revealedIds.value = nextRevealed;
-    persistUiState();
   }
 }
 </script>

--- a/src/features/character-sheet/components/sections/SubMemoItem.vue
+++ b/src/features/character-sheet/components/sections/SubMemoItem.vue
@@ -38,7 +38,7 @@
       </button>
     </div>
     <Transition name="fade">
-      <div v-show="!collapsed" class="submemo-body box-content">
+      <div v-show="!collapsed" class="submemo-body">
         <div v-if="showGuard" class="submemo-guard">
           <p>{{ messages.spoilerNotice }}</p>
           <button class="button-base" type="button" @click="$emit('reveal')">{{ messages.readButton }}</button>

--- a/src/features/character-sheet/components/sections/SubMemoItem.vue
+++ b/src/features/character-sheet/components/sections/SubMemoItem.vue
@@ -1,8 +1,14 @@
 <template>
   <div class="submemo-item">
     <div class="submemo-header sub-box-title">
-      <button class="button-base submemo-toggle" type="button" @click="$emit('toggle-collapse')">
-        <span>{{ collapsed ? messages.toggle.expand : messages.toggle.collapse }}</span>
+      <button
+        class="submemo-toggle"
+        type="button"
+        :aria-label="collapsed ? messages.toggle.expand : messages.toggle.collapse"
+        @click="$emit('toggle-collapse')"
+      >
+        <span aria-hidden="true">{{ collapsed ? '▶' : '▼' }}</span>
+        <span class="sr-only">{{ collapsed ? messages.toggle.expand : messages.toggle.collapse }}</span>
       </button>
       <input
         class="submemo-title"
@@ -21,8 +27,14 @@
         />
         <span>{{ messages.spoilerLabel }}</span>
       </label>
-      <button class="button-base submemo-delete" type="button" :disabled="readonly" @click="$emit('request-remove')">
-        {{ messages.deleteLabel }}
+      <button
+        class="button-base list-button list-button--remove submemo-delete"
+        type="button"
+        :disabled="readonly"
+        :aria-label="messages.deleteLabel"
+        @click="$emit('request-remove')"
+      >
+        －
       </button>
     </div>
     <Transition name="fade">
@@ -88,7 +100,16 @@ const showGuard = computed(() => props.subMemo.isSpoiler && !props.revealed);
 }
 
 .submemo-toggle {
-  min-width: 90px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-main);
+  font-size: 1rem;
+  cursor: pointer;
 }
 
 .submemo-title {
@@ -130,6 +151,18 @@ const showGuard = computed(() => props.subMemo.isSpoiler && !props.revealed);
   flex-direction: column;
   gap: 12px;
   align-items: flex-start;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .fade-enter-active,

--- a/src/features/character-sheet/components/sections/SubMemoItem.vue
+++ b/src/features/character-sheet/components/sections/SubMemoItem.vue
@@ -1,0 +1,144 @@
+<template>
+  <div class="submemo-item">
+    <div class="submemo-header sub-box-title">
+      <button class="button-base submemo-toggle" type="button" @click="$emit('toggle-collapse')">
+        <span>{{ collapsed ? messages.toggle.expand : messages.toggle.collapse }}</span>
+      </button>
+      <input
+        class="submemo-title"
+        type="text"
+        :value="subMemo.title"
+        :placeholder="messages.titlePlaceholder"
+        :readonly="readonly"
+        @input="$emit('update-title', $event.target.value)"
+      />
+      <label class="submemo-spoiler">
+        <input
+          type="checkbox"
+          :checked="subMemo.isSpoiler"
+          :disabled="readonly"
+          @change="$emit('update-spoiler', $event.target.checked)"
+        />
+        <span>{{ messages.spoilerLabel }}</span>
+      </label>
+      <button class="button-base submemo-delete" type="button" :disabled="readonly" @click="$emit('request-remove')">
+        {{ messages.deleteLabel }}
+      </button>
+    </div>
+    <Transition name="fade">
+      <div v-show="!collapsed" class="submemo-body box-content">
+        <div v-if="showGuard" class="submemo-guard">
+          <p>{{ messages.spoilerNotice }}</p>
+          <button class="button-base" type="button" @click="$emit('reveal')">{{ messages.readButton }}</button>
+        </div>
+        <textarea
+          v-else
+          class="submemo-textarea"
+          :placeholder="messages.contentPlaceholder"
+          :value="subMemo.content"
+          :readonly="readonly"
+          @input="$emit('update-content', $event.target.value)"
+        ></textarea>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  subMemo: {
+    type: Object,
+    required: true,
+  },
+  messages: {
+    type: Object,
+    required: true,
+  },
+  collapsed: {
+    type: Boolean,
+    default: false,
+  },
+  revealed: {
+    type: Boolean,
+    default: false,
+  },
+  readonly: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const showGuard = computed(() => props.subMemo.isSpoiler && !props.revealed);
+</script>
+
+<style scoped>
+.submemo-item {
+  border: 1px solid var(--color-border, #444);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.submemo-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+}
+
+.submemo-toggle {
+  min-width: 90px;
+}
+
+.submemo-title {
+  flex: 1;
+  min-width: 0;
+  padding: 6px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border, #444);
+  background: transparent;
+  color: inherit;
+}
+
+.submemo-title:read-only {
+  opacity: 0.7;
+}
+
+.submemo-spoiler {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.submemo-delete {
+  min-width: 80px;
+}
+
+.submemo-body {
+  padding: 12px;
+}
+
+.submemo-textarea {
+  width: 100%;
+  min-height: 120px;
+  resize: vertical;
+}
+
+.submemo-guard {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/features/character-sheet/components/sections/SubMemoItem.vue
+++ b/src/features/character-sheet/components/sections/SubMemoItem.vue
@@ -10,7 +10,7 @@
         :value="subMemo.title"
         :placeholder="messages.titlePlaceholder"
         :readonly="readonly"
-        @input="$emit('update-title', $event.target.value)"
+        @change="$emit('update-title', $event.target.value)"
       />
       <label class="submemo-spoiler">
         <input
@@ -37,7 +37,7 @@
           :placeholder="messages.contentPlaceholder"
           :value="subMemo.content"
           :readonly="readonly"
-          @input="$emit('update-content', $event.target.value)"
+          @change="$emit('update-content', $event.target.value)"
         ></textarea>
       </div>
     </Transition>
@@ -75,7 +75,7 @@ const showGuard = computed(() => props.subMemo.isSpoiler && !props.revealed);
 
 <style scoped>
 .submemo-item {
-  border: 1px solid var(--color-border, #444);
+  border: 1px solid var(--color-border-normal);
   border-radius: 4px;
   overflow: hidden;
 }
@@ -96,7 +96,7 @@ const showGuard = computed(() => props.subMemo.isSpoiler && !props.revealed);
   min-width: 0;
   padding: 6px 8px;
   border-radius: 4px;
-  border: 1px solid var(--color-border, #444);
+  border: 1px solid var(--color-border-normal);
   background: transparent;
   color: inherit;
 }

--- a/src/features/character-sheet/components/sections/SubMemoItem.vue
+++ b/src/features/character-sheet/components/sections/SubMemoItem.vue
@@ -28,7 +28,7 @@
         <span>{{ messages.spoilerLabel }}</span>
       </label>
       <button
-        class="button-base list-button list-button--remove submemo-delete"
+        class="button-base list-button list-button--delete"
         type="button"
         :disabled="readonly"
         :aria-label="messages.deleteLabel"
@@ -82,7 +82,7 @@ const props = defineProps({
   },
 });
 
-const showGuard = computed(() => props.subMemo.isSpoiler && !props.revealed);
+const showGuard = computed(() => props.readonly && props.subMemo.isSpoiler && !props.revealed);
 </script>
 
 <style scoped>
@@ -129,11 +129,7 @@ const showGuard = computed(() => props.subMemo.isSpoiler && !props.revealed);
 .submemo-spoiler {
   display: flex;
   align-items: center;
-  gap: 6px;
-}
-
-.submemo-delete {
-  min-width: 80px;
+  gap: 4px;
 }
 
 .submemo-body {

--- a/src/features/character-sheet/stores/characterStore.js
+++ b/src/features/character-sheet/stores/characterStore.js
@@ -3,9 +3,37 @@ import { AioniaGameData } from '@/data/gameData.js';
 import { messages } from '@/i18n/index.js';
 import { deepClone, createWeaknessArray } from '@/shared/utils/utils.js';
 
+function generateUniqueId(existingIds = new Set()) {
+  let id = '';
+  do {
+    const cryptoApi = globalThis.crypto;
+    id = typeof cryptoApi?.randomUUID === 'function' ? cryptoApi.randomUUID() : Math.random().toString(36).slice(2, 10);
+  } while (existingIds.has(id));
+  return id;
+}
+
+function normalizeSubMemo(subMemo, existingIds) {
+  const sanitizedMemo = subMemo && typeof subMemo === 'object' ? subMemo : {};
+  const memoId = sanitizedMemo.id && !existingIds.has(sanitizedMemo.id) ? sanitizedMemo.id : generateUniqueId(existingIds);
+  existingIds.add(memoId);
+  return {
+    id: memoId,
+    title: sanitizedMemo.title ?? '',
+    content: sanitizedMemo.content ?? '',
+    isSpoiler: Boolean(sanitizedMemo.isSpoiler),
+  };
+}
+
+function normalizeSubMemos(list = []) {
+  const existingIds = new Set();
+  const source = Array.isArray(list) ? list : [];
+  return source.map((memo) => normalizeSubMemo(memo, existingIds));
+}
+
 function createCharacter() {
   const base = deepClone(AioniaGameData.defaultCharacterData);
   base.weaknesses = createWeaknessArray(AioniaGameData.config.maxWeaknesses);
+  base.subMemos = normalizeSubMemos(base.subMemos);
   return base;
 }
 
@@ -144,6 +172,36 @@ export const useCharacterStore = defineStore('character', {
           const emptyItem = typeof newItemFactory === 'function' ? newItemFactory() : newItemFactory;
           list[index] = typeof emptyItem === 'object' && emptyItem !== null ? deepClone(emptyItem) : emptyItem;
         }
+      }
+    },
+    addSubMemo(payload = {}) {
+      const list = Array.isArray(this.character.subMemos) ? this.character.subMemos : [];
+      this.character.subMemos = list;
+      const existingIds = new Set(list.map((memo) => memo.id).filter(Boolean));
+      const newMemo = normalizeSubMemo({ ...payload, isSpoiler: payload.isSpoiler ?? false }, existingIds);
+      list.push(newMemo);
+      return newMemo;
+    },
+    updateSubMemo(id, updates = {}) {
+      if (!Array.isArray(this.character.subMemos)) return null;
+      const target = this.character.subMemos.find((memo) => memo.id === id);
+      if (!target) return null;
+      if ('title' in updates) {
+        target.title = updates.title ?? '';
+      }
+      if ('content' in updates) {
+        target.content = updates.content ?? '';
+      }
+      if ('isSpoiler' in updates) {
+        target.isSpoiler = Boolean(updates.isSpoiler);
+      }
+      return target;
+    },
+    removeSubMemo(id) {
+      if (!Array.isArray(this.character.subMemos)) return;
+      const index = this.character.subMemos.findIndex((memo) => memo.id === id);
+      if (index !== -1) {
+        this.character.subMemos.splice(index, 1);
       }
     },
     addSpecialSkillItem() {

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -319,6 +319,25 @@ export const messages = {
       },
       memo: {
         title: t('sheet.sections.memo.title'),
+        subMemo: {
+          titlePlaceholder: t('sheet.sections.memo.subMemo.titlePlaceholder'),
+          contentPlaceholder: t('sheet.sections.memo.subMemo.contentPlaceholder'),
+          spoilerLabel: t('sheet.sections.memo.subMemo.spoilerLabel'),
+          spoilerNotice: t('sheet.sections.memo.subMemo.spoilerNotice'),
+          readButton: t('sheet.sections.memo.subMemo.readButton'),
+          addButton: t('sheet.sections.memo.subMemo.addButton'),
+          deleteLabel: t('sheet.sections.memo.subMemo.deleteLabel'),
+          toggle: {
+            expand: t('sheet.sections.memo.subMemo.toggle.expand'),
+            collapse: t('sheet.sections.memo.subMemo.toggle.collapse'),
+          },
+          deleteConfirm: {
+            title: t('sheet.sections.memo.subMemo.deleteConfirm.title'),
+            message: t('sheet.sections.memo.subMemo.deleteConfirm.message'),
+            delete: t('sheet.sections.memo.subMemo.deleteConfirm.delete'),
+            cancel: t('sheet.sections.memo.subMemo.deleteConfirm.cancel'),
+          },
+        },
       },
       specialSkills: {
         title: t('sheet.sections.specialSkills.title'),

--- a/tests/unit/components/CharacterMemoSection.test.js
+++ b/tests/unit/components/CharacterMemoSection.test.js
@@ -1,0 +1,56 @@
+import * as Vue from 'vue';
+global.Vue = Vue;
+import { mount } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+import CharacterMemoSection from '@/features/character-sheet/components/sections/CharacterMemoSection.vue';
+import { useCharacterStore } from '@/features/character-sheet/stores/characterStore.js';
+
+const mockShowModal = vi.fn();
+vi.mock('@/features/modals/composables/useModal.js', () => ({
+  useModal: () => ({ showModal: mockShowModal }),
+}));
+
+describe('CharacterMemoSection', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockShowModal.mockReset();
+    localStorage.clear();
+  });
+
+  test('adds sub memos and toggles visibility', async () => {
+    const wrapper = mount(CharacterMemoSection);
+    await wrapper.find('.submemo-actions .button-base').trigger('click');
+    await wrapper.vm.$nextTick();
+    const toggle = wrapper.find('.submemo-toggle');
+    expect(wrapper.findAllComponents({ name: 'SubMemoItem' }).length || wrapper.findAll('.submemo-item').length).toBe(1);
+    expect(wrapper.find('.submemo-body').element.style.display).toBe('none');
+    await toggle.trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('.submemo-body').element.style.display).not.toBe('none');
+  });
+
+  test('shows spoiler guard until revealed', async () => {
+    const store = useCharacterStore();
+    const memo = store.addSubMemo({ isSpoiler: true, content: 'Secret' });
+    const wrapper = mount(CharacterMemoSection);
+    const toggle = wrapper.find('.submemo-toggle');
+    await toggle.trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.text()).toContain('※ネタバレを含む内容です');
+    await wrapper.find('.submemo-guard .button-base').trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('.submemo-textarea').element.value).toBe('Secret');
+    const saved = JSON.parse(localStorage.getItem('aioniacs_ui_submemos_state'));
+    expect(saved.revealedIds).toContain(memo.id);
+  });
+
+  test('confirms before deleting sub memo', async () => {
+    const store = useCharacterStore();
+    store.addSubMemo({ title: 'Temp' });
+    mockShowModal.mockResolvedValue({ value: 'delete' });
+    const wrapper = mount(CharacterMemoSection);
+    await wrapper.find('.submemo-delete').trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(store.character.subMemos).toHaveLength(0);
+  });
+});

--- a/tests/unit/components/CharacterMemoSection.test.js
+++ b/tests/unit/components/CharacterMemoSection.test.js
@@ -19,7 +19,7 @@ describe('CharacterMemoSection', () => {
 
   test('adds sub memos and toggles visibility', async () => {
     const wrapper = mount(CharacterMemoSection);
-    await wrapper.find('.submemo-actions .button-base').trigger('click');
+    await wrapper.find('.add-button-container-left .list-button--add').trigger('click');
     await wrapper.vm.$nextTick();
     const toggle = wrapper.find('.submemo-toggle');
     expect(wrapper.findAllComponents({ name: 'SubMemoItem' }).length || wrapper.findAll('.submemo-item').length).toBe(1);

--- a/tests/unit/components/CharacterMemoSection.test.js
+++ b/tests/unit/components/CharacterMemoSection.test.js
@@ -4,6 +4,7 @@ import { mount } from '@vue/test-utils';
 import { setActivePinia, createPinia } from 'pinia';
 import CharacterMemoSection from '@/features/character-sheet/components/sections/CharacterMemoSection.vue';
 import { useCharacterStore } from '@/features/character-sheet/stores/characterStore.js';
+import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
 
 const mockShowModal = vi.fn();
 vi.mock('@/features/modals/composables/useModal.js', () => ({
@@ -31,6 +32,8 @@ describe('CharacterMemoSection', () => {
 
   test('shows spoiler guard until revealed', async () => {
     const store = useCharacterStore();
+    const uiStore = useUiStore();
+    uiStore.isViewingShared = true;
     const memo = store.addSubMemo({ isSpoiler: true, content: 'Secret' });
     const wrapper = mount(CharacterMemoSection);
     const toggle = wrapper.find('.submemo-toggle');
@@ -49,7 +52,7 @@ describe('CharacterMemoSection', () => {
     store.addSubMemo({ title: 'Temp' });
     mockShowModal.mockResolvedValue({ value: 'delete' });
     const wrapper = mount(CharacterMemoSection);
-    await wrapper.find('.submemo-delete').trigger('click');
+    await wrapper.find('.list-button--delete').trigger('click');
     await wrapper.vm.$nextTick();
     expect(store.character.subMemos).toHaveLength(0);
   });

--- a/tests/unit/components/CharacterMemoSection.test.js
+++ b/tests/unit/components/CharacterMemoSection.test.js
@@ -20,7 +20,7 @@ describe('CharacterMemoSection', () => {
 
   test('adds sub memos and toggles visibility', async () => {
     const wrapper = mount(CharacterMemoSection);
-    await wrapper.find('.add-button-container-left .list-button--add').trigger('click');
+    await wrapper.find('.add-button-row .list-button--add').trigger('click');
     await wrapper.vm.$nextTick();
     const toggle = wrapper.find('.submemo-toggle');
     expect(wrapper.findAllComponents({ name: 'SubMemoItem' }).length || wrapper.findAll('.submemo-item').length).toBe(1);

--- a/tests/unit/stores/characterStore.test.js
+++ b/tests/unit/stores/characterStore.test.js
@@ -113,4 +113,30 @@ describe('characterStore', () => {
       expect(store.calculatedScar).toBe(11);
     });
   });
+
+  describe('subMemos', () => {
+    test('addSubMemo creates entries with unique ids', () => {
+      const store = useCharacterStore();
+      const first = store.addSubMemo();
+      const second = store.addSubMemo();
+      expect(first.id).toBeDefined();
+      expect(second.id).toBeDefined();
+      expect(first.id).not.toBe(second.id);
+      expect(store.character.subMemos).toHaveLength(2);
+    });
+
+    test('updateSubMemo updates fields', () => {
+      const store = useCharacterStore();
+      const memo = store.addSubMemo();
+      store.updateSubMemo(memo.id, { title: 'Title', content: 'Body', isSpoiler: true });
+      expect(store.character.subMemos[0]).toMatchObject({ title: 'Title', content: 'Body', isSpoiler: true });
+    });
+
+    test('removeSubMemo deletes by id', () => {
+      const store = useCharacterStore();
+      const memo = store.addSubMemo();
+      store.removeSubMemo(memo.id);
+      expect(store.character.subMemos).toHaveLength(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add sub memo data model and CRUD actions to the character store with unique ID generation
- extend the character memo section with a dedicated sub memo UI, spoiler guard handling, and local persistence of UI state
- introduce localized strings and unit tests covering sub memo behavior and UI interactions

## Testing
- npm test
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940abc2f20483268aaec329c138b8a3)