### PR TITLE
Refactor share flow to user-driven copy

### DIFF
--- a/src/contents/ui_messages.csv
+++ b/src/contents/ui_messages.csv
@@ -49,11 +49,19 @@ share.needSignIn.message,サインインしてください,,Share sign-in needed
 share.toast.creating.title,共有リンク,,Share creating toast title
 share.toast.creating.message,作成中...,,Share creating toast body
 share.toast.success.title,共有リンク,,Share success toast title
-share.toast.success.message,URLをコピーしました,,Share success toast body
+share.toast.success.message,共有リンクを生成しました,,Share success toast body
 share.toast.error.title,共有リンク,,Share error toast title
 share.toast.error.message,共有リンクの生成に失敗しました,,Share error toast default body
 share.toast.clipboardUnavailable.title,共有リンク,,Share clipboard unavailable toast title
 share.toast.clipboardUnavailable.message,クリップボードにアクセスできません,,Share clipboard unavailable toast body
+share.resultModal.title,共有リンク,,Share result modal title
+share.resultModal.description,共有リンクが生成されました。下のURLをコピーして共有してください。,,Share result modal description
+share.resultModal.urlLabel,共有URL,,Share result modal url label
+share.resultModal.copyLabel,コピー,,Share result modal copy button
+share.resultModal.copySuccess.title,コピー,,Share result modal copy success title
+share.resultModal.copySuccess.message,URLをクリップボードにコピーしました,,Share result modal copy success message
+share.resultModal.copyError.title,コピー失敗,,Share result modal copy error title
+share.resultModal.copyError.message,コピーに失敗しました。もう一度お試しください,,Share result modal copy error message
 share.errors.saveFailed,Google Drive への保存に失敗しました,,Share save failed error
 share.errors.shareFailed,共有リンクの取得に失敗しました,,Share retrieval failed error
 share.errors.managerMissing,Google Drive マネージャーが設定されていません,,Share manager missing error

