### PR TITLE
Reduce Drive picker lag

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -46,6 +46,8 @@ const {
   promptForDriveFolder,
   updateDriveFolderPath,
   prefetchDriveAccessToken,
+  isDriveTokenWarm,
+  isDriveActionInFlight,
 } = useGoogleDrive(dataManager);
 
 const { helpState, isHelpVisible, handleHelpIconMouseOver, handleHelpIconMouseLeave, handleHelpIconClick, closeHelpPanel } = useHelp(
@@ -121,6 +123,8 @@ const { openLoadModal, openIoModal, openShareModal } = useAppModals({
   canSignInToGoogle,
   isDriveReady,
   prefetchDriveAccessToken,
+  isDriveTokenWarm,
+  isDriveActionInFlight,
 });
 
 const maxExperiencePoints = computed(() => characterStore.maxExperiencePoints);

--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -26,6 +26,7 @@ export function useGoogleDrive(dataManager) {
   const canSignInToGoogle = computed(() => !uiStore.isSignedIn);
   const isDriveReady = computed(() => uiStore.isGapiInitialized && uiStore.isSignedIn);
   const isDriveTokenWarm = ref(false);
+  const isDriveActionInFlight = ref(false);
 
   function syncGoogleDriveManager() {
     try {
@@ -82,20 +83,28 @@ export function useGoogleDrive(dataManager) {
       logAndToastError(pickerError, () => messages.googleDrive.folderPicker.unavailable(), 'promptForDriveFolder');
       return uiStore.driveFolderPath;
     }
+    isDriveActionInFlight.value = true;
+    const clearDriveAction = () => {
+      if (isDriveActionInFlight.value) {
+        isDriveActionInFlight.value = false;
+      }
+    };
 
     return new Promise((resolve) => {
       gdm.showFolderPicker(async (err, folder) => {
         if (err || !folder) {
           const pickerError = err || new Error(messages.googleDrive.folderPicker.error().message);
           logAndToastError(pickerError, (caught) => messages.googleDrive.folderPicker.error(caught), 'promptForDriveFolder');
+          clearDriveAction();
           resolve(uiStore.driveFolderPath);
           return;
         }
         const targetPath = folder.path || folder.name;
         const normalized = await updateDriveFolderPath(targetPath);
+        clearDriveAction();
         resolve(normalized);
       });
-    });
+    }).finally(clearDriveAction);
   }
 
   async function refreshDriveFolderPath() {
@@ -150,51 +159,81 @@ export function useGoogleDrive(dataManager) {
       return null;
     }
     if (!dataManager.googleDriveManager) return null;
+    isDriveActionInFlight.value = true;
+    const clearDriveAction = () => {
+      if (isDriveActionInFlight.value) {
+        isDriveActionInFlight.value = false;
+      }
+    };
 
-    const folderId = await dataManager.googleDriveManager.findOrCreateConfiguredCharacterFolder();
+    let folderId;
+    try {
+      folderId = await dataManager.googleDriveManager.findOrCreateConfiguredCharacterFolder();
+    } catch (error) {
+      clearDriveAction();
+      logAndToastError(error, messages.googleDrive.load.error, 'loadCharacterFromDrive');
+      return null;
+    }
 
     return new Promise((resolve) => {
-      dataManager.googleDriveManager.showFilePicker(
-        (err, file) => {
-          if (err || !file) {
-            const pickerError = err || new Error(messages.googleDrive.load.noSelection().message);
-            const toastFactory = err ? (caught) => messages.googleDrive.load.error(caught) : () => messages.googleDrive.load.noSelection();
-            logAndToastError(pickerError, toastFactory, 'loadCharacterFromDrive');
-            resolve(null);
-            return;
-          }
-
-          const loadPromise = dataManager.loadDataFromDrive(file.id).then((parsedData) => {
-            if (!parsedData) {
-              throw new Error(messages.googleDrive.load.missingData().message);
+      try {
+        dataManager.googleDriveManager.showFilePicker(
+          (err, file) => {
+            if (err || !file) {
+              const pickerError = err || new Error(messages.googleDrive.load.noSelection().message);
+              const toastFactory = err
+                ? (caught) => messages.googleDrive.load.error(caught)
+                : () => messages.googleDrive.load.noSelection();
+              logAndToastError(pickerError, toastFactory, 'loadCharacterFromDrive');
+              clearDriveAction();
+              resolve(null);
+              return;
             }
-            Object.assign(characterStore.character, parsedData.character);
-            characterStore.skills.splice(0, characterStore.skills.length, ...parsedData.skills);
-            characterStore.specialSkills.splice(0, characterStore.specialSkills.length, ...parsedData.specialSkills);
-            Object.assign(characterStore.equipments, parsedData.equipments);
-            characterStore.histories.splice(0, characterStore.histories.length, ...parsedData.histories);
-            uiStore.setCurrentDriveFileId(file.id);
-            removeStoredCharacterDraft();
-            uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
-            return parsedData;
-          });
 
-          showAsyncToast(
-            loadPromise,
-            {
-              loading: messages.googleDrive.load.loading(file.name),
-              success: messages.googleDrive.load.success(file.name),
-              error: (loadErr) => messages.googleDrive.load.error(loadErr),
-            },
-            'loadCharacterFromDrive',
-          );
+            const loadPromise = dataManager.loadDataFromDrive(file.id).then((parsedData) => {
+              if (!parsedData) {
+                throw new Error(messages.googleDrive.load.missingData().message);
+              }
+              Object.assign(characterStore.character, parsedData.character);
+              characterStore.skills.splice(0, characterStore.skills.length, ...parsedData.skills);
+              characterStore.specialSkills.splice(0, characterStore.specialSkills.length, ...parsedData.specialSkills);
+              Object.assign(characterStore.equipments, parsedData.equipments);
+              characterStore.histories.splice(0, characterStore.histories.length, ...parsedData.histories);
+              uiStore.setCurrentDriveFileId(file.id);
+              removeStoredCharacterDraft();
+              uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
+              return parsedData;
+            });
 
-          loadPromise.then((result) => resolve(result)).catch(() => resolve(null));
-        },
-        folderId,
-        ['application/json', 'application/zip'],
-      );
-    });
+            showAsyncToast(
+              loadPromise,
+              {
+                loading: messages.googleDrive.load.loading(file.name),
+                success: messages.googleDrive.load.success(file.name),
+                error: (loadErr) => messages.googleDrive.load.error(loadErr),
+              },
+              'loadCharacterFromDrive',
+            );
+
+            loadPromise
+              .then((result) => {
+                clearDriveAction();
+                resolve(result);
+              })
+              .catch(() => {
+                clearDriveAction();
+                resolve(null);
+              });
+          },
+          folderId,
+          ['application/json', 'application/zip'],
+        );
+      } catch (error) {
+        clearDriveAction();
+        logAndToastError(error, messages.googleDrive.load.error, 'loadCharacterFromDrive');
+        resolve(null);
+      }
+    }).finally(clearDriveAction);
   }
 
   async function prefetchDriveAccessToken() {
@@ -363,5 +402,7 @@ export function useGoogleDrive(dataManager) {
     loadCharacterFromDrive,
     saveCharacterToDrive,
     prefetchDriveAccessToken,
+    isDriveTokenWarm,
+    isDriveActionInFlight,
   };
 }

