### PR TITLE
Add drive load routing entrypoint and skeleton page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "marked": "^15.0.12",
         "pako": "^2.1.0",
         "pinia": "^2.1.7",
-        "vue": "^3.5.13"
+        "vue": "^3.5.13",
+        "vue-router": "^4.6.4"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.24.7",
@@ -9082,6 +9083,21 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "marked": "^15.0.12",
     "pako": "^2.1.0",
     "pinia": "^2.1.7",
-    "vue": "^3.5.13"
+    "vue": "^3.5.13",
+    "vue-router": "^4.6.4"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.24.7",

--- a/src/app/RootApp.vue
+++ b/src/app/RootApp.vue
@@ -1,0 +1,7 @@
+<script setup>
+import { RouterView } from 'vue-router';
+</script>
+
+<template>
+  <RouterView />
+</template>

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -1,6 +1,7 @@
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
-import App from './App.vue';
+import RootApp from './RootApp.vue';
+import { router } from './router/index.js';
 import { initializeGoogleDriveManager, initializeMockGoogleDriveManager } from '@/infrastructure/google-drive/index.js';
 import '@/shared/styles/style.css';
 
@@ -11,6 +12,7 @@ if (useMockDrive) {
   initializeGoogleDriveManager(import.meta.env.VITE_GOOGLE_API_KEY, import.meta.env.VITE_GOOGLE_CLIENT_ID);
 }
 
-const app = createApp(App);
+const app = createApp(RootApp);
 app.use(createPinia());
+app.use(router);
 app.mount('#app');

--- a/src/app/router/index.js
+++ b/src/app/router/index.js
@@ -1,0 +1,23 @@
+import { createRouter, createWebHistory } from 'vue-router';
+import App from '@/app/App.vue';
+
+const DriveLoadPage = () => import('@/features/cloud-sync/pages/DriveLoadPage.vue');
+
+export const router = createRouter({
+  history: createWebHistory(import.meta.env.BASE_URL),
+  routes: [
+    {
+      path: '/',
+      name: 'character-sheet',
+      component: App,
+    },
+    {
+      path: '/drive/load',
+      name: 'drive-load',
+      component: DriveLoadPage,
+    },
+  ],
+  scrollBehavior: () => ({ top: 0 }),
+});
+
+export default router;

--- a/src/contents/ui_messages.csv
+++ b/src/contents/ui_messages.csv
@@ -103,7 +103,11 @@ ui.confirmations.unsavedChanges.buttons.cancel,キャンセル,,Unsaved changes 
 ui.modal.load.title,読込,,Load modal title
 ui.modal.load.buttons.loadLocal,ローカルから読み込む,,Load modal local button
 ui.modal.load.buttons.loadDrive,Driveから読み込む,,Load modal drive button
+ui.modal.load.buttons.selectCharacter,キャラクターを選ぶ,,Load modal select character button
 ui.modal.load.signInMessage,Drive機能を使うにはGoogleにサインインしてください。,,Load modal sign-in message
+driveLoadPage.title,キャラクターを選ぶ,,Drive load page title
+driveLoadPage.placeholder,ここにGoogle Drive上のキャラクター一覧が表示されます,,Drive load page placeholder
+driveLoadPage.buttons.back,シートに戻る,,Drive load page back button
 ui.modal.io.title,入出力,,IO modal title
 ui.modal.io.buttons.saveLocal,ローカルファイルで出力,,IO modal save local button
 ui.modal.io.buttons.print,印刷,,IO modal print button