--- a/src/features/modals/components/contents/ShareResultModal.vue
+++ b/src/features/modals/components/contents/ShareResultModal.vue
@@ -1,0 +1,102 @@
+<template>
+  <div class="share-result-modal">
+    <p class="share-result-modal__description">{{ description }}</p>
+    <label class="share-result-modal__label" :for="inputId">{{ urlLabel }}</label>
+    <div class="share-result-modal__field">
+      <input
+        :id="inputId"
+        class="share-result-modal__input"
+        type="text"
+        :value="shareUrl"
+        readonly
+      />
+      <button type="button" class="button-base share-result-modal__copy" @click="handleCopy">
+        {{ copyLabel }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { messages } from '@/i18n/index.js';
+import { useNotifications } from '@/features/notifications/composables/useNotifications.js';
+
+const props = defineProps({
+  shareUrl: {
+    type: String,
+    required: true,
+  },
+  description: {
+    type: String,
+    default: () => messages.share.resultModal.description,
+  },
+  urlLabel: {
+    type: String,
+    default: () => messages.share.resultModal.urlLabel,
+  },
+  copyLabel: {
+    type: String,
+    default: () => messages.share.resultModal.copyLabel,
+  },
+});
+
+const inputId = `share-url-${Math.random().toString(36).slice(2, 8)}`;
+const { showToast, logAndToastError } = useNotifications();
+
+async function handleCopy() {
+  if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+    const unavailable = messages.share.toast.clipboardUnavailable();
+    logAndToastError(new Error(unavailable.message), unavailable, 'share-result-copy');
+    return;
+  }
+
+  try {
+    await navigator.clipboard.writeText(props.shareUrl);
+    showToast({ type: 'success', ...messages.share.resultModal.copySuccess() });
+  } catch (error) {
+    logAndToastError(error, messages.share.resultModal.copyError(), 'share-result-copy');
+  }
+}
+</script>
+
+<style scoped>
+.share-result-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.share-result-modal__description {
+  margin: 0;
+  color: var(--color-text-primary, #f0f0f0);
+}
+
+.share-result-modal__label {
+  font-weight: bold;
+  color: var(--color-text-primary, #f0f0f0);
+}
+
+.share-result-modal__field {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.share-result-modal__input {
+  flex: 1;
+  padding: 8px;
+  background: #1f1f1f;
+  color: var(--color-text-primary, #f0f0f0);
+  border: 1px solid #444;
+  border-radius: 4px;
+}
+
+.share-result-modal__input:focus {
+  outline: 2px solid var(--color-accent, #9b59b6);
+  outline-offset: 2px;
+}
+
+.share-result-modal__copy {
+  white-space: nowrap;
+}
+</style>

--- a/src/features/modals/composables/useAppModals.js
+++ b/src/features/modals/composables/useAppModals.js
@@ -4,6 +4,7 @@ import { useModalStore } from '@/features/modals/stores/modalStore.js';
 import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
 const LoadModal = defineAsyncComponent(() => import('@/features/modals/components/contents/LoadModal.vue'));
 const IoModal = defineAsyncComponent(() => import('@/features/modals/components/contents/IoModal.vue'));
+const ShareResultModal = defineAsyncComponent(() => import('@/features/modals/components/contents/ShareResultModal.vue'));
 import { isDesktopDevice } from '@/shared/utils/device.js';
 import { messages } from '@/i18n/index.js';
 import { useShare } from '@/features/cloud-sync/composables/useShare.js';
@@ -141,14 +142,7 @@ export function useAppModals(options) {
       showToast({ type: 'error', ...messages.share.needSignIn() });
       return;
     }
-    const sharePromise = (async () => {
-      const link = await createShareLink();
-      if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
-        throw new Error(messages.share.toast.clipboardUnavailable().message);
-      }
-      await navigator.clipboard.writeText(link);
-      return link;
-    })();
+    const sharePromise = createShareLink();
 
     showAsyncToast(
       sharePromise,
@@ -159,6 +153,22 @@ export function useAppModals(options) {
       },
       'openShareModal',
     );
+
+    sharePromise
+      .then((link) =>
+        showModal({
+          component: ShareResultModal,
+          title: messages.share.resultModal.title,
+          props: {
+            shareUrl: link,
+            description: messages.share.resultModal.description,
+            urlLabel: messages.share.resultModal.urlLabel,
+            copyLabel: messages.share.resultModal.copyLabel,
+          },
+          buttons: [],
+        }),
+      )
+      .catch(() => {});
 
     return sharePromise;
   }

--- a/src/features/modals/composables/useAppModals.js
+++ b/src/features/modals/composables/useAppModals.js
@@ -168,7 +168,7 @@ export function useAppModals(options) {
           buttons: [],
         }),
       )
-      .catch(() => {});
+      .catch((error) => console.error('Failed to show share result modal:', error));
 
     return sharePromise;
   }

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -143,6 +143,20 @@ export const messages = {
       shareFailed: t('share.errors.shareFailed'),
       managerMissing: t('share.errors.managerMissing'),
     },
+    resultModal: {
+      title: t('share.resultModal.title'),
+      description: t('share.resultModal.description'),
+      urlLabel: t('share.resultModal.urlLabel'),
+      copyLabel: t('share.resultModal.copyLabel'),
+      copySuccess: () => ({
+        title: t('share.resultModal.copySuccess.title'),
+        message: t('share.resultModal.copySuccess.message'),
+      }),
+      copyError: () => ({
+        title: t('share.resultModal.copyError.title'),
+        message: t('share.resultModal.copyError.message'),
+      }),
+    },
     loadError: {
       toast: (key = 'general') => ({
         title: t('share.loadError.title'),

--- a/tests/unit/composables/useAppModals.test.js
+++ b/tests/unit/composables/useAppModals.test.js
@@ -113,9 +113,15 @@ describe('useAppModals', () => {
     uiStore.isSignedIn = true;
     const { openShareModal } = useAppModals(createOptions());
     await openShareModal();
+    await Promise.resolve();
     expect(createShareLinkMock).toHaveBeenCalled();
     expect(showAsyncToastMock).toHaveBeenCalled();
-    expect(clipboardWriteMock).toHaveBeenCalledWith('https://example.com');
+    expect(showModalMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        props: expect.objectContaining({ shareUrl: 'https://example.com' }),
+      }),
+    );
+    expect(clipboardWriteMock).not.toHaveBeenCalled();
   });
 
   test('openShareModal warns when signed out', async () => {


### PR DESCRIPTION
## Summary
- replace automatic clipboard copy in the share flow with a modal that displays the generated link
- add a share result modal UI with manual copy handling and updated messaging
- adjust translations and unit tests to reflect the new user-driven sharing flow

## Testing
- npm run lint
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940e53a6194832692d2e2500f691b04)