### PR TITLE
Add Drive metadata caching and hashing support

### DIFF
--- a/functions/api/[[route]].js
+++ b/functions/api/[[route]].js
@@ -370,7 +370,9 @@ app.post('/api/drive/sync', async (c) => {
 
   try {
     const existing = await c.env.DB.prepare('SELECT * FROM character_metadata WHERE user_id = ?').bind(auth.session.user_id).all();
-    const existingMap = new Map((existing?.results || []).map((row) => [row.file_id, row]));
+    const existingRows = existing?.results || [];
+    const existingMap = new Map(existingRows.map((row) => [row.file_id, row]));
+    const incomingIds = new Set();
 
     const items = [];
     const statements = [];
@@ -381,6 +383,8 @@ app.post('/api/drive/sync', async (c) => {
       if (!fileId) {
         return c.json({ error: 'Each file entry must include an id.' }, 400);
       }
+
+      incomingIds.add(fileId);
 
       const fileName = file.name || file.fileName || '';
       const appProps = file.appProperties || file.app_properties || {};
@@ -418,6 +422,14 @@ app.post('/api/drive/sync', async (c) => {
         lastModifiedAtDrive,
         outOfSync: hashMismatch || modifiedMismatch,
       });
+    }
+
+    for (const row of existingRows) {
+      if (!incomingIds.has(row.file_id)) {
+        statements.push(
+          c.env.DB.prepare('DELETE FROM character_metadata WHERE file_id = ? AND user_id = ?').bind(row.file_id, auth.session.user_id),
+        );
+      }
     }
 
     if (statements.length > 0) {

--- a/functions/api/[[route]].js
+++ b/functions/api/[[route]].js
@@ -5,10 +5,7 @@ import { handle } from 'hono/cloudflare-pages';
 const SESSION_COOKIE_NAME = 'aioniacs_session';
 const STATE_COOKIE_NAME = 'aioniacs_oauth_state';
 const AUTH_SCOPE = 'https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive.file openid email profile';
-const REQUIRED_SCOPES = [
-  'https://www.googleapis.com/auth/drive.appdata',
-  'https://www.googleapis.com/auth/drive.file',
-];
+const REQUIRED_SCOPES = ['https://www.googleapis.com/auth/drive.appdata', 'https://www.googleapis.com/auth/drive.file'];
 const SESSION_TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days
 const STATE_TTL_SECONDS = 10 * 60; // 10 minutes
 
@@ -165,6 +162,29 @@ function createSessionId() {
     .join('');
 }
 
+async function getAuthenticatedSession(c) {
+  const sessionId = getCookie(c, SESSION_COOKIE_NAME);
+  if (!sessionId) {
+    return { ok: false, response: c.json({ error: 'Not authenticated.' }, 401) };
+  }
+
+  try {
+    const session = await c.env.DB.prepare('SELECT * FROM sessions WHERE id = ?').bind(sessionId).first();
+    const nowSeconds = Math.floor(Date.now() / 1000);
+
+    if (!session || session.expires_at <= nowSeconds) {
+      await c.env.DB.prepare('DELETE FROM sessions WHERE id = ?').bind(sessionId).run();
+      deleteCookie(c, SESSION_COOKIE_NAME, { path: '/' });
+      return { ok: false, response: c.json({ error: 'Session expired.' }, 401) };
+    }
+
+    return { ok: true, session, sessionId };
+  } catch (error) {
+    console.error('Session lookup error:', error);
+    return { ok: false, response: c.json({ error: 'Failed to verify session.' }, 500) };
+  }
+}
+
 const app = new Hono();
 
 app.get('/api/auth/login', async (c) => {
@@ -307,6 +327,102 @@ app.post('/api/auth/logout', async (c) => {
   }
   deleteCookie(c, SESSION_COOKIE_NAME, { path: '/' });
   return c.json({ success: true });
+});
+
+app.get('/api/drive/metadata', async (c) => {
+  const auth = await getAuthenticatedSession(c);
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  try {
+    const result = await c.env.DB.prepare(
+      'SELECT file_id, user_id, character_name, file_name, content_hash, last_modified_at_drive, synced_at FROM character_metadata WHERE user_id = ? ORDER BY synced_at DESC',
+    )
+      .bind(auth.session.user_id)
+      .all();
+
+    return c.json({ items: result?.results || [] });
+  } catch (error) {
+    console.error('Failed to fetch cached metadata:', error);
+    return c.json({ error: 'Failed to fetch cached metadata.' }, 500);
+  }
+});
+
+app.post('/api/drive/sync', async (c) => {
+  const auth = await getAuthenticatedSession(c);
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  let payload;
+  try {
+    payload = await c.req.json();
+  } catch (error) {
+    return c.json({ error: 'Invalid JSON payload.' }, 400);
+  }
+
+  const files = Array.isArray(payload?.files) ? payload.files : Array.isArray(payload?.items) ? payload.items : null;
+
+  if (!files) {
+    return c.json({ error: 'files array is required.' }, 400);
+  }
+
+  try {
+    const existing = await c.env.DB.prepare('SELECT * FROM character_metadata WHERE user_id = ?').bind(auth.session.user_id).all();
+    const existingMap = new Map((existing?.results || []).map((row) => [row.file_id, row]));
+
+    const items = [];
+    const nowSeconds = Math.floor(Date.now() / 1000);
+
+    for (const file of files) {
+      const fileId = file?.id || file?.fileId;
+      if (!fileId) {
+        return c.json({ error: 'Each file entry must include an id.' }, 400);
+      }
+
+      const fileName = file.name || file.fileName || '';
+      const appProps = file.appProperties || file.app_properties || {};
+      const contentHash = appProps?.last_app_hash || file.contentHash || null;
+      const characterName = appProps?.character_name || file.characterName || null;
+      const modifiedTime = file.modifiedTime || file.lastModifiedAtDrive || null;
+      const lastModifiedAtDrive = modifiedTime ? Number(new Date(modifiedTime).getTime()) : null;
+
+      const previous = existingMap.get(fileId);
+      const hashMismatch = Boolean(previous && previous.content_hash && contentHash && previous.content_hash !== contentHash);
+      const modifiedMismatch = Boolean(
+        previous && previous.last_modified_at_drive && lastModifiedAtDrive && previous.last_modified_at_drive !== lastModifiedAtDrive,
+      );
+
+      await c.env.DB.prepare(
+        `INSERT INTO character_metadata (file_id, user_id, character_name, file_name, content_hash, last_modified_at_drive, synced_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(file_id) DO UPDATE SET
+           user_id=excluded.user_id,
+           character_name=excluded.character_name,
+           file_name=excluded.file_name,
+           content_hash=excluded.content_hash,
+           last_modified_at_drive=excluded.last_modified_at_drive,
+           synced_at=excluded.synced_at`,
+      )
+        .bind(fileId, auth.session.user_id, characterName, fileName, contentHash, lastModifiedAtDrive, nowSeconds)
+        .run();
+
+      items.push({
+        fileId,
+        fileName,
+        characterName,
+        contentHash,
+        lastModifiedAtDrive,
+        outOfSync: hashMismatch || modifiedMismatch,
+      });
+    }
+
+    return c.json({ items });
+  } catch (error) {
+    console.error('Drive metadata sync failed:', error);
+    return c.json({ error: 'Failed to sync metadata.' }, 500);
+  }
 });
 
 export { app };

--- a/functions/api/[[route]].js
+++ b/functions/api/[[route]].js
@@ -373,6 +373,7 @@ app.post('/api/drive/sync', async (c) => {
     const existingMap = new Map((existing?.results || []).map((row) => [row.file_id, row]));
 
     const items = [];
+    const statements = [];
     const nowSeconds = Math.floor(Date.now() / 1000);
 
     for (const file of files) {
@@ -386,7 +387,8 @@ app.post('/api/drive/sync', async (c) => {
       const contentHash = appProps?.last_app_hash || file.contentHash || null;
       const characterName = appProps?.character_name || file.characterName || null;
       const modifiedTime = file.modifiedTime || file.lastModifiedAtDrive || null;
-      const lastModifiedAtDrive = modifiedTime ? Number(new Date(modifiedTime).getTime()) : null;
+      const lastModifiedMs = modifiedTime ? new Date(modifiedTime).getTime() : NaN;
+      const lastModifiedAtDrive = Number.isFinite(lastModifiedMs) ? Math.floor(lastModifiedMs / 1000) : null;
 
       const previous = existingMap.get(fileId);
       const hashMismatch = Boolean(previous && previous.content_hash && contentHash && previous.content_hash !== contentHash);
@@ -394,19 +396,19 @@ app.post('/api/drive/sync', async (c) => {
         previous && previous.last_modified_at_drive && lastModifiedAtDrive && previous.last_modified_at_drive !== lastModifiedAtDrive,
       );
 
-      await c.env.DB.prepare(
-        `INSERT INTO character_metadata (file_id, user_id, character_name, file_name, content_hash, last_modified_at_drive, synced_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)
-         ON CONFLICT(file_id) DO UPDATE SET
-           user_id=excluded.user_id,
-           character_name=excluded.character_name,
-           file_name=excluded.file_name,
-           content_hash=excluded.content_hash,
-           last_modified_at_drive=excluded.last_modified_at_drive,
-           synced_at=excluded.synced_at`,
-      )
-        .bind(fileId, auth.session.user_id, characterName, fileName, contentHash, lastModifiedAtDrive, nowSeconds)
-        .run();
+      statements.push(
+        c.env.DB.prepare(
+          `INSERT INTO character_metadata (file_id, user_id, character_name, file_name, content_hash, last_modified_at_drive, synced_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(file_id) DO UPDATE SET
+             user_id=excluded.user_id,
+             character_name=excluded.character_name,
+             file_name=excluded.file_name,
+             content_hash=excluded.content_hash,
+             last_modified_at_drive=excluded.last_modified_at_drive,
+             synced_at=excluded.synced_at`,
+        ).bind(fileId, auth.session.user_id, characterName, fileName, contentHash, lastModifiedAtDrive, nowSeconds),
+      );
 
       items.push({
         fileId,
@@ -416,6 +418,10 @@ app.post('/api/drive/sync', async (c) => {
         lastModifiedAtDrive,
         outOfSync: hashMismatch || modifiedMismatch,
       });
+    }
+
+    if (statements.length > 0) {
+      await c.env.DB.batch(statements);
     }
 
     return c.json({ items });

--- a/schema.sql
+++ b/schema.sql
@@ -7,3 +7,16 @@ CREATE TABLE IF NOT EXISTS sessions (
   created_at INTEGER,
   expires_at INTEGER
 );
+
+CREATE TABLE IF NOT EXISTS character_metadata (
+  file_id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  character_name TEXT,
+  file_name TEXT,
+  content_hash TEXT,
+  last_modified_at_drive INTEGER,
+  synced_at INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_character_metadata_user_id ON character_metadata(user_id);
+CREATE INDEX IF NOT EXISTS idx_character_metadata_synced_at ON character_metadata(synced_at);

--- a/src/infrastructure/google-drive/googleDriveManager.js
+++ b/src/infrastructure/google-drive/googleDriveManager.js
@@ -5,6 +5,67 @@ import { deserializeCharacterPayload } from '@/shared/utils/characterSerializati
  */
 let singletonInstance = null;
 
+function bufferToHex(buffer) {
+  return Array.from(new Uint8Array(buffer))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function stripImageData(payload) {
+  if (!payload || typeof payload !== 'object') {
+    return payload;
+  }
+  const sanitized = JSON.parse(JSON.stringify(payload));
+  if (sanitized.character && typeof sanitized.character === 'object') {
+    delete sanitized.character.images;
+  }
+  if (Array.isArray(sanitized.images)) {
+    delete sanitized.images;
+  }
+  return sanitized;
+}
+
+function parseHashPayload(payload) {
+  if (payload == null) {
+    return null;
+  }
+  if (typeof payload === 'string') {
+    try {
+      return JSON.parse(payload);
+    } catch (error) {
+      console.error('Failed to parse hash payload string:', error);
+      return null;
+    }
+  }
+  if (payload instanceof ArrayBuffer) {
+    try {
+      const decoder = new TextDecoder();
+      return JSON.parse(decoder.decode(new Uint8Array(payload)));
+    } catch (error) {
+      console.error('Failed to parse hash payload buffer:', error);
+      return null;
+    }
+  }
+  if (ArrayBuffer.isView(payload)) {
+    return parseHashPayload(payload.buffer);
+  }
+  if (typeof payload === 'object') {
+    return JSON.parse(JSON.stringify(payload));
+  }
+  return null;
+}
+
+export async function calculateMetadataHash(payload) {
+  const parsed = parseHashPayload(payload);
+  if (!parsed) {
+    return null;
+  }
+  const sanitized = stripImageData(parsed);
+  const jsonString = JSON.stringify(sanitized);
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(jsonString));
+  return bufferToHex(digest);
+}
+
 function uint8ArrayToBase64(bytes) {
   const chunkSize = 0x8000;
   let binary = '';
@@ -467,7 +528,7 @@ export class GoogleDriveManager {
     try {
       const response = await gapi.client.drive.files.list({
         q: `'${folderId}' in parents and mimeType='${mimeType}' and trashed=false`,
-        fields: 'files(id, name)',
+        fields: 'files(id, name, modifiedTime, appProperties, shared)',
         spaces: 'drive',
       });
       return response.result.files || [];
@@ -485,7 +546,7 @@ export class GoogleDriveManager {
    * @param {string|null} fileId - The ID of the file to update, or null to create a new file.
    * @returns {Promise<{id: string, name: string}|null>} File ID and name, or null on error.
    */
-  async saveFile(folderId, fileName, fileContent, fileId = null, mimeType = 'application/json') {
+  async saveFile(folderId, fileName, fileContent, fileId = null, mimeType = 'application/json', appProperties = null) {
     if (!gapi.client || !gapi.client.drive) {
       console.error('GAPI client or Drive API not loaded for saveFile.');
       return null;
@@ -500,6 +561,9 @@ export class GoogleDriveManager {
       name: fileName,
       mimeType,
     };
+    if (appProperties) {
+      metadata.appProperties = appProperties;
+    }
     let payload;
     try {
       payload = prepareMultipartPayload(fileContent);
@@ -983,6 +1047,16 @@ export class GoogleDriveManager {
     }
   }
 
+  async buildAppPropertiesFromPayload(hashPayload) {
+    try {
+      const hash = await calculateMetadataHash(hashPayload);
+      return hash ? { last_app_hash: hash } : undefined;
+    } catch (error) {
+      console.error('Failed to build appProperties from payload:', error);
+      return undefined;
+    }
+  }
+
   /**
    * Creates a character data file inside the configured Drive folder.
    * @param {{content: string|ArrayBuffer|ArrayBufferView, mimeType?: string, name?: string}} payload
@@ -993,7 +1067,8 @@ export class GoogleDriveManager {
     const fileName = `${sanitizeFileName(payload?.name)}.${extension}`;
     const folderId = await this.findOrCreateConfiguredCharacterFolder();
     if (!folderId) return null;
-    return this.saveFile(folderId, fileName, payload?.content || '', null, mimeType);
+    const appProperties = payload?.hashData ? await this.buildAppPropertiesFromPayload(payload.hashData) : undefined;
+    return this.saveFile(folderId, fileName, payload?.content || '', null, mimeType, appProperties);
   }
 
   /**
@@ -1007,7 +1082,8 @@ export class GoogleDriveManager {
     const fileName = `${sanitizeFileName(payload?.name)}.${extension}`;
     const folderId = await this.findOrCreateConfiguredCharacterFolder();
     if (!folderId) return null;
-    return this.saveFile(folderId, fileName, payload?.content || '', id, mimeType);
+    const appProperties = payload?.hashData ? await this.buildAppPropertiesFromPayload(payload.hashData) : undefined;
+    return this.saveFile(folderId, fileName, payload?.content || '', id, mimeType, appProperties);
   }
 
   async renameFile(fileId, newName) {

--- a/tests/unit/functions/driveSync.test.js
+++ b/tests/unit/functions/driveSync.test.js
@@ -1,0 +1,148 @@
+import { describe, expect, test, beforeEach } from 'vitest';
+import { app } from '../../../functions/api/[[route]].js';
+
+function createMockDb() {
+  const sessions = new Map();
+  const metadata = new Map();
+
+  return {
+    sessions,
+    metadata,
+    prepare(query) {
+      const normalized = query.trim().toLowerCase();
+
+      return {
+        bind: (...params) => ({
+          async first() {
+            if (normalized.startsWith('select * from sessions')) {
+              const [id] = params;
+              return sessions.get(id) || null;
+            }
+            return null;
+          },
+          async all() {
+            if (normalized.startsWith('select * from character_metadata')) {
+              const [userId] = params;
+              const results = Array.from(metadata.values()).filter((row) => row.user_id === userId);
+              return { results };
+            }
+
+            if (normalized.startsWith('select file_id')) {
+              const [userId] = params;
+              const results = Array.from(metadata.values())
+                .filter((row) => row.user_id === userId)
+                .sort((a, b) => b.synced_at - a.synced_at);
+              return { results };
+            }
+
+            return { results: [] };
+          },
+          async run() {
+            if (normalized.startsWith('delete from sessions')) {
+              const [id] = params;
+              sessions.delete(id);
+              return { success: true };
+            }
+
+            if (normalized.startsWith('delete from character_metadata')) {
+              const [fileId] = params;
+              metadata.delete(fileId);
+              return { success: true };
+            }
+
+            if (normalized.startsWith('insert into character_metadata')) {
+              const [fileId, userId, characterName, fileName, contentHash, lastModifiedAtDrive, syncedAt] = params;
+              metadata.set(fileId, {
+                file_id: fileId,
+                user_id: userId,
+                character_name: characterName,
+                file_name: fileName,
+                content_hash: contentHash,
+                last_modified_at_drive: lastModifiedAtDrive,
+                synced_at: syncedAt,
+              });
+              return { success: true };
+            }
+
+            return { success: false };
+          },
+        }),
+      };
+    },
+    async batch(statements) {
+      for (const statement of statements) {
+        await statement.run();
+      }
+      return { success: true };
+    },
+  };
+}
+
+describe('drive sync metadata deletion', () => {
+  let env;
+  let db;
+
+  beforeEach(() => {
+    db = createMockDb();
+    const sessionId = 'session-1';
+    const now = Math.floor(Date.now() / 1000);
+    db.sessions.set(sessionId, { id: sessionId, user_id: 'user-1', expires_at: now + 1000 });
+    db.metadata.set('keep', {
+      file_id: 'keep',
+      user_id: 'user-1',
+      character_name: 'Keep',
+      file_name: 'keep.json',
+      content_hash: 'hash-keep',
+      last_modified_at_drive: 10,
+      synced_at: now - 10,
+    });
+    db.metadata.set('remove', {
+      file_id: 'remove',
+      user_id: 'user-1',
+      character_name: 'Remove',
+      file_name: 'remove.json',
+      content_hash: 'hash-remove',
+      last_modified_at_drive: 20,
+      synced_at: now - 20,
+    });
+
+    env = {
+      GOOGLE_CLIENT_ID: 'client-id',
+      GOOGLE_CLIENT_SECRET: 'client-secret',
+      SESSION_SECRET: 'secret',
+      DB: db,
+    };
+  });
+
+  test('removes metadata entries that are absent from sync payload', async () => {
+    const payload = {
+      files: [
+        {
+          id: 'keep',
+          name: 'keep.json',
+          appProperties: { character_name: 'Keep', last_app_hash: 'hash-keep' },
+          modifiedTime: new Date(0).toISOString(),
+        },
+      ],
+    };
+
+    const res = await app.request(
+      'https://example.com/api/drive/sync',
+      {
+        method: 'POST',
+        body: JSON.stringify(payload),
+        headers: { 'content-type': 'application/json', Cookie: 'aioniacs_session=session-1' },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(db.metadata.has('remove')).toBe(false);
+    expect(db.metadata.has('keep')).toBe(true);
+
+    const updated = db.metadata.get('keep');
+    expect(updated.last_modified_at_drive).toBe(0);
+    const body = await res.json();
+    expect(body.items).toHaveLength(1);
+  });
+});

--- a/tests/unit/googleDriveManager.test.js
+++ b/tests/unit/googleDriveManager.test.js
@@ -3,6 +3,7 @@ import {
   initializeGoogleDriveManager,
   getGoogleDriveManagerInstance,
   resetGoogleDriveManagerForTests,
+  calculateMetadataHash,
 } from '@/infrastructure/google-drive/googleDriveManager.js';
 import { vi } from 'vitest';
 
@@ -161,6 +162,27 @@ describe('GoogleDriveManager configuration and folder handling', () => {
     expect(call.body).toContain('Content-Type: application/zip');
   });
 
+  test('createCharacterFile stores last_app_hash when hash data is provided', async () => {
+    gapi.client.drive.files.list.mockResolvedValue({ result: { files: [] } });
+    gapi.client.request.mockResolvedValueOnce({ result: { id: 'cfg-10', name: 'aioniacs.cfg' } });
+    gapi.client.drive.files.create.mockResolvedValue({ result: { id: 'folder-hash', name: '慈悲なきアイオニア' } });
+    gapi.client.request.mockResolvedValueOnce({ result: { id: 'file-hash', name: 'Hero.json' } });
+
+    const hashData = {
+      character: { name: 'Hash Hero', images: ['data:image/png;base64,AAA'] },
+      skills: [],
+      specialSkills: [],
+      equipments: {},
+      histories: [],
+    };
+
+    await gdm.createCharacterFile({ content: '{}', mimeType: 'application/json', name: 'Hash Hero', hashData });
+
+    const expectedHash = await calculateMetadataHash(hashData);
+    const requestCall = gapi.client.request.mock.calls.at(-1)[0];
+    expect(requestCall.body).toContain(`"appProperties":{"last_app_hash":"${expectedHash}"`);
+  });
+
   test('renameFile updates file metadata without uploading content', async () => {
     gapi.client.drive.files.update.mockResolvedValue({ result: { id: 'file-rename', name: 'Knight.zip' } });
 
@@ -221,5 +243,32 @@ describe('GoogleDriveManager configuration and folder handling', () => {
     expect(() => new GoogleDriveManager('other', 'other')).toThrow('already been instantiated');
     expect(initializeGoogleDriveManager('second', 'second')).toBe(gdm);
     expect(getGoogleDriveManagerInstance()).toBe(gdm);
+  });
+
+  test('calculateMetadataHash drops images from payload before hashing', async () => {
+    const payload = {
+      character: { name: 'Tester', images: ['data:image/png;base64,zzz'] },
+      skills: [],
+      specialSkills: [],
+      equipments: {},
+      histories: [],
+      images: ['data:image/png;base64,yyy'],
+    };
+
+    const hash = await calculateMetadataHash(payload);
+    const expectedPayload = {
+      character: { name: 'Tester' },
+      skills: [],
+      specialSkills: [],
+      equipments: {},
+      histories: [],
+    };
+
+    const buffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(JSON.stringify(expectedPayload)));
+    const expectedHash = Array.from(new Uint8Array(buffer))
+      .map((byte) => byte.toString(16).padStart(2, '0'))
+      .join('');
+
+    expect(hash).toBe(expectedHash);
   });
 });


### PR DESCRIPTION
## Summary
- add a D1 character_metadata table for caching character file metadata and indexes
- extend the API routes with authenticated metadata listing and Drive sync endpoints
- add Drive metadata hash utilities and appProperties handling with updated tests

## Testing
- npm test
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943ad6c13f88326b02b1a14e1cd4b3c)