--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -84,27 +84,28 @@ export function useGoogleDrive(dataManager) {
       return uiStore.driveFolderPath;
     }
     isDriveActionInFlight.value = true;
-    const clearDriveAction = () => {
-      if (isDriveActionInFlight.value) {
-        isDriveActionInFlight.value = false;
-      }
-    };
-
-    return new Promise((resolve) => {
-      gdm.showFolderPicker(async (err, folder) => {
-        if (err || !folder) {
-          const pickerError = err || new Error(messages.googleDrive.folderPicker.error().message);
-          logAndToastError(pickerError, (caught) => messages.googleDrive.folderPicker.error(caught), 'promptForDriveFolder');
-          clearDriveAction();
-          resolve(uiStore.driveFolderPath);
-          return;
-        }
-        const targetPath = folder.path || folder.name;
-        const normalized = await updateDriveFolderPath(targetPath);
-        clearDriveAction();
-        resolve(normalized);
+    try {
+      const folder = await new Promise((resolve) => {
+        gdm.showFolderPicker((err, pickedFolder) => {
+          if (err || !pickedFolder) {
+            const pickerError = err || new Error(messages.googleDrive.folderPicker.error().message);
+            logAndToastError(pickerError, (caught) => messages.googleDrive.folderPicker.error(caught), 'promptForDriveFolder');
+            resolve(null);
+            return;
+          }
+          resolve(pickedFolder);
+        });
       });
-    }).finally(clearDriveAction);
+
+      if (!folder) {
+        return uiStore.driveFolderPath;
+      }
+
+      const targetPath = folder.path || folder.name;
+      return await updateDriveFolderPath(targetPath);
+    } finally {
+      isDriveActionInFlight.value = false;
+    }
   }
 
   async function refreshDriveFolderPath() {
@@ -160,80 +161,68 @@ export function useGoogleDrive(dataManager) {
     }
     if (!dataManager.googleDriveManager) return null;
     isDriveActionInFlight.value = true;
-    const clearDriveAction = () => {
-      if (isDriveActionInFlight.value) {
-        isDriveActionInFlight.value = false;
-      }
-    };
 
-    let folderId;
     try {
-      folderId = await dataManager.googleDriveManager.findOrCreateConfiguredCharacterFolder();
+      const folderId = await dataManager.googleDriveManager.findOrCreateConfiguredCharacterFolder();
+      const file = await new Promise((resolve, reject) => {
+        try {
+          dataManager.googleDriveManager.showFilePicker(
+            (err, pickedFile) => {
+              if (err || !pickedFile) {
+                const pickerError = err || new Error(messages.googleDrive.load.noSelection().message);
+                const toastFactory = err
+                  ? (caught) => messages.googleDrive.load.error(caught)
+                  : () => messages.googleDrive.load.noSelection();
+                logAndToastError(pickerError, toastFactory, 'loadCharacterFromDrive');
+                resolve(null);
+                return;
+              }
+              resolve(pickedFile);
+            },
+            folderId,
+            ['application/json', 'application/zip'],
+          );
+        } catch (error) {
+          reject(error);
+        }
+      });
+
+      if (!file) {
+        return null;
+      }
+
+      const loadPromise = dataManager.loadDataFromDrive(file.id).then((parsedData) => {
+        if (!parsedData) {
+          throw new Error(messages.googleDrive.load.missingData().message);
+        }
+        Object.assign(characterStore.character, parsedData.character);
+        characterStore.skills.splice(0, characterStore.skills.length, ...parsedData.skills);
+        characterStore.specialSkills.splice(0, characterStore.specialSkills.length, ...parsedData.specialSkills);
+        Object.assign(characterStore.equipments, parsedData.equipments);
+        characterStore.histories.splice(0, characterStore.histories.length, ...parsedData.histories);
+        uiStore.setCurrentDriveFileId(file.id);
+        removeStoredCharacterDraft();
+        uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
+        return parsedData;
+      });
+
+      showAsyncToast(
+        loadPromise,
+        {
+          loading: messages.googleDrive.load.loading(file.name),
+          success: messages.googleDrive.load.success(file.name),
+          error: (loadErr) => messages.googleDrive.load.error(loadErr),
+        },
+        'loadCharacterFromDrive',
+      );
+
+      return await loadPromise.catch(() => null);
     } catch (error) {
-      clearDriveAction();
       logAndToastError(error, messages.googleDrive.load.error, 'loadCharacterFromDrive');
       return null;
+    } finally {
+      isDriveActionInFlight.value = false;
     }
-
-    return new Promise((resolve) => {
-      try {
-        dataManager.googleDriveManager.showFilePicker(
-          (err, file) => {
-            if (err || !file) {
-              const pickerError = err || new Error(messages.googleDrive.load.noSelection().message);
-              const toastFactory = err
-                ? (caught) => messages.googleDrive.load.error(caught)
-                : () => messages.googleDrive.load.noSelection();
-              logAndToastError(pickerError, toastFactory, 'loadCharacterFromDrive');
-              clearDriveAction();
-              resolve(null);
-              return;
-            }
-
-            const loadPromise = dataManager.loadDataFromDrive(file.id).then((parsedData) => {
-              if (!parsedData) {
-                throw new Error(messages.googleDrive.load.missingData().message);
-              }
-              Object.assign(characterStore.character, parsedData.character);
-              characterStore.skills.splice(0, characterStore.skills.length, ...parsedData.skills);
-              characterStore.specialSkills.splice(0, characterStore.specialSkills.length, ...parsedData.specialSkills);
-              Object.assign(characterStore.equipments, parsedData.equipments);
-              characterStore.histories.splice(0, characterStore.histories.length, ...parsedData.histories);
-              uiStore.setCurrentDriveFileId(file.id);
-              removeStoredCharacterDraft();
-              uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
-              return parsedData;
-            });
-
-            showAsyncToast(
-              loadPromise,
-              {
-                loading: messages.googleDrive.load.loading(file.name),
-                success: messages.googleDrive.load.success(file.name),
-                error: (loadErr) => messages.googleDrive.load.error(loadErr),
-              },
-              'loadCharacterFromDrive',
-            );
-
-            loadPromise
-              .then((result) => {
-                clearDriveAction();
-                resolve(result);
-              })
-              .catch(() => {
-                clearDriveAction();
-                resolve(null);
-              });
-          },
-          folderId,
-          ['application/json', 'application/zip'],
-        );
-      } catch (error) {
-        clearDriveAction();
-        logAndToastError(error, messages.googleDrive.load.error, 'loadCharacterFromDrive');
-        resolve(null);
-      }
-    }).finally(clearDriveAction);
   }
 
   async function prefetchDriveAccessToken() {

--- a/src/features/modals/components/contents/LoadModal.vue
+++ b/src/features/modals/components/contents/LoadModal.vue
@@ -7,8 +7,16 @@
       </button>
     </section>
     <section class="load-modal__section load-modal__section--drive">
-      <button class="button-base load-modal__button" v-if="canUseDrive" data-test="load-modal-drive-button" @click="$emit('load-drive')">
-        {{ loadDriveLabel }}
+      <button
+        class="button-base load-modal__button"
+        v-if="canUseDrive"
+        :disabled="isDriveButtonDisabled"
+        :aria-busy="showDriveLoading"
+        data-test="load-modal-drive-button"
+        @click="$emit('load-drive')"
+      >
+        <span v-if="showDriveLoading" class="load-modal__spinner" aria-hidden="true"></span>
+        <span>{{ loadDriveLabel }}</span>
       </button>
       <div class="load-modal__config">
         <label class="load-modal__label" :for="folderInputId">{{ driveFolderLabel }}</label>
@@ -50,6 +58,8 @@ const props = defineProps({
   isSignedIn: Boolean,
   canSignIn: Boolean,
   isDriveReady: Boolean,
+  isDriveTokenWarm: Boolean,
+  isDriveActionLoading: Boolean,
   driveFolderPath: String,
   driveFolderLabel: String,
   driveFolderPlaceholder: String,
@@ -82,8 +92,11 @@ watch(
 );
 
 const canUseDrive = computed(() => props.isSignedIn && props.isDriveReady);
-const isDriveControlsDisabled = computed(() => !props.isSignedIn);
-const isFolderPickerDisabled = computed(() => !canUseDrive.value);
+const isDriveWarming = computed(() => canUseDrive.value && !props.isDriveTokenWarm);
+const showDriveLoading = computed(() => isDriveWarming.value || props.isDriveActionLoading);
+const isDriveButtonDisabled = computed(() => !canUseDrive.value || props.isDriveActionLoading);
+const isDriveControlsDisabled = computed(() => !props.isSignedIn || props.isDriveActionLoading);
+const isFolderPickerDisabled = computed(() => !canUseDrive.value || props.isDriveActionLoading);
 
 function commitFolderPath() {
   if (!props.isSignedIn) {
@@ -115,6 +128,8 @@ function handleLocalChange(event) {
 .load-modal__button {
   width: 100%;
   justify-content: center;
+  align-items: center;
+  gap: 8px;
 }
 
 .load-modal__config {
@@ -165,5 +180,23 @@ function handleLocalChange(event) {
 .button-base:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.load-modal__spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--color-border-normal);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: load-modal-spin 1s linear infinite;
+}
+
+@keyframes load-modal-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 </style>

--- a/src/features/modals/composables/useAppModals.js
+++ b/src/features/modals/composables/useAppModals.js
@@ -31,6 +31,8 @@ export function useAppModals(options) {
     canSignInToGoogle,
     isDriveReady,
     prefetchDriveAccessToken,
+    isDriveTokenWarm,
+    isDriveActionInFlight,
   } = options;
 
   async function openLoadModal() {
@@ -55,6 +57,8 @@ export function useAppModals(options) {
       loadDriveLabel: messages.ui.modal.load.buttons.loadDrive,
       signInLabel: messages.characterHub.buttons.signIn,
       signInMessage: messages.ui.modal.load.signInMessage,
+      isDriveTokenWarm: isDriveTokenWarm?.value ?? false,
+      isDriveActionLoading: isDriveActionInFlight?.value ?? false,
     };
 
     const modalPromise = showModal({
@@ -77,6 +81,8 @@ export function useAppModals(options) {
         canSignIn: canSignInToGoogle?.value ?? false,
         isDriveReady: isDriveReady?.value ?? false,
         driveFolderPath: uiStore.driveFolderPath,
+        isDriveTokenWarm: isDriveTokenWarm?.value ?? false,
+        isDriveActionLoading: isDriveActionInFlight?.value ?? false,
       }),
       (values) => {
         if (modalStore.component === LoadModal) {

--- a/src/infrastructure/google-drive/googleDriveManager.js
+++ b/src/infrastructure/google-drive/googleDriveManager.js
@@ -49,6 +49,7 @@ export class GoogleDriveManager {
     this.aioniaFolderId = null;
     this.gapiLoadPromise = null;
     this.currentTokenInfo = null;
+    this.tokenRefreshPromise = null;
     this.authStatusEndpoint = '/api/auth/status';
     this.loginEndpoint = '/api/auth/login';
     this.logoutEndpoint = '/api/auth/logout';
@@ -296,20 +297,32 @@ export class GoogleDriveManager {
       return this.currentTokenInfo.accessToken;
     }
 
-    const response = await fetch(this.authStatusEndpoint, { credentials: 'include' });
-    if (!response.ok) {
-      throw new Error('Authentication required.');
+    if (this.tokenRefreshPromise) {
+      return this.tokenRefreshPromise;
     }
 
-    const data = await response.json();
-    if (!data.access_token) {
-      throw new Error('Access token not available from server.');
-    }
+    this.tokenRefreshPromise = (async () => {
+      const response = await fetch(this.authStatusEndpoint, { credentials: 'include' });
+      if (!response.ok) {
+        throw new Error('Authentication required.');
+      }
 
-    const expiresAt = now + ((data.expires_in || 3600) * 1000 - 5000);
-    this.currentTokenInfo = { accessToken: data.access_token, expiresAt };
-    gapi.client.setToken({ access_token: data.access_token, expires_in: data.expires_in });
-    return data.access_token;
+      const data = await response.json();
+      if (!data.access_token) {
+        throw new Error('Access token not available from server.');
+      }
+
+      const expiresAt = now + ((data.expires_in || 3600) * 1000 - 5000);
+      this.currentTokenInfo = { accessToken: data.access_token, expiresAt };
+      gapi.client.setToken({ access_token: data.access_token, expires_in: data.expires_in });
+      return data.access_token;
+    })();
+
+    try {
+      return await this.tokenRefreshPromise;
+    } finally {
+      this.tokenRefreshPromise = null;
+    }
   }
 
   async restoreSession() {


### PR DESCRIPTION
## Summary
- deduplicate Google Drive token refresh requests and reuse in-flight fetches
- surface Drive token warm/action loading state to the load modal with spinner feedback
- guard Drive picker/folder interactions with immediate loading flags to avoid UI freezes

## Testing
- npm run lint
- npm test (fails: functions/authApi.test.js missing hono import dependency)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940ecc7e8d08326b3b7cd76896a0e43)