--- a/src/features/cloud-sync/pages/DriveLoadPage.vue
+++ b/src/features/cloud-sync/pages/DriveLoadPage.vue
@@ -1,0 +1,83 @@
+<script setup>
+import { useRouter } from 'vue-router';
+import { messages } from '@/i18n/index.js';
+
+const router = useRouter();
+
+function goBackToSheet() {
+  router.push({ name: 'character-sheet' });
+}
+</script>
+
+<template>
+  <div class="drive-load-page">
+    <header class="drive-load-page__header">
+      <button class="button-base drive-load-page__back" type="button" @click="goBackToSheet">
+        {{ messages.driveLoadPage.backLabel }}
+      </button>
+      <h1 class="drive-load-page__title">{{ messages.driveLoadPage.title }}</h1>
+    </header>
+    <section class="drive-load-page__content">
+      <p class="drive-load-page__placeholder">{{ messages.driveLoadPage.placeholder }}</p>
+      <div class="drive-load-page__list" aria-hidden="true">
+        <div class="drive-load-page__list-item" />
+        <div class="drive-load-page__list-item" />
+        <div class="drive-load-page__list-item" />
+      </div>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.drive-load-page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  color: var(--color-text-primary, #fff);
+}
+
+.drive-load-page__header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.drive-load-page__back {
+  min-width: 120px;
+}
+
+.drive-load-page__title {
+  margin: 0;
+  font-size: 1.5rem;
+  letter-spacing: 0.5px;
+}
+
+.drive-load-page__content {
+  background: var(--color-panel, #1f1f2b);
+  border: 1px solid var(--color-border-normal);
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.drive-load-page__placeholder {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.drive-load-page__list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.drive-load-page__list-item {
+  min-height: 120px;
+  border: 1px dashed var(--color-border-muted, #3a3a4a);
+  border-radius: 6px;
+  background: var(--color-panel-body, #181824);
+}
+</style>

--- a/src/features/modals/components/contents/LoadModal.vue
+++ b/src/features/modals/components/contents/LoadModal.vue
@@ -10,6 +10,14 @@
       <button class="button-base load-modal__button" v-if="canUseDrive" data-test="load-modal-drive-button" @click="$emit('load-drive')">
         {{ loadDriveLabel }}
       </button>
+      <button
+        class="button-base load-modal__button load-modal__button--secondary"
+        type="button"
+        data-test="load-modal-select-character"
+        @click="$emit('select-character')"
+      >
+        {{ selectCharacterLabel }}
+      </button>
       <div class="load-modal__config">
         <label class="load-modal__label" :for="folderInputId">{{ driveFolderLabel }}</label>
         <div class="load-modal__input-group">
@@ -56,11 +64,19 @@ const props = defineProps({
   changeFolderLabel: String,
   loadLocalLabel: String,
   loadDriveLabel: String,
+  selectCharacterLabel: String,
   signInLabel: String,
   signInMessage: String,
 });
 
-const emit = defineEmits(['load-local', 'load-drive', 'sign-in', 'update-drive-folder-path', 'choose-drive-folder']);
+const emit = defineEmits([
+  'load-local',
+  'load-drive',
+  'sign-in',
+  'update-drive-folder-path',
+  'choose-drive-folder',
+  'select-character',
+]);
 
 const folderInputId = 'load_modal_drive_folder';
 const folderPathInput = ref(props.driveFolderPath || '');
@@ -121,6 +137,12 @@ function handleLocalChange(event) {
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.load-modal__button--secondary {
+  background-color: var(--color-panel);
+  color: var(--color-text-primary, #fff);
+  border: 1px solid var(--color-border-normal);
 }
 
 .load-modal__label {

--- a/src/features/modals/composables/useAppModals.js
+++ b/src/features/modals/composables/useAppModals.js
@@ -8,6 +8,7 @@ import { isDesktopDevice } from '@/shared/utils/device.js';
 import { messages } from '@/i18n/index.js';
 import { useShare } from '@/features/cloud-sync/composables/useShare.js';
 import { useNotifications } from '@/features/notifications/composables/useNotifications.js';
+import { router } from '@/app/router/index.js';
 
 export function useAppModals(options) {
   const uiStore = useUiStore();
@@ -42,6 +43,7 @@ export function useAppModals(options) {
       changeFolderLabel: messages.characterHub.driveFolder.changeButton,
       loadLocalLabel: messages.ui.modal.load.buttons.loadLocal,
       loadDriveLabel: messages.ui.modal.load.buttons.loadDrive,
+      selectCharacterLabel: messages.ui.modal.load.buttons.selectCharacter,
       signInLabel: messages.characterHub.buttons.signIn,
       signInMessage: messages.ui.modal.load.signInMessage,
     };
@@ -57,6 +59,10 @@ export function useAppModals(options) {
         'sign-in': handleSignInClick,
         'update-drive-folder-path': updateDriveFolderPath,
         'choose-drive-folder': promptForDriveFolder,
+        'select-character': () => {
+          modalStore.resolveModal({ value: 'drive-load' });
+          router.push({ name: 'drive-load' });
+        },
       },
     });
 

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -226,6 +226,7 @@ export const messages = {
         buttons: {
           loadLocal: t('ui.modal.load.buttons.loadLocal'),
           loadDrive: t('ui.modal.load.buttons.loadDrive'),
+          selectCharacter: t('ui.modal.load.buttons.selectCharacter'),
         },
         signInMessage: t('ui.modal.load.signInMessage'),
       },
@@ -249,6 +250,11 @@ export const messages = {
         },
       },
     },
+  },
+  driveLoadPage: {
+    title: t('driveLoadPage.title'),
+    placeholder: t('driveLoadPage.placeholder'),
+    backLabel: t('driveLoadPage.buttons.back'),
   },
   sheet: {
     loadIndicator: {

--- a/tests/unit/components/LoadModal.test.js
+++ b/tests/unit/components/LoadModal.test.js
@@ -14,6 +14,7 @@ function baseProps(overrides = {}) {
     changeFolderLabel: 'change',
     loadLocalLabel: 'local',
     loadDriveLabel: 'drive',
+    selectCharacterLabel: 'select',
     signInLabel: 'signin',
     signInMessage: 'message',
     ...overrides,
@@ -40,5 +41,13 @@ describe('LoadModal', () => {
     const wrapper = mount(LoadModal, { props: baseProps({ isSignedIn: false }) });
     expect(wrapper.find('.load-modal__input').attributes('disabled')).toBeDefined();
     expect(wrapper.find('[data-test="load-modal-drive-button"]').exists()).toBe(false);
+  });
+
+  test('emits select-character when selector button clicked', async () => {
+    const wrapper = mount(LoadModal, { props: baseProps({ isSignedIn: true }) });
+    const button = wrapper.find('[data-test="load-modal-select-character"]');
+    expect(button.exists()).toBe(true);
+    await button.trigger('click');
+    expect(wrapper.emitted('select-character')).toHaveLength(1);
   });
 });

--- a/tests/unit/composables/useAppModals.test.js
+++ b/tests/unit/composables/useAppModals.test.js
@@ -6,6 +6,7 @@ import { isDesktopDevice } from '@/shared/utils/device.js';
 import { useNotifications } from '@/features/notifications/composables/useNotifications.js';
 import { useShare } from '@/features/cloud-sync/composables/useShare.js';
 import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
+import { useModalStore } from '@/features/modals/stores/modalStore.js';
 
 vi.mock('@/features/modals/composables/useModal.js', () => ({
   useModal: vi.fn(),
@@ -18,6 +19,10 @@ vi.mock('@/features/notifications/composables/useNotifications.js', () => ({
 }));
 vi.mock('@/features/cloud-sync/composables/useShare.js', () => ({
   useShare: vi.fn(),
+}));
+const { pushMock } = vi.hoisted(() => ({ pushMock: vi.fn() }));
+vi.mock('@/app/router/index.js', () => ({
+  router: { push: pushMock },
 }));
 
 describe('useAppModals', () => {
@@ -51,6 +56,7 @@ describe('useAppModals', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setActivePinia(createPinia());
+    pushMock.mockClear();
     showModalMock = vi.fn().mockResolvedValue(null);
     useModal.mockReturnValue({ showModal: showModalMock });
     showToastMock = vi.fn();
@@ -135,5 +141,16 @@ describe('useAppModals', () => {
     await openShareModal();
     expect(copyEditCallback).toHaveBeenCalled();
     expect(showAsyncToastMock).not.toHaveBeenCalled();
+  });
+
+  test('openLoadModal select-character routes to drive load page', async () => {
+    const { openLoadModal } = useAppModals(createOptions());
+    const modalStore = useModalStore();
+    await openLoadModal();
+    const args = showModalMock.mock.calls[0][0];
+    modalStore.showModal({});
+    await args.on['select-character']();
+    expect(modalStore.isVisible).toBe(false);
+    expect(pushMock).toHaveBeenCalledWith({ name: 'drive-load' });
   });
 });

--- a/tests/unit/router/index.test.js
+++ b/tests/unit/router/index.test.js
@@ -1,0 +1,14 @@
+import { router } from '@/app/router/index.js';
+
+describe('router configuration', () => {
+  test('includes character sheet and drive load routes', () => {
+    const routeNames = router.getRoutes().map((route) => route.name);
+    expect(routeNames).toContain('character-sheet');
+    expect(routeNames).toContain('drive-load');
+  });
+
+  test('drive load route points to expected path', () => {
+    const driveLoadRoute = router.getRoutes().find((route) => route.name === 'drive-load');
+    expect(driveLoadRoute?.path).toBe('/drive/load');
+  });
+});


### PR DESCRIPTION
## Summary
- add Vue Router setup with root router view and drive load route
- create DriveLoadPage skeleton with navigation back to the character sheet and new i18n strings
- add character selector button to the load modal that closes the modal and routes to the new page with supporting tests

## Testing
- npm test
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943ce7289b4832682e2b62266b1df55)