### PR TITLE
Add synchronous Google Drive picker flow

### DIFF
--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -167,14 +167,46 @@ export function useGoogleDrive(dataManager) {
       showToast({ type: 'error', ...messages.googleDrive.initPending() });
       return null;
     }
+    if (!isDriveTokenWarm.value) {
+      showToast({ type: 'error', ...messages.googleDrive.initPending() });
+      return null;
+    }
     if (!dataManager.googleDriveManager) return null;
     isDriveActionInFlight.value = true;
 
     try {
+      if (typeof document !== 'undefined' && typeof document.requestStorageAccess === 'function') {
+        try {
+          await document.requestStorageAccess();
+        } catch (error) {
+          logAndToastError(error, messages.googleDrive.load.error, 'loadCharacterFromDrive');
+          return null;
+        }
+      }
+
       const folderId = cachedFolderId.value;
+      const cachedToken =
+        typeof dataManager.googleDriveManager.getCachedAccessToken === 'function'
+          ? dataManager.googleDriveManager.getCachedAccessToken()
+          : null;
+      const fallbackToken = typeof gapi !== 'undefined' && gapi.client?.getToken ? gapi.client.getToken()?.access_token : null;
+      const accessToken = cachedToken || fallbackToken;
+
+      if (!accessToken) {
+        const tokenError = new Error('Drive access token is not ready.');
+        logAndToastError(tokenError, messages.googleDrive.load.error, 'loadCharacterFromDrive');
+        return null;
+      }
+
+      if (typeof dataManager.googleDriveManager.showFilePickerSync !== 'function') {
+        const pickerError = new Error(messages.googleDrive.load.error().message);
+        logAndToastError(pickerError, (err) => messages.googleDrive.load.error(err), 'loadCharacterFromDrive');
+        return null;
+      }
+
       const file = await new Promise((resolve, reject) => {
         try {
-          dataManager.googleDriveManager.showFilePicker(
+          dataManager.googleDriveManager.showFilePickerSync(
             (err, pickedFile) => {
               if (err || !pickedFile) {
                 const pickerError = err || new Error(messages.googleDrive.load.noSelection().message);
@@ -187,6 +219,7 @@ export function useGoogleDrive(dataManager) {
               }
               resolve(pickedFile);
             },
+            accessToken,
             folderId,
             ['application/json', 'application/zip'],
           );

--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -194,7 +194,7 @@ export function useGoogleDrive(dataManager) {
 
       if (!accessToken) {
         const tokenError = new Error('Drive access token is not ready.');
-        logAndToastError(tokenError, messages.googleDrive.load.error, 'loadCharacterFromDrive');
+        logAndToastError(tokenError, () => messages.googleDrive.load.error(), 'loadCharacterFromDrive');
         return null;
       }
 

--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -199,8 +199,8 @@ export function useGoogleDrive(dataManager) {
       }
 
       if (typeof dataManager.googleDriveManager.showFilePickerSync !== 'function') {
-        const pickerError = new Error(messages.googleDrive.load.error().message);
-        logAndToastError(pickerError, (err) => messages.googleDrive.load.error(err), 'loadCharacterFromDrive');
+        const pickerError = new Error('showFilePickerSync is not available on the Google Drive manager.');
+        logAndToastError(pickerError, () => messages.googleDrive.load.error(), 'loadCharacterFromDrive');
         return null;
       }
 

--- a/src/features/modals/components/contents/LoadModal.vue
+++ b/src/features/modals/components/contents/LoadModal.vue
@@ -16,7 +16,7 @@
         @click="$emit('load-drive')"
       >
         <span v-if="showDriveLoading" class="load-modal__spinner" aria-hidden="true"></span>
-        <span>{{ loadDriveLabel }}</span>
+        <span>{{ driveButtonLabel }}</span>
       </button>
       <div class="load-modal__config">
         <label class="load-modal__label" :for="folderInputId">{{ driveFolderLabel }}</label>
@@ -101,9 +101,10 @@ watch(
 const canUseDrive = computed(() => props.isSignedIn && props.isDriveReady);
 const isDriveWarming = computed(() => canUseDrive.value && !props.isDriveTokenWarm);
 const showDriveLoading = computed(() => isDriveWarming.value || props.isDriveActionLoading);
-const isDriveButtonDisabled = computed(() => !canUseDrive.value || props.isDriveActionLoading);
+const isDriveButtonDisabled = computed(() => !canUseDrive.value || isDriveWarming.value || props.isDriveActionLoading);
 const isDriveControlsDisabled = computed(() => !props.isSignedIn || props.isDriveActionLoading);
 const isFolderPickerDisabled = computed(() => !canUseDrive.value || props.isDriveActionLoading);
+const driveButtonLabel = computed(() => (isDriveWarming.value ? '接続準備中…' : props.loadDriveLabel));
 
 function commitFolderPath() {
   if (!props.isSignedIn) {

--- a/src/infrastructure/google-drive/googleDriveManager.js
+++ b/src/infrastructure/google-drive/googleDriveManager.js
@@ -905,30 +905,20 @@ export class GoogleDriveManager {
   }
 
   /**
-   * Shows the Google File Picker to select a file.
+   * Shows the Google File Picker to select a file without awaiting token refresh.
    * @param {function} callback - Function to call with the result (error, {id, name}).
+   * @param {string} accessToken - Access token prepared by the caller.
    * @param {string|null} parentFolderId - Optional ID of the folder to start in.
    * @param {Array<string>} mimeTypes - Array of MIME types to filter by.
    */
-  async showFilePicker(callback, parentFolderId = null, mimeTypes = ['application/json']) {
+  showFilePickerSync(callback, accessToken, parentFolderId = null, mimeTypes = ['application/json']) {
     if (!this.pickerApiLoaded) {
       console.error('Picker API not loaded yet.');
       if (callback) callback(new Error('Picker API not loaded.'));
       return;
     }
 
-    const cachedToken = this.getCachedAccessToken();
-    if (!cachedToken) {
-      try {
-        await this.ensureAccessToken();
-      } catch (error) {
-        console.error('Failed to prepare Picker token:', error);
-        if (callback) callback(new Error('Authentication required.'));
-        return;
-      }
-    }
-
-    const token = gapi.client.getToken();
+    const token = accessToken || this.getCachedAccessToken();
     if (!token) {
       console.error('User not signed in or token not available for Picker.');
       if (callback) callback(new Error('Not signed in or token unavailable.'));
@@ -958,7 +948,7 @@ export class GoogleDriveManager {
       .setOrigin(window.location.origin)
       .addView(view)
       .enableFeature(google.picker.Feature.NAV_HIDDEN)
-      .setOAuthToken(token.access_token)
+      .setOAuthToken(token)
       .setCallback(pickerCallback);
 
     const picker = pickerBuilder.build();
@@ -966,9 +956,16 @@ export class GoogleDriveManager {
   }
 
   /**
-   * Shows the Google Folder Picker to select a folder.
+   * Backward-compatible wrapper that uses any cached token.
    * @param {function} callback - Function to call with the result (error, {id, name}).
+   * @param {string|null} parentFolderId - Optional ID of the folder to start in.
+   * @param {Array<string>} mimeTypes - Array of MIME types to filter by.
    */
+  showFilePicker(callback, parentFolderId = null, mimeTypes = ['application/json']) {
+    const token = this.getCachedAccessToken();
+    this.showFilePickerSync(callback, token, parentFolderId, mimeTypes);
+  }
+
   /**
    * Shows the Google Folder Picker to select a folder.
    * @param {function} callback - Function to call with the result (error, {id, name}).

--- a/src/infrastructure/google-drive/mockGoogleDriveManager.js
+++ b/src/infrastructure/google-drive/mockGoogleDriveManager.js
@@ -244,7 +244,15 @@ export class MockGoogleDriveManager {
     return `https://drive.mock/${fileId}`;
   }
 
-  showFilePicker(callback, parentFolderId = null) {
+  getCachedAccessToken() {
+    return 'mock-access-token';
+  }
+
+  showFilePickerSync(callback, accessToken, parentFolderId = null) {
+    if (!accessToken) {
+      callback?.(new Error('No access token provided.'));
+      return;
+    }
     const files = Object.values(this.state.files).filter((file) => (parentFolderId ? file.parentId === parentFolderId : true));
     const first = files[0];
     if (first) {
@@ -252,6 +260,11 @@ export class MockGoogleDriveManager {
     } else {
       callback?.(new Error('No files available.'));
     }
+  }
+
+  showFilePicker(callback, parentFolderId = null) {
+    const token = this.getCachedAccessToken();
+    this.showFilePickerSync(callback, token, parentFolderId);
   }
 
   showFolderPicker(callback) {

--- a/tests/unit/composables/useGoogleDrive.test.js
+++ b/tests/unit/composables/useGoogleDrive.test.js
@@ -38,6 +38,9 @@ describe('useGoogleDrive', () => {
     global.fetch = vi.fn(() =>
       Promise.resolve({ ok: true, json: async () => ({ folder_path: '慈悲なきアイオニア', folder_id: null, folder_name: null }) }),
     );
+    if (typeof document !== 'undefined') {
+      document.requestStorageAccess = undefined;
+    }
   });
 
   test('saveCharacterToDrive updates an existing file when current id is set', async () => {
@@ -68,6 +71,8 @@ describe('useGoogleDrive', () => {
   });
 
   test('loadCharacterFromDrive loads data and updates store', async () => {
+    document.requestStorageAccess = vi.fn().mockResolvedValue();
+
     const loadData = {
       character: { name: 'Explorer' },
       skills: [],
@@ -79,17 +84,19 @@ describe('useGoogleDrive', () => {
       saveCharacterToDrive: vi.fn(),
       loadDataFromDrive: vi.fn().mockResolvedValue(loadData),
       googleDriveManager: {
-        showFilePicker: vi.fn((cb, parentId) => cb(null, { id: 'file-1', name: 'Explorer.json', parentId })),
+        getCachedAccessToken: vi.fn().mockReturnValue('picker-token'),
+        showFilePickerSync: vi.fn((cb, token, parentId) => cb(null, { id: 'file-1', name: 'Explorer.json', parentId, token })),
         findOrCreateConfiguredCharacterFolder: vi.fn().mockResolvedValue('folder-id'),
         loadConfig: vi.fn().mockResolvedValue({ characterFolderPath: '慈悲なきアイオニア', folderId: 'folder-id' }),
       },
       getDriveFileName: vi.fn().mockReturnValue('Explorer.json'),
     };
-    const { loadCharacterFromDrive, refreshDriveFolderPath } = useGoogleDrive(dataManager);
+    const { loadCharacterFromDrive, refreshDriveFolderPath, isDriveTokenWarm } = useGoogleDrive(dataManager);
     const charStore = useCharacterStore();
     const uiStore = useUiStore();
     uiStore.isGapiInitialized = true;
     uiStore.isSignedIn = true;
+    isDriveTokenWarm.value = true;
     global.fetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -102,14 +109,69 @@ describe('useGoogleDrive', () => {
     await refreshDriveFolderPath();
     const result = await loadCharacterFromDrive();
 
+    expect(document.requestStorageAccess).toHaveBeenCalledTimes(1);
     expect(result).toEqual(loadData);
     expect(charStore.character.name).toBe('Explorer');
     expect(uiStore.currentDriveFileId).toBe('file-1');
     expect(uiStore.lastSavedSnapshot).toBe(buildSnapshotFromStore(charStore));
-    expect(dataManager.googleDriveManager.showFilePicker).toHaveBeenCalledWith(expect.any(Function), 'folder-id', [
+    expect(dataManager.googleDriveManager.showFilePickerSync).toHaveBeenCalledWith(expect.any(Function), 'picker-token', 'folder-id', [
       'application/json',
       'application/zip',
     ]);
+  });
+
+  test('loadCharacterFromDrive triggers picker synchronously when token is warm', async () => {
+    const showFilePickerSync = vi.fn((cb) => cb(null, { id: 'file-sync', name: 'Sync.json' }));
+    const dataManager = {
+      saveCharacterToDrive: vi.fn(),
+      loadDataFromDrive: vi.fn().mockResolvedValue({
+        character: { name: 'Sync' },
+        skills: [],
+        specialSkills: [],
+        equipments: {},
+        histories: [],
+      }),
+      googleDriveManager: {
+        getCachedAccessToken: vi.fn().mockReturnValue('sync-token'),
+        showFilePickerSync,
+      },
+      getDriveFileName: vi.fn().mockReturnValue('Sync.json'),
+    };
+    const { loadCharacterFromDrive, isDriveTokenWarm } = useGoogleDrive(dataManager);
+    const uiStore = useUiStore();
+    uiStore.isGapiInitialized = true;
+    uiStore.isSignedIn = true;
+    isDriveTokenWarm.value = true;
+
+    const promise = loadCharacterFromDrive();
+    expect(showFilePickerSync).toHaveBeenCalledTimes(1);
+    await promise;
+  });
+
+  test('loadCharacterFromDrive shows toast when storage access request fails', async () => {
+    const accessError = new Error('denied');
+    document.requestStorageAccess = vi.fn(() => Promise.reject(accessError));
+
+    const dataManager = {
+      saveCharacterToDrive: vi.fn(),
+      loadDataFromDrive: vi.fn(),
+      googleDriveManager: {
+        getCachedAccessToken: vi.fn().mockReturnValue('picker-token'),
+        showFilePickerSync: vi.fn(),
+      },
+      getDriveFileName: vi.fn(),
+    };
+    const { loadCharacterFromDrive, isDriveTokenWarm } = useGoogleDrive(dataManager);
+    const uiStore = useUiStore();
+    uiStore.isGapiInitialized = true;
+    uiStore.isSignedIn = true;
+    isDriveTokenWarm.value = true;
+
+    const result = await loadCharacterFromDrive();
+
+    expect(result).toBeNull();
+    expect(logAndToastErrorMock).toHaveBeenCalledWith(accessError, expect.anything(), 'loadCharacterFromDrive');
+    expect(dataManager.googleDriveManager.showFilePickerSync).not.toHaveBeenCalled();
   });
 
   test('promptForDriveFolder applies picker selection to drive path', async () => {


### PR DESCRIPTION
## Summary
- add a synchronous Drive Picker entry point that accepts warmed tokens and requests storage access when available
- block Drive loading until tokens are warm and surface a preparing indicator on the load button
- align mock implementations and unit tests with the synchronous picker and storage access flow

## Testing
- npm test
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943683748cc8326a6f66c24597027e6)