### PR TITLE
Improve character image layout flexibility

### DIFF
--- a/src/features/character-sheet/components/ui/CharacterImageDisplay.vue
+++ b/src/features/character-sheet/components/ui/CharacterImageDisplay.vue
@@ -173,24 +173,24 @@ const handleImageUpload = async (event) => {
 }
 
 .image-display-area {
-  position: relative; 
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
   margin-bottom: 0;
   width: 100%;
-  min-height: 300px; 
-  flex: 1;
+  height: 300px;
   background-color: var(--color-background);
   border: 1px solid var(--color-border-normal);
   border-radius: 2px;
-  overflow: hidden; 
+  overflow: hidden;
 }
 
 .character-image-display {
   display: block;
   max-width: 100%;
   max-height: 100%;
+  width: auto;
   height: auto;
   object-fit: contain;
 }
@@ -304,8 +304,14 @@ const handleImageUpload = async (event) => {
 @media (min-width: 769px) {
   .character-image-container {
     flex: 1;
-    height: 100%;
     width: 100%;
+    min-height: 0;
+  }
+
+  .image-display-area {
+    height: auto;
+    flex: 1;
+    min-height: 0;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- adjust character image display area to use a fixed mobile height and flexible desktop height for better grid alignment
- allow the image container to shrink and fill available space while preserving image aspect ratio

## Testing
- npm run lint
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69424efecc408326a7d1cf94eedde73a)