### PR TITLE
Start Drive token prefetch when opening load modal

### DIFF
--- a/src/features/modals/components/contents/LoadModal.vue
+++ b/src/features/modals/components/contents/LoadModal.vue
@@ -56,7 +56,6 @@ import { ref, watch, computed, onMounted, onUnmounted } from 'vue';
 import { useNotifications } from '@/features/notifications/composables/useNotifications.js';
 import { useModalStore } from '@/features/modals/stores/modalStore.js';
 
-
 const props = defineProps({
   isSignedIn: Boolean,
   canSignIn: Boolean,
@@ -73,7 +72,7 @@ const props = defineProps({
   signInMessage: String,
 });
 
-const emit = defineEmits(['load-local', 'load-drive', 'sign-in', 'update-drive-folder-path', 'choose-drive-folder', 'prefetch-drive']);
+const emit = defineEmits(['load-local', 'load-drive', 'sign-in', 'update-drive-folder-path', 'choose-drive-folder']);
 
 const folderInputId = 'load_modal_drive_folder';
 const AUTO_CLOSE_MS = 40 * 60 * 1000;
@@ -129,7 +128,6 @@ function closeForInactivity() {
 }
 
 onMounted(() => {
-  emit('prefetch-drive');
   autoCloseTimer = window.setTimeout(() => {
     closeForInactivity();
   }, AUTO_CLOSE_MS);

--- a/src/features/modals/composables/useAppModals.js
+++ b/src/features/modals/composables/useAppModals.js
@@ -61,6 +61,8 @@ export function useAppModals(options) {
       isDriveActionLoading: isDriveActionInFlight?.value ?? false,
     };
 
+    triggerPrefetch(initialProps);
+
     const modalPromise = showModal({
       component: LoadModal,
       title: messages.ui.modal.load.title,
@@ -72,7 +74,6 @@ export function useAppModals(options) {
         'sign-in': handleSignInClick,
         'update-drive-folder-path': updateDriveFolderPath,
         'choose-drive-folder': promptForDriveFolder,
-        'prefetch-drive': prefetchDriveAccessToken,
       },
     });
 
@@ -93,8 +94,6 @@ export function useAppModals(options) {
       },
       { immediate: true },
     );
-
-    triggerPrefetch(initialProps);
 
     try {
       await modalPromise;

--- a/tests/unit/composables/useAppModals.test.js
+++ b/tests/unit/composables/useAppModals.test.js
@@ -143,14 +143,22 @@ describe('useAppModals', () => {
     expect(showAsyncToastMock).not.toHaveBeenCalled();
   });
 
-  test('openLoadModal prefetches drive token when ready', async () => {
-    const prefetchDriveAccessToken = vi.fn();
+  test('openLoadModal prefetches drive token before showing modal when ready', async () => {
+    const callOrder = [];
+    const prefetchDriveAccessToken = vi.fn(() => {
+      callOrder.push('prefetch');
+    });
+    showModalMock.mockImplementation((args) => {
+      callOrder.push('showModal');
+      return Promise.resolve(args);
+    });
     const uiStore = useUiStore();
     uiStore.isSignedIn = true;
     const { openLoadModal } = useAppModals(createOptions({ prefetchDriveAccessToken }));
 
-    await openLoadModal();
+    const modalPromise = openLoadModal();
 
-    expect(prefetchDriveAccessToken).toHaveBeenCalled();
+    expect(callOrder).toEqual(['prefetch', 'showModal']);
+    await modalPromise;
   });
 });


### PR DESCRIPTION
## Summary
- start Drive token prefetch from the load modal trigger without awaiting it to keep the user gesture
- remove redundant Drive prefetch emit from `LoadModal` lifecycle
- add coverage to confirm prefetch begins before the modal opens

## Testing
- npm run lint (warnings about existing unused variables)
- npm test *(fails: Error: Failed to resolve import "hono" from functions/api/[[route]].js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943652431348326beb1ea2e1bcb887e)