### PR TITLE
Improve character image display flex sizing

### DIFF
--- a/src/features/character-sheet/components/sections/CharacterBasicInfo.vue
+++ b/src/features/character-sheet/components/sections/CharacterBasicInfo.vue
@@ -92,6 +92,7 @@ const handleSpeciesChange = () => {
     flex-direction: column;
     flex: 1;
     height: 100%;
+    min-height: 0;
   }
 }
 </style>

--- a/src/features/character-sheet/components/ui/CharacterImageDisplay.vue
+++ b/src/features/character-sheet/components/ui/CharacterImageDisplay.vue
@@ -173,24 +173,23 @@ const handleImageUpload = async (event) => {
 }
 
 .image-display-area {
-  position: relative; 
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-bottom: 0;
   width: 100%;
-  min-height: 300px; 
-  flex: 1;
+  height: 300px;
   background-color: var(--color-background);
   border: 1px solid var(--color-border-normal);
   border-radius: 2px;
-  overflow: hidden; 
+  overflow: hidden;
 }
 
 .character-image-display {
   display: block;
   max-width: 100%;
   max-height: 100%;
+  width: auto;
   height: auto;
   object-fit: contain;
 }
@@ -304,8 +303,13 @@ const handleImageUpload = async (event) => {
 @media (min-width: 769px) {
   .character-image-container {
     flex: 1;
-    height: 100%;
-    width: 100%;
+    min-height: 200px;
+  }
+
+  .image-display-area {
+    height: auto;
+    flex: 1;
+    min-height: 0;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- let CharacterImageDisplay stretch within box content and maintain responsive sizing
- allow the character info box content to shrink by giving its flex child min-height tolerance

## Testing
- npm run lint *(warns about existing unused variables)*
- npm test *(fails: cannot resolve `hono` import in tests/unit/functions/authApi.test.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69424a95b3f4832692a4475bc20f8afd)