### PR TITLE
Add prefetch flow for Google Drive picker readiness

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -45,6 +45,7 @@ const {
   loadCharacterFromDrive,
   promptForDriveFolder,
   updateDriveFolderPath,
+  prefetchDriveAccessToken,
 } = useGoogleDrive(dataManager);
 
 const { helpState, isHelpVisible, handleHelpIconMouseOver, handleHelpIconMouseLeave, handleHelpIconClick, closeHelpPanel } = useHelp(
@@ -119,6 +120,7 @@ const { openLoadModal, openIoModal, openShareModal } = useAppModals({
   updateDriveFolderPath,
   canSignInToGoogle,
   isDriveReady,
+  prefetchDriveAccessToken,
 });
 
 const maxExperiencePoints = computed(() => characterStore.maxExperiencePoints);

--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -210,9 +210,6 @@ export function useGoogleDrive(dataManager) {
       isDriveTokenWarm.value = true;
       return;
     }
-    if (isDriveTokenWarm.value) {
-      return;
-    }
 
     try {
       await googleDriveManager.value.ensureAccessToken();

--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -25,6 +25,7 @@ export function useGoogleDrive(dataManager) {
 
   const canSignInToGoogle = computed(() => !uiStore.isSignedIn);
   const isDriveReady = computed(() => uiStore.isGapiInitialized && uiStore.isSignedIn);
+  const isDriveTokenWarm = ref(false);
 
   function syncGoogleDriveManager() {
     try {
@@ -66,6 +67,7 @@ export function useGoogleDrive(dataManager) {
     await googleDriveManager.value.handleSignOut();
     uiStore.isSignedIn = false;
     uiStore.clearCurrentDriveFileId();
+    isDriveTokenWarm.value = false;
     showToast({ type: 'success', ...messages.googleDrive.signOut.success() });
   }
 
@@ -195,6 +197,32 @@ export function useGoogleDrive(dataManager) {
     });
   }
 
+  async function prefetchDriveAccessToken() {
+    if (!googleDriveManager.value || !uiStore.isSignedIn || !uiStore.isGapiInitialized) {
+      return;
+    }
+    if (typeof googleDriveManager.value.ensureAccessToken !== 'function') {
+      return;
+    }
+    const cachedToken =
+      typeof googleDriveManager.value.getCachedAccessToken === 'function' ? googleDriveManager.value.getCachedAccessToken() : null;
+    if (cachedToken) {
+      isDriveTokenWarm.value = true;
+      return;
+    }
+    if (isDriveTokenWarm.value) {
+      return;
+    }
+
+    try {
+      await googleDriveManager.value.ensureAccessToken();
+      isDriveTokenWarm.value = true;
+    } catch (error) {
+      console.error('Failed to prefetch Google Drive token:', error);
+      isDriveTokenWarm.value = false;
+    }
+  }
+
   async function saveCharacterToDrive(option = false) {
     if (!isDriveReady.value) {
       showToast({ type: 'error', ...messages.googleDrive.initPending() });
@@ -291,6 +319,7 @@ export function useGoogleDrive(dataManager) {
         uiStore.isSignedIn = restored;
         if (restored) {
           refreshDriveFolderPath();
+          isDriveTokenWarm.value = true;
         }
       } catch (error) {
         uiStore.isGapiInitialized = false;
@@ -336,5 +365,6 @@ export function useGoogleDrive(dataManager) {
     updateDriveFolderPath,
     loadCharacterFromDrive,
     saveCharacterToDrive,
+    prefetchDriveAccessToken,
   };
 }

--- a/src/features/modals/composables/useAppModals.js
+++ b/src/features/modals/composables/useAppModals.js
@@ -29,9 +29,19 @@ export function useAppModals(options) {
     updateDriveFolderPath,
     canSignInToGoogle,
     isDriveReady,
+    prefetchDriveAccessToken,
   } = options;
 
   async function openLoadModal() {
+    let hasPrefetchedDriveToken = false;
+    const triggerPrefetch = (values) => {
+      if (hasPrefetchedDriveToken || typeof prefetchDriveAccessToken !== 'function' || !values.isSignedIn || !values.isDriveReady) {
+        return;
+      }
+      hasPrefetchedDriveToken = true;
+      prefetchDriveAccessToken();
+    };
+
     const initialProps = {
       isSignedIn: uiStore.isSignedIn,
       canSignIn: canSignInToGoogle?.value ?? false,
@@ -71,9 +81,12 @@ export function useAppModals(options) {
         if (modalStore.component === LoadModal) {
           Object.assign(modalStore.props, values);
         }
+        triggerPrefetch(values);
       },
       { immediate: true },
     );
+
+    triggerPrefetch(initialProps);
 
     try {
       await modalPromise;

--- a/src/infrastructure/google-drive/googleDriveManager.js
+++ b/src/infrastructure/google-drive/googleDriveManager.js
@@ -267,6 +267,24 @@ export class GoogleDriveManager {
    * Fetches an access token from the server and applies it to gapi.
    * @returns {Promise<string>}
    */
+  getCachedAccessToken() {
+    if (typeof gapi === 'undefined' || !gapi.client || typeof gapi.client.getToken !== 'function') {
+      return null;
+    }
+
+    const now = Date.now();
+    const existingToken = gapi.client.getToken();
+    if (
+      existingToken?.access_token &&
+      this.currentTokenInfo?.accessToken === existingToken.access_token &&
+      this.currentTokenInfo.expiresAt > now
+    ) {
+      return existingToken.access_token;
+    }
+
+    return null;
+  }
+
   async ensureAccessToken() {
     if (typeof gapi === 'undefined' || !gapi.client || !gapi.client.setToken) {
       throw new Error('GAPI client is not initialized for token application.');
@@ -274,12 +292,7 @@ export class GoogleDriveManager {
 
     const now = Date.now();
     const existingToken = typeof gapi.client.getToken === 'function' ? gapi.client.getToken() : null;
-    if (
-      this.currentTokenInfo &&
-      this.currentTokenInfo.expiresAt > now &&
-      existingToken &&
-      existingToken.access_token === this.currentTokenInfo.accessToken
-    ) {
+    if (this.currentTokenInfo?.expiresAt > now && existingToken?.access_token === this.currentTokenInfo.accessToken) {
       return this.currentTokenInfo.accessToken;
     }
 
@@ -846,12 +859,15 @@ export class GoogleDriveManager {
       return;
     }
 
-    try {
-      await this.ensureAccessToken();
-    } catch (error) {
-      console.error('Failed to prepare Picker token:', error);
-      if (callback) callback(new Error('Authentication required.'));
-      return;
+    const cachedToken = this.getCachedAccessToken();
+    if (!cachedToken) {
+      try {
+        await this.ensureAccessToken();
+      } catch (error) {
+        console.error('Failed to prepare Picker token:', error);
+        if (callback) callback(new Error('Authentication required.'));
+        return;
+      }
     }
 
     const token = gapi.client.getToken();
@@ -905,12 +921,15 @@ export class GoogleDriveManager {
       return;
     }
 
-    try {
-      await this.ensureAccessToken();
-    } catch (error) {
-      console.error('Failed to prepare Folder Picker token:', error);
-      if (callback) callback(new Error('Authentication required.'));
-      return;
+    const cachedToken = this.getCachedAccessToken();
+    if (!cachedToken) {
+      try {
+        await this.ensureAccessToken();
+      } catch (error) {
+        console.error('Failed to prepare Folder Picker token:', error);
+        if (callback) callback(new Error('Authentication required.'));
+        return;
+      }
     }
 
     const token = gapi.client.getToken();

--- a/src/infrastructure/google-drive/googleDriveManager.js
+++ b/src/infrastructure/google-drive/googleDriveManager.js
@@ -277,7 +277,7 @@ export class GoogleDriveManager {
     if (
       existingToken?.access_token &&
       this.currentTokenInfo?.accessToken === existingToken.access_token &&
-      this.currentTokenInfo.expiresAt > now
+      this.currentTokenInfo?.expiresAt > now
     ) {
       return existingToken.access_token;
     }

--- a/tests/unit/composables/useAppModals.test.js
+++ b/tests/unit/composables/useAppModals.test.js
@@ -136,4 +136,15 @@ describe('useAppModals', () => {
     expect(copyEditCallback).toHaveBeenCalled();
     expect(showAsyncToastMock).not.toHaveBeenCalled();
   });
+
+  test('openLoadModal prefetches drive token when ready', async () => {
+    const prefetchDriveAccessToken = vi.fn();
+    const uiStore = useUiStore();
+    uiStore.isSignedIn = true;
+    const { openLoadModal } = useAppModals(createOptions({ prefetchDriveAccessToken }));
+
+    await openLoadModal();
+
+    expect(prefetchDriveAccessToken).toHaveBeenCalled();
+  });
 });

--- a/tests/unit/googleDriveManager.test.js
+++ b/tests/unit/googleDriveManager.test.js
@@ -35,6 +35,7 @@ describe('GoogleDriveManager configuration and folder handling', () => {
   afterEach(() => {
     vi.clearAllMocks();
     resetGoogleDriveManagerForTests();
+    delete global.google;
   });
 
   test('loadConfig creates default config when missing', async () => {
@@ -210,6 +211,35 @@ describe('GoogleDriveManager configuration and folder handling', () => {
     gapi.client.drive.files.delete.mockResolvedValue({});
     await gdm.deleteCharacterFile('del-1');
     expect(gapi.client.drive.files.delete).toHaveBeenCalledWith({ fileId: 'del-1' });
+  });
+
+  test('showFilePicker uses cached token without fetching', async () => {
+    const pickerSetVisible = vi.fn();
+    const pickerBuilder = {
+      setOrigin: vi.fn().mockReturnThis(),
+      addView: vi.fn().mockReturnThis(),
+      enableFeature: vi.fn().mockReturnThis(),
+      setOAuthToken: vi.fn().mockReturnThis(),
+      setCallback: vi.fn().mockReturnThis(),
+      build: vi.fn(() => ({ setVisible: pickerSetVisible })),
+    };
+    global.google = {
+      picker: {
+        Response: { ACTION: 'action', DOCUMENTS: 'docs' },
+        Action: { PICKED: 'picked', CANCEL: 'cancel' },
+        ViewId: { DOCS: 'docs' },
+        Feature: { NAV_HIDDEN: 'nav' },
+        View: vi.fn(() => ({ setParent: vi.fn(), setMimeTypes: vi.fn() })),
+        PickerBuilder: vi.fn(() => pickerBuilder),
+      },
+    };
+    gdm.pickerApiLoaded = true;
+
+    await gdm.showFilePicker(() => {});
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(pickerBuilder.setOAuthToken).toHaveBeenCalledWith('cached-token');
+    expect(pickerSetVisible).toHaveBeenCalledWith(true);
   });
 
   test('onGapiLoad rejects when gapi.load missing', async () => {


### PR DESCRIPTION
## Summary
- prefetch Google Drive access tokens when the Load modal becomes available to keep picker launches user-gesture friendly
- skip unnecessary token refreshes in picker helpers by reusing cached access tokens
- add coverage for picker caching and prefetch triggers

## Testing
- npm run lint
- npm test *(fails: tests/unit/functions/authApi.test.js missing hono dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940dffe0f848326a878a771c5c26c6c)