### PR TITLE
Implement drive load page metadata sync

### DIFF
--- a/src/contents/ui_messages.csv
+++ b/src/contents/ui_messages.csv
@@ -114,6 +114,7 @@ driveLoadPage.status.syncing,Google Driveと同期中…,,Drive load page syncin
 driveLoadPage.status.refreshed,最新の一覧を表示しています,,Drive load page refreshed status
 driveLoadPage.status.loadMore,さらに読み込み中…,,Drive load page load more status
 driveLoadPage.status.error,一覧の取得に失敗しました,,Drive load page error status
+driveLoadPage.status.retryHint,再試行してください。ネットワークや認証状態をご確認ください,,Drive load page retry hint
 driveLoadPage.labels.untitled,無題のファイル,,Drive load page untitled label
 driveLoadPage.labels.unknownCharacter,キャラクター名未設定,,Drive load page unknown character label
 driveLoadPage.labels.modified,更新日時,,Drive load page modified label
@@ -121,6 +122,7 @@ driveLoadPage.labels.hash,ハッシュ,,Drive load page hash label
 driveLoadPage.labels.notAvailable,なし,,Drive load page not available label
 driveLoadPage.labels.unknownDate,日時不明,,Drive load page unknown date label
 driveLoadPage.labels.outOfSync,要同期,,Drive load page out-of-sync badge
+driveLoadPage.labels.selectAction,このキャラクターを開く,,Drive load page select card aria label
 driveLoadPage.errors.missingDriveManager,Driveの初期化が完了していません,,Drive load page missing manager error
 driveLoadPage.errors.folderUnavailable,キャラクターフォルダにアクセスできません,,Drive load page folder unavailable error
 driveLoadPage.errors.apiUnavailable,Google Drive APIが利用できません,,Drive load page api unavailable error

--- a/src/contents/ui_messages.csv
+++ b/src/contents/ui_messages.csv
@@ -108,6 +108,24 @@ ui.modal.load.signInMessage,Drive機能を使うにはGoogleにサインイン�
 driveLoadPage.title,キャラクターを選ぶ,,Drive load page title
 driveLoadPage.placeholder,ここにGoogle Drive上のキャラクター一覧が表示されます,,Drive load page placeholder
 driveLoadPage.buttons.back,シートに戻る,,Drive load page back button
+driveLoadPage.buttons.refresh,再同期,,Drive load page refresh button
+driveLoadPage.status.loadingCache,キャッシュを読み込み中…,,Drive load page cache status
+driveLoadPage.status.syncing,Google Driveと同期中…,,Drive load page syncing status
+driveLoadPage.status.refreshed,最新の一覧を表示しています,,Drive load page refreshed status
+driveLoadPage.status.loadMore,さらに読み込み中…,,Drive load page load more status
+driveLoadPage.status.error,一覧の取得に失敗しました,,Drive load page error status
+driveLoadPage.labels.untitled,無題のファイル,,Drive load page untitled label
+driveLoadPage.labels.unknownCharacter,キャラクター名未設定,,Drive load page unknown character label
+driveLoadPage.labels.modified,更新日時,,Drive load page modified label
+driveLoadPage.labels.hash,ハッシュ,,Drive load page hash label
+driveLoadPage.labels.notAvailable,なし,,Drive load page not available label
+driveLoadPage.labels.unknownDate,日時不明,,Drive load page unknown date label
+driveLoadPage.labels.outOfSync,要同期,,Drive load page out-of-sync badge
+driveLoadPage.errors.missingDriveManager,Driveの初期化が完了していません,,Drive load page missing manager error
+driveLoadPage.errors.folderUnavailable,キャラクターフォルダにアクセスできません,,Drive load page folder unavailable error
+driveLoadPage.errors.apiUnavailable,Google Drive APIが利用できません,,Drive load page api unavailable error
+driveLoadPage.errors.cacheFailed,キャッシュの読み込みに失敗しました,,Drive load page cache failed error
+driveLoadPage.errors.syncFailed,同期に失敗しました,,Drive load page sync failed error
 ui.modal.io.title,入出力,,IO modal title
 ui.modal.io.buttons.saveLocal,ローカルファイルで出力,,IO modal save local button
 ui.modal.io.buttons.print,印刷,,IO modal print button

--- a/src/features/character-sheet/composables/useLocalCharacterPersistence.js
+++ b/src/features/character-sheet/composables/useLocalCharacterPersistence.js
@@ -1,4 +1,4 @@
-import { watch, onMounted } from 'vue';
+import { watch } from 'vue';
 
 export const LOCAL_CHARACTER_STORAGE_KEY = 'aionia-character';
 

--- a/src/features/cloud-sync/composables/useDriveLoadPageState.js
+++ b/src/features/cloud-sync/composables/useDriveLoadPageState.js
@@ -81,7 +81,11 @@ async function defaultRequestDrivePage(driveManager, { pageSize, pageToken, abor
 
   await driveManager.ensureAccessToken();
 
-  const response = await gapiClient.client.drive.files.list({
+  if (abortSignal?.aborted) {
+    return { files: [], nextPageToken: null };
+  }
+
+  const response = await gapi.client.drive.files.list({
     q: `'${folderId}' in parents and mimeType='application/json' and trashed=false`,
     fields: 'nextPageToken, files(id, name, modifiedTime, appProperties)',
     spaces: 'drive',
@@ -89,12 +93,7 @@ async function defaultRequestDrivePage(driveManager, { pageSize, pageToken, abor
     pageToken,
   });
 
-  if (abortSignal?.aborted) {
-    return { files: [], nextPageToken: null };
-  }
-
   return { files: response.result.files || [], nextPageToken: response.result.nextPageToken || null };
-}
 
 export function useDriveLoadPageState(options = {}) {
   const fetchImpl = options.fetchImpl || fetch;

--- a/src/features/cloud-sync/composables/useDriveLoadPageState.js
+++ b/src/features/cloud-sync/composables/useDriveLoadPageState.js
@@ -2,6 +2,7 @@ import { computed, ref } from 'vue';
 import { getGoogleDriveManagerInstance } from '@/infrastructure/google-drive/googleDriveManager.js';
 import { useNotifications } from '@/features/notifications/composables/useNotifications.js';
 import { messages } from '@/i18n/index.js';
+import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
 
 const DISPLAY_BATCH = 10;
 const PREFETCH_BUFFER = 10;
@@ -101,6 +102,7 @@ export function useDriveLoadPageState(options = {}) {
   const requestDrivePage = options.requestDrivePage || ((params) => defaultRequestDrivePage(driveManager, params));
   const metadataEndpoint = options.metadataEndpoint || '/api/drive/metadata';
   const syncEndpoint = options.syncEndpoint || '/api/drive/sync';
+  const uiStore = useUiStore();
   const { logAndToastError } = useNotifications();
 
   const items = ref([]);
@@ -195,9 +197,9 @@ export function useDriveLoadPageState(options = {}) {
     storeItems(mapped, { cachedOnly: false });
   }
 
-  async function postSync(payload) {
+  async function postSync(payload, { allowEmpty = false } = {}) {
     if (!payload || payload.length === 0) {
-      return [];
+      if (!allowEmpty) return [];
     }
     const controller = registerAborter(new AbortController());
     try {
@@ -205,7 +207,7 @@ export function useDriveLoadPageState(options = {}) {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ files: payload }),
+        body: JSON.stringify({ files: payload || [] }),
         signal: controller.signal,
       });
       if (!response.ok) {
@@ -258,6 +260,14 @@ export function useDriveLoadPageState(options = {}) {
         removeCachedOnly();
       }
     } catch (error) {
+      if (error?.status === 404 || error?.response?.status === 404) {
+        const missingId = error?.fileId || error?.id;
+        if (missingId) {
+          cacheMap.delete(missingId);
+          updateItemsFromCacheMap();
+          await postSync(getSyncPayload(true), { allowEmpty: true });
+        }
+      }
       handleError(error, 'syncFromDrive');
     } finally {
       isSyncing.value = false;
@@ -290,6 +300,11 @@ export function useDriveLoadPageState(options = {}) {
     syncFromDrive();
   }
 
+  function selectCharacter(id) {
+    if (!id) return;
+    uiStore.setCurrentDriveFileId(id);
+  }
+
   return {
     displayedItems,
     isLoadingCache,
@@ -302,5 +317,6 @@ export function useDriveLoadPageState(options = {}) {
     revealMore,
     cleanup,
     refresh: () => syncFromDrive(),
+    selectCharacter,
   };
 }

--- a/src/features/cloud-sync/composables/useDriveLoadPageState.js
+++ b/src/features/cloud-sync/composables/useDriveLoadPageState.js
@@ -1,0 +1,306 @@
+import { computed, ref } from 'vue';
+import { getGoogleDriveManagerInstance } from '@/infrastructure/google-drive/googleDriveManager.js';
+import { useNotifications } from '@/features/notifications/composables/useNotifications.js';
+import { messages } from '@/i18n/index.js';
+
+const DISPLAY_BATCH = 10;
+const PREFETCH_BUFFER = 10;
+const INITIAL_PAGE_SIZE = 20;
+const NEXT_PAGE_SIZE = 10;
+
+export function normalizeMetadataItem(raw) {
+  const id = raw?.fileId || raw?.file_id || raw?.id;
+  if (!id) return null;
+
+  const characterName =
+    raw?.characterName || raw?.character_name || raw?.appProperties?.character_name || raw?.app_properties?.character_name || '';
+  const fileName = raw?.fileName || raw?.file_name || raw?.name || '';
+  const contentHash =
+    raw?.contentHash || raw?.content_hash || raw?.appProperties?.last_app_hash || raw?.app_properties?.last_app_hash || null;
+  const modified = raw?.lastModifiedAtDrive || raw?.last_modified_at_drive || raw?.modifiedTime;
+  const lastModifiedAtDrive = modified ? Math.floor(new Date(modified).getTime() / 1000) : null;
+  const syncedAt = raw?.syncedAt || raw?.synced_at || null;
+  const outOfSync = Boolean(raw?.outOfSync || raw?.out_of_sync || raw?.hashMismatch || raw?.modifiedMismatch);
+
+  return { id, characterName, fileName, contentHash, lastModifiedAtDrive, syncedAt, outOfSync };
+}
+
+function buildSyncSource(item) {
+  const normalized = normalizeMetadataItem(item);
+  if (!normalized) return null;
+  return {
+    id: normalized.id,
+    name: normalized.fileName,
+    modifiedTime: normalized.lastModifiedAtDrive ? new Date(normalized.lastModifiedAtDrive * 1000).toISOString() : undefined,
+    appProperties:
+      normalized.contentHash || normalized.characterName
+        ? {
+            last_app_hash: normalized.contentHash || undefined,
+            character_name: normalized.characterName || undefined,
+          }
+        : undefined,
+  };
+}
+
+function sortItems(list) {
+  return [...list].sort((a, b) => {
+    const left = a.lastModifiedAtDrive || 0;
+    const right = b.lastModifiedAtDrive || 0;
+    if (left !== right) return right - left;
+    return (a.fileName || '').localeCompare(b.fileName || '');
+  });
+}
+
+function stripInternal(entry) {
+  const { ...rest } = entry;
+  delete rest.cachedOnly;
+  delete rest.syncSource;
+  return rest;
+}
+
+async function defaultRequestDrivePage(driveManager, { pageSize, pageToken, abortSignal }) {
+  if (!driveManager) {
+    throw new Error(messages.driveLoadPage.errors.missingDriveManager);
+  }
+
+  const folderId = await driveManager.findOrCreateConfiguredCharacterFolder();
+  if (!folderId) {
+    throw new Error(messages.driveLoadPage.errors.folderUnavailable);
+  }
+
+  const gapiClient = typeof globalThis !== 'undefined' ? globalThis.gapi : undefined;
+
+  if (!gapiClient?.client?.drive?.files?.list) {
+    if (typeof driveManager.listFiles === 'function') {
+      const files = await driveManager.listFiles(folderId);
+      return { files, nextPageToken: null };
+    }
+    throw new Error(messages.driveLoadPage.errors.apiUnavailable);
+  }
+
+  await driveManager.ensureAccessToken();
+
+  const response = await gapiClient.client.drive.files.list({
+    q: `'${folderId}' in parents and mimeType='application/json' and trashed=false`,
+    fields: 'nextPageToken, files(id, name, modifiedTime, appProperties)',
+    spaces: 'drive',
+    pageSize,
+    pageToken,
+  });
+
+  if (abortSignal?.aborted) {
+    return { files: [], nextPageToken: null };
+  }
+
+  return { files: response.result.files || [], nextPageToken: response.result.nextPageToken || null };
+}
+
+export function useDriveLoadPageState(options = {}) {
+  const fetchImpl = options.fetchImpl || fetch;
+  const driveManager = options.driveManager || getGoogleDriveManagerInstance();
+  const requestDrivePage = options.requestDrivePage || ((params) => defaultRequestDrivePage(driveManager, params));
+  const metadataEndpoint = options.metadataEndpoint || '/api/drive/metadata';
+  const syncEndpoint = options.syncEndpoint || '/api/drive/sync';
+  const { logAndToastError } = useNotifications();
+
+  const items = ref([]);
+  const isLoadingCache = ref(false);
+  const isSyncing = ref(false);
+  const isFetchingMore = ref(false);
+  const errorMessage = ref('');
+  const visibleCount = ref(0);
+  const statusMessage = computed(() => {
+    if (errorMessage.value) return errorMessage.value;
+    if (isSyncing.value) return messages.driveLoadPage.status.syncing;
+    if (isLoadingCache.value) return messages.driveLoadPage.status.loadingCache;
+    return messages.driveLoadPage.status.refreshed;
+  });
+  const displayedItems = computed(() => items.value.slice(0, visibleCount.value));
+  const nextPageToken = ref(null);
+
+  let disposed = false;
+  let fetchedAllPages = false;
+  const abortControllers = new Set();
+  const cacheMap = new Map();
+
+  function handleError(error, context) {
+    const fallbackMessage = messages.driveLoadPage.status.error;
+    const normalized = error instanceof Error ? error : new Error(fallbackMessage);
+    logAndToastError(normalized, { title: messages.driveLoadPage.title, message: fallbackMessage }, context);
+    errorMessage.value = normalized.message || fallbackMessage;
+    return normalized;
+  }
+
+  function getSyncPayload(includeCachedPlaceholders) {
+    const entries = Array.from(cacheMap.values());
+    const source = includeCachedPlaceholders ? entries : entries.filter((item) => !item.cachedOnly);
+    return source.map((entry) => ({
+      id: entry.id,
+      name: entry.syncSource?.name || entry.fileName,
+      modifiedTime:
+        entry.syncSource?.modifiedTime ||
+        (entry.lastModifiedAtDrive ? new Date(entry.lastModifiedAtDrive * 1000).toISOString() : undefined),
+      appProperties:
+        entry.syncSource?.appProperties ||
+        (entry.contentHash || entry.characterName
+          ? { last_app_hash: entry.contentHash || undefined, character_name: entry.characterName || undefined }
+          : undefined),
+    }));
+  }
+
+  function updateItemsFromCacheMap() {
+    const publicItems = Array.from(cacheMap.values()).map((entry) => stripInternal(entry));
+    items.value = sortItems(publicItems);
+    if (visibleCount.value === 0 && items.value.length > 0) {
+      visibleCount.value = Math.min(DISPLAY_BATCH, items.value.length);
+    }
+  }
+
+  function storeItems(list, { cachedOnly = false } = {}) {
+    for (const raw of list) {
+      const normalized = normalizeMetadataItem(raw);
+      if (!normalized) continue;
+      cacheMap.set(normalized.id, {
+        ...normalized,
+        cachedOnly,
+        syncSource: raw.syncSource || buildSyncSource(raw),
+      });
+    }
+    updateItemsFromCacheMap();
+  }
+
+  function removeCachedOnly() {
+    for (const [key, entry] of cacheMap.entries()) {
+      if (entry.cachedOnly) {
+        cacheMap.delete(key);
+      }
+    }
+    updateItemsFromCacheMap();
+  }
+
+  function registerAborter(controller) {
+    abortControllers.add(controller);
+    return controller;
+  }
+
+  function cleanup() {
+    disposed = true;
+    abortControllers.forEach((controller) => controller.abort());
+    abortControllers.clear();
+  }
+
+  function applySyncResponse(syncItems) {
+    if (!Array.isArray(syncItems)) return;
+    const mapped = syncItems.map((item) => ({ ...item, syncSource: buildSyncSource(item) }));
+    storeItems(mapped, { cachedOnly: false });
+  }
+
+  async function postSync(payload) {
+    if (!payload || payload.length === 0) {
+      return [];
+    }
+    const controller = registerAborter(new AbortController());
+    try {
+      const response = await fetchImpl(syncEndpoint, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ files: payload }),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(messages.driveLoadPage.errors.syncFailed);
+      }
+      const data = await response.json();
+      return Array.isArray(data?.items) ? data.items : [];
+    } finally {
+      abortControllers.delete(controller);
+    }
+  }
+
+  async function fetchCachedMetadata() {
+    isLoadingCache.value = true;
+    errorMessage.value = '';
+    const controller = registerAborter(new AbortController());
+    try {
+      const response = await fetchImpl(metadataEndpoint, { credentials: 'include', signal: controller.signal });
+      if (!response.ok) {
+        throw new Error(messages.driveLoadPage.errors.cacheFailed);
+      }
+      const data = await response.json();
+      const incoming = Array.isArray(data?.items) ? data.items : [];
+      storeItems(incoming, { cachedOnly: true });
+    } catch (error) {
+      handleError(error, 'fetchCachedMetadata');
+    } finally {
+      abortControllers.delete(controller);
+      if (!disposed) {
+        isLoadingCache.value = false;
+      }
+    }
+  }
+
+  async function syncFromDrive(pageToken = null) {
+    if (disposed) return;
+    isSyncing.value = true;
+    isFetchingMore.value = Boolean(pageToken);
+    errorMessage.value = '';
+    try {
+      const pageSize = pageToken ? NEXT_PAGE_SIZE : INITIAL_PAGE_SIZE;
+      const { files, nextPageToken: token } = await requestDrivePage({ pageSize, pageToken, abortSignal: null });
+      storeItems(files, { cachedOnly: false });
+      nextPageToken.value = token || null;
+      fetchedAllPages = !token;
+      const payload = getSyncPayload(!fetchedAllPages);
+      const syncItems = await postSync(payload);
+      applySyncResponse(syncItems);
+      if (fetchedAllPages) {
+        removeCachedOnly();
+      }
+    } catch (error) {
+      handleError(error, 'syncFromDrive');
+    } finally {
+      isSyncing.value = false;
+      isFetchingMore.value = false;
+    }
+  }
+
+  function shouldPrefetch() {
+    return !isSyncing.value && !isFetchingMore.value && nextPageToken.value && visibleCount.value + PREFETCH_BUFFER >= items.value.length;
+  }
+
+  async function revealMore() {
+    const nextVisible = Math.min(items.value.length, visibleCount.value + DISPLAY_BATCH);
+    if (nextVisible > visibleCount.value) {
+      visibleCount.value = nextVisible;
+    }
+    if (shouldPrefetch()) {
+      await syncFromDrive(nextPageToken.value);
+    }
+  }
+
+  async function initialize() {
+    disposed = false;
+    visibleCount.value = DISPLAY_BATCH;
+    fetchedAllPages = false;
+    nextPageToken.value = null;
+    cacheMap.clear();
+    items.value = [];
+    await fetchCachedMetadata();
+    syncFromDrive();
+  }
+
+  return {
+    displayedItems,
+    isLoadingCache,
+    isSyncing,
+    isFetchingMore,
+    statusMessage,
+    errorMessage,
+    nextPageToken,
+    initialize,
+    revealMore,
+    cleanup,
+    refresh: () => syncFromDrive(),
+  };
+}

--- a/src/features/cloud-sync/pages/DriveLoadPage.vue
+++ b/src/features/cloud-sync/pages/DriveLoadPage.vue
@@ -19,14 +19,28 @@ const {
   revealMore,
   refresh,
   cleanup,
+  selectCharacter,
 } = useDriveLoadPageState();
 
 const isEmpty = computed(() => !isLoadingCache.value && displayedItems.value.length === 0);
 const isBusy = computed(() => isSyncing.value || isFetchingMore.value);
 const statusLabel = computed(() => statusMessage.value);
+const statusDetail = computed(() => (errorMessage.value ? messages.driveLoadPage.status.retryHint : ''));
 
 function goBackToSheet() {
   router.push({ name: 'character-sheet' });
+}
+
+function onSelectCharacter(fileId) {
+  if (!fileId) return;
+  selectCharacter(fileId);
+  router.push({ name: 'character-sheet' });
+}
+
+function formatHash(hash) {
+  if (!hash) return messages.driveLoadPage.labels.notAvailable;
+  const shortHash = hash.slice(0, 8);
+  return hash.length > 8 ? `${shortHash}...` : shortHash;
 }
 
 function formatTimestamp(seconds) {
@@ -95,11 +109,21 @@ onBeforeUnmount(() => {
           {{ messages.driveLoadPage.buttons.refresh }}
         </button>
       </div>
+      <p v-if="statusDetail" class="drive-load-page__status-detail">{{ statusDetail }}</p>
 
       <p v-if="isEmpty" class="drive-load-page__placeholder">{{ messages.driveLoadPage.placeholder }}</p>
 
       <div v-else class="drive-load-page__list" role="list">
-        <article v-for="item in displayedItems" :key="item.id" class="drive-load-page__card" role="listitem">
+        <button
+          v-for="item in displayedItems"
+          :key="item.id"
+          class="drive-load-page__card"
+          type="button"
+          role="listitem"
+          :aria-label="`${messages.driveLoadPage.labels.selectAction}: ${item.fileName || messages.driveLoadPage.labels.untitled}`"
+          data-test="drive-card"
+          @click="onSelectCharacter(item.id)"
+        >
           <header class="drive-load-page__card-header">
             <div>
               <p class="drive-load-page__file-name">{{ item.fileName || messages.driveLoadPage.labels.untitled }}</p>
@@ -114,10 +138,12 @@ onBeforeUnmount(() => {
             </div>
             <div class="drive-load-page__row">
               <dt>{{ messages.driveLoadPage.labels.hash }}</dt>
-              <dd>{{ item.contentHash || messages.driveLoadPage.labels.notAvailable }}</dd>
+              <dd :title="item.contentHash || messages.driveLoadPage.labels.notAvailable">
+                {{ formatHash(item.contentHash) }}
+              </dd>
             </div>
           </dl>
-        </article>
+        </button>
       </div>
 
       <div ref="sentinelRef" class="drive-load-page__sentinel" aria-hidden="true">
@@ -161,6 +187,12 @@ onBeforeUnmount(() => {
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.drive-load-page__status-detail {
+  margin: 0 0 4px;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
 }
 
 .drive-load-page__status {
@@ -214,6 +246,10 @@ onBeforeUnmount(() => {
 }
 
 .drive-load-page__card {
+  appearance: none;
+  border: none;
+  text-align: left;
+  width: 100%;
   border: 1px solid var(--color-border-muted, #3a3a4a);
   border-radius: 6px;
   padding: 12px;
@@ -221,6 +257,19 @@ onBeforeUnmount(() => {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  color: inherit;
+  cursor: pointer;
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+
+.drive-load-page__card:hover {
+  border-color: var(--color-border-normal);
+  transform: translateY(-1px);
+}
+
+.drive-load-page__card:focus-visible {
+  outline: 2px solid #4da3ff;
+  outline-offset: 2px;
 }
 
 .drive-load-page__card-header {

--- a/src/features/cloud-sync/pages/DriveLoadPage.vue
+++ b/src/features/cloud-sync/pages/DriveLoadPage.vue
@@ -1,28 +1,128 @@
 <script setup>
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { messages } from '@/i18n/index.js';
+import { useDriveLoadPageState } from '@/features/cloud-sync/composables/useDriveLoadPageState.js';
 
 const router = useRouter();
+const sentinelRef = ref(null);
+const observer = ref(null);
+
+const {
+  displayedItems,
+  isLoadingCache,
+  isSyncing,
+  isFetchingMore,
+  statusMessage,
+  errorMessage,
+  initialize,
+  revealMore,
+  refresh,
+  cleanup,
+} = useDriveLoadPageState();
+
+const isEmpty = computed(() => !isLoadingCache.value && displayedItems.value.length === 0);
+const isBusy = computed(() => isSyncing.value || isFetchingMore.value);
+const statusLabel = computed(() => statusMessage.value);
 
 function goBackToSheet() {
   router.push({ name: 'character-sheet' });
 }
+
+function formatTimestamp(seconds) {
+  if (!seconds) return messages.driveLoadPage.labels.unknownDate;
+  const date = new Date(seconds * 1000);
+  if (Number.isNaN(date.getTime())) {
+    return messages.driveLoadPage.labels.unknownDate;
+  }
+  return new Intl.DateTimeFormat('ja-JP', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function setupObserver() {
+  if (!sentinelRef.value) return;
+  if (observer.value) {
+    observer.value.disconnect();
+  }
+
+  observer.value = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          revealMore();
+          break;
+        }
+      }
+    },
+    { rootMargin: '0px 0px 180px 0px', threshold: 0.1 },
+  );
+
+  observer.value.observe(sentinelRef.value);
+}
+
+onMounted(() => {
+  initialize();
+  setupObserver();
+});
+
+onBeforeUnmount(() => {
+  if (observer.value) {
+    observer.value.disconnect();
+  }
+  cleanup();
+});
 </script>
 
 <template>
   <div class="drive-load-page">
     <header class="drive-load-page__header">
       <button class="button-base drive-load-page__back" type="button" @click="goBackToSheet">
-        {{ messages.driveLoadPage.backLabel }}
+        {{ messages.driveLoadPage.buttons.back }}
       </button>
       <h1 class="drive-load-page__title">{{ messages.driveLoadPage.title }}</h1>
     </header>
+
     <section class="drive-load-page__content">
-      <p class="drive-load-page__placeholder">{{ messages.driveLoadPage.placeholder }}</p>
-      <div class="drive-load-page__list" aria-hidden="true">
-        <div class="drive-load-page__list-item" />
-        <div class="drive-load-page__list-item" />
-        <div class="drive-load-page__list-item" />
+      <div class="drive-load-page__status" :data-busy="isBusy">
+        <div class="drive-load-page__status-indicator" :data-state="errorMessage ? 'error' : isSyncing ? 'sync' : 'idle'" />
+        <div class="drive-load-page__status-text">{{ statusLabel }}</div>
+        <button class="button-base drive-load-page__refresh" type="button" :disabled="isBusy" @click="refresh">
+          {{ messages.driveLoadPage.buttons.refresh }}
+        </button>
+      </div>
+
+      <p v-if="isEmpty" class="drive-load-page__placeholder">{{ messages.driveLoadPage.placeholder }}</p>
+
+      <div v-else class="drive-load-page__list" role="list">
+        <article v-for="item in displayedItems" :key="item.id" class="drive-load-page__card" role="listitem">
+          <header class="drive-load-page__card-header">
+            <div>
+              <p class="drive-load-page__file-name">{{ item.fileName || messages.driveLoadPage.labels.untitled }}</p>
+              <p class="drive-load-page__character-name">{{ item.characterName || messages.driveLoadPage.labels.unknownCharacter }}</p>
+            </div>
+            <span v-if="item.outOfSync" class="drive-load-page__badge">{{ messages.driveLoadPage.labels.outOfSync }}</span>
+          </header>
+          <dl class="drive-load-page__details">
+            <div class="drive-load-page__row">
+              <dt>{{ messages.driveLoadPage.labels.modified }}</dt>
+              <dd>{{ formatTimestamp(item.lastModifiedAtDrive) }}</dd>
+            </div>
+            <div class="drive-load-page__row">
+              <dt>{{ messages.driveLoadPage.labels.hash }}</dt>
+              <dd>{{ item.contentHash || messages.driveLoadPage.labels.notAvailable }}</dd>
+            </div>
+          </dl>
+        </article>
+      </div>
+
+      <div ref="sentinelRef" class="drive-load-page__sentinel" aria-hidden="true">
+        <span v-if="isSyncing">{{ messages.driveLoadPage.status.syncing }}</span>
+        <span v-else-if="isFetchingMore">{{ messages.driveLoadPage.status.loadMore }}</span>
       </div>
     </section>
   </div>
@@ -63,6 +163,45 @@ function goBackToSheet() {
   gap: 12px;
 }
 
+.drive-load-page__status {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 1px solid var(--color-border-muted, #3a3a4a);
+  border-radius: 6px;
+  background: var(--color-panel-body, #181824);
+}
+
+.drive-load-page__status-indicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--color-border-muted, #3a3a4a);
+}
+
+.drive-load-page__status-indicator[data-state='sync'] {
+  background: #4da3ff;
+  box-shadow: 0 0 0 6px rgba(77, 163, 255, 0.15);
+}
+
+.drive-load-page__status-indicator[data-state='error'] {
+  background: #ff6b6b;
+  box-shadow: 0 0 0 6px rgba(255, 107, 107, 0.15);
+}
+
+.drive-load-page__status-text {
+  color: var(--color-text-primary);
+  font-weight: 600;
+  min-height: 20px;
+}
+
+.drive-load-page__refresh {
+  justify-self: end;
+  min-width: 120px;
+}
+
 .drive-load-page__placeholder {
   margin: 0;
   color: var(--color-text-muted);
@@ -70,14 +209,75 @@ function goBackToSheet() {
 
 .drive-load-page__list {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 12px;
 }
 
-.drive-load-page__list-item {
-  min-height: 120px;
-  border: 1px dashed var(--color-border-muted, #3a3a4a);
+.drive-load-page__card {
+  border: 1px solid var(--color-border-muted, #3a3a4a);
   border-radius: 6px;
-  background: var(--color-panel-body, #181824);
+  padding: 12px;
+  background: linear-gradient(145deg, rgba(39, 39, 52, 0.9), rgba(26, 26, 36, 0.9));
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.drive-load-page__card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.drive-load-page__file-name {
+  margin: 0;
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.drive-load-page__character-name {
+  margin: 4px 0 0;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.drive-load-page__badge {
+  background: #ffb347;
+  color: #1a1a24;
+  border-radius: 12px;
+  padding: 4px 8px;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.drive-load-page__details {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.drive-load-page__row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.drive-load-page__row dt {
+  color: var(--color-text-muted);
+}
+
+.drive-load-page__row dd {
+  margin: 0;
+  text-align: right;
+  color: var(--color-text-primary);
+}
+
+.drive-load-page__sentinel {
+  min-height: 16px;
+  color: var(--color-text-muted);
+  text-align: center;
+  padding: 4px;
 }
 </style>

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -254,7 +254,33 @@ export const messages = {
   driveLoadPage: {
     title: t('driveLoadPage.title'),
     placeholder: t('driveLoadPage.placeholder'),
-    backLabel: t('driveLoadPage.buttons.back'),
+    buttons: {
+      back: t('driveLoadPage.buttons.back'),
+      refresh: t('driveLoadPage.buttons.refresh'),
+    },
+    status: {
+      loadingCache: t('driveLoadPage.status.loadingCache'),
+      syncing: t('driveLoadPage.status.syncing'),
+      refreshed: t('driveLoadPage.status.refreshed'),
+      loadMore: t('driveLoadPage.status.loadMore'),
+      error: t('driveLoadPage.status.error'),
+    },
+    labels: {
+      untitled: t('driveLoadPage.labels.untitled'),
+      unknownCharacter: t('driveLoadPage.labels.unknownCharacter'),
+      modified: t('driveLoadPage.labels.modified'),
+      hash: t('driveLoadPage.labels.hash'),
+      notAvailable: t('driveLoadPage.labels.notAvailable'),
+      unknownDate: t('driveLoadPage.labels.unknownDate'),
+      outOfSync: t('driveLoadPage.labels.outOfSync'),
+    },
+    errors: {
+      missingDriveManager: t('driveLoadPage.errors.missingDriveManager'),
+      folderUnavailable: t('driveLoadPage.errors.folderUnavailable'),
+      apiUnavailable: t('driveLoadPage.errors.apiUnavailable'),
+      cacheFailed: t('driveLoadPage.errors.cacheFailed'),
+      syncFailed: t('driveLoadPage.errors.syncFailed'),
+    },
   },
   sheet: {
     loadIndicator: {

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -264,6 +264,7 @@ export const messages = {
       refreshed: t('driveLoadPage.status.refreshed'),
       loadMore: t('driveLoadPage.status.loadMore'),
       error: t('driveLoadPage.status.error'),
+      retryHint: t('driveLoadPage.status.retryHint'),
     },
     labels: {
       untitled: t('driveLoadPage.labels.untitled'),
@@ -273,6 +274,7 @@ export const messages = {
       notAvailable: t('driveLoadPage.labels.notAvailable'),
       unknownDate: t('driveLoadPage.labels.unknownDate'),
       outOfSync: t('driveLoadPage.labels.outOfSync'),
+      selectAction: t('driveLoadPage.labels.selectAction'),
     },
     errors: {
       missingDriveManager: t('driveLoadPage.errors.missingDriveManager'),

--- a/src/shared/utils/characterSerialization.js
+++ b/src/shared/utils/characterSerialization.js
@@ -180,7 +180,7 @@ export async function deserializeCharacterPayload(content) {
       try {
         const bytes = isLikelyBase64(content) ? base64ToUint8Array(content) : stringToUint8Array(content);
         return deserializeCharacterPayload(bytes);
-      } catch (nestedError) {
+      } catch {
         throw jsonError;
       }
     }

--- a/tests/unit/components/DriveLoadPage.test.js
+++ b/tests/unit/components/DriveLoadPage.test.js
@@ -1,0 +1,57 @@
+/* @vitest-environment jsdom */
+import { mount } from '@vue/test-utils';
+import { computed, ref } from 'vue';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import DriveLoadPage from '@/features/cloud-sync/pages/DriveLoadPage.vue';
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+let observerCallback;
+class MockIntersectionObserver {
+  constructor(callback) {
+    observerCallback = callback;
+  }
+
+  observe() {}
+  disconnect() {}
+}
+
+global.IntersectionObserver = MockIntersectionObserver;
+
+const revealMore = vi.fn();
+const initialize = vi.fn();
+const refresh = vi.fn();
+const cleanup = vi.fn();
+
+vi.mock('@/features/cloud-sync/composables/useDriveLoadPageState.js', () => {
+  return {
+    useDriveLoadPageState: () => ({
+      displayedItems: ref([]),
+      isLoadingCache: ref(false),
+      isSyncing: ref(false),
+      isFetchingMore: ref(false),
+      statusMessage: computed(() => 'status'),
+      errorMessage: ref(''),
+      initialize,
+      revealMore,
+      refresh,
+      cleanup,
+    }),
+  };
+});
+
+describe('DriveLoadPage', () => {
+  beforeEach(() => {
+    revealMore.mockClear();
+    initialize.mockClear();
+  });
+
+  it('triggers revealMore when the sentinel enters view', async () => {
+    mount(DriveLoadPage);
+    observerCallback?.([{ isIntersecting: true }]);
+    expect(revealMore).toHaveBeenCalled();
+    expect(initialize).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/components/DriveLoadPage.test.js
+++ b/tests/unit/components/DriveLoadPage.test.js
@@ -4,8 +4,10 @@ import { computed, ref } from 'vue';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import DriveLoadPage from '@/features/cloud-sync/pages/DriveLoadPage.vue';
 
+const pushMock = vi.fn();
+
 vi.mock('vue-router', () => ({
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: pushMock }),
 }));
 
 let observerCallback;
@@ -20,15 +22,17 @@ class MockIntersectionObserver {
 
 global.IntersectionObserver = MockIntersectionObserver;
 
+const displayedItems = ref([]);
 const revealMore = vi.fn();
 const initialize = vi.fn();
 const refresh = vi.fn();
 const cleanup = vi.fn();
+const selectCharacter = vi.fn();
 
 vi.mock('@/features/cloud-sync/composables/useDriveLoadPageState.js', () => {
   return {
     useDriveLoadPageState: () => ({
-      displayedItems: ref([]),
+      displayedItems,
       isLoadingCache: ref(false),
       isSyncing: ref(false),
       isFetchingMore: ref(false),
@@ -38,6 +42,7 @@ vi.mock('@/features/cloud-sync/composables/useDriveLoadPageState.js', () => {
       revealMore,
       refresh,
       cleanup,
+      selectCharacter,
     }),
   };
 });
@@ -46,6 +51,9 @@ describe('DriveLoadPage', () => {
   beforeEach(() => {
     revealMore.mockClear();
     initialize.mockClear();
+    selectCharacter.mockClear();
+    pushMock.mockClear();
+    displayedItems.value = [];
   });
 
   it('triggers revealMore when the sentinel enters view', async () => {
@@ -53,5 +61,15 @@ describe('DriveLoadPage', () => {
     observerCallback?.([{ isIntersecting: true }]);
     expect(revealMore).toHaveBeenCalled();
     expect(initialize).toHaveBeenCalled();
+  });
+
+  it('selects a character and navigates back to the sheet', async () => {
+    displayedItems.value = [
+      { id: 'file-1', fileName: 'Sample', characterName: 'Hero', contentHash: 'abcd1234ef', lastModifiedAtDrive: 1000 },
+    ];
+    const wrapper = mount(DriveLoadPage);
+    await wrapper.find('[data-test="drive-card"]').trigger('click');
+    expect(selectCharacter).toHaveBeenCalledWith('file-1');
+    expect(pushMock).toHaveBeenCalledWith({ name: 'character-sheet' });
   });
 });

--- a/tests/unit/composables/useDriveLoadPageState.test.js
+++ b/tests/unit/composables/useDriveLoadPageState.test.js
@@ -1,5 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { effectScope, nextTick } from 'vue';
+import { createPinia, setActivePinia } from 'pinia';
+import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
 import { useDriveLoadPageState } from '@/features/cloud-sync/composables/useDriveLoadPageState.js';
 
 vi.mock('@/features/notifications/composables/useNotifications.js', () => ({
@@ -16,6 +18,10 @@ function createResponse(body) {
 }
 
 describe('useDriveLoadPageState', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
   it('loads cached metadata immediately and starts drive sync', async () => {
     const fetchMock = vi
       .fn()
@@ -86,6 +92,55 @@ describe('useDriveLoadPageState', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     await state.revealMore();
     expect(requestDrivePage).toHaveBeenCalledTimes(2);
+
+    scope.stop();
+  });
+
+  it('cleans up missing files on 404 errors', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse({ items: [{ file_id: '1', file_name: 'Cached', last_modified_at_drive: 1000 }] }))
+      .mockResolvedValue(createResponse({ items: [] }));
+
+    const requestDrivePage = vi.fn().mockRejectedValue({ status: 404, fileId: '1' });
+
+    const driveManager = {
+      findOrCreateConfiguredCharacterFolder: vi.fn().mockResolvedValue('folder'),
+      ensureAccessToken: vi.fn(),
+    };
+
+    const scope = effectScope();
+    scope.run(() => {
+      const state = useDriveLoadPageState({ fetchImpl: fetchMock, requestDrivePage, driveManager });
+      state.initialize();
+    });
+
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(body.files).toEqual([]);
+
+    scope.stop();
+  });
+
+  it('stores the selected file id in the ui store', () => {
+    const fetchMock = vi.fn().mockResolvedValue(createResponse({ items: [] }));
+    const requestDrivePage = vi.fn().mockResolvedValue({ files: [], nextPageToken: null });
+    const driveManager = {
+      findOrCreateConfiguredCharacterFolder: vi.fn().mockResolvedValue('folder'),
+      ensureAccessToken: vi.fn(),
+    };
+
+    const scope = effectScope();
+    let state;
+    scope.run(() => {
+      state = useDriveLoadPageState({ fetchImpl: fetchMock, requestDrivePage, driveManager });
+    });
+
+    const uiStore = useUiStore();
+    state.selectCharacter('abc');
+    expect(uiStore.currentDriveFileId).toBe('abc');
 
     scope.stop();
   });

--- a/tests/unit/composables/useDriveLoadPageState.test.js
+++ b/tests/unit/composables/useDriveLoadPageState.test.js
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import { effectScope, nextTick } from 'vue';
+import { useDriveLoadPageState } from '@/features/cloud-sync/composables/useDriveLoadPageState.js';
+
+vi.mock('@/features/notifications/composables/useNotifications.js', () => ({
+  useNotifications: () => ({
+    logAndToastError: vi.fn(),
+  }),
+}));
+
+function createResponse(body) {
+  return {
+    ok: true,
+    json: async () => body,
+  };
+}
+
+describe('useDriveLoadPageState', () => {
+  it('loads cached metadata immediately and starts drive sync', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse({ items: [{ file_id: '1', file_name: 'Cached', last_modified_at_drive: 1000 }] }))
+      .mockResolvedValue(createResponse({ items: [] }));
+
+    const requestDrivePage = vi.fn().mockResolvedValue({
+      files: [
+        {
+          id: '2',
+          name: 'Drive',
+          modifiedTime: '2024-01-01T00:00:00.000Z',
+          appProperties: { character_name: 'Drive', last_app_hash: 'hash' },
+        },
+      ],
+      nextPageToken: 'next',
+    });
+
+    const driveManager = {
+      findOrCreateConfiguredCharacterFolder: vi.fn().mockResolvedValue('folder'),
+      ensureAccessToken: vi.fn(),
+    };
+
+    const scope = effectScope();
+    let state;
+    scope.run(() => {
+      state = useDriveLoadPageState({ fetchImpl: fetchMock, requestDrivePage, driveManager });
+    });
+
+    await state.initialize();
+    expect(state.displayedItems.value[0].fileName).toBe('Cached');
+    await nextTick();
+    expect(requestDrivePage).toHaveBeenCalledWith({ pageSize: 20, pageToken: null, abortSignal: null });
+
+    scope.stop();
+  });
+
+  it('prefetches the next page when the visible buffer is low', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse({ items: [{ file_id: '1', file_name: 'Cached', last_modified_at_drive: 1000 }] }))
+      .mockResolvedValue(createResponse({ items: [] }));
+
+    const requestDrivePage = vi
+      .fn()
+      .mockResolvedValueOnce({
+        files: Array.from({ length: 2 }).map((_, idx) => ({ id: `${idx + 1}`, name: `Drive ${idx + 1}` })),
+        nextPageToken: 'next-token',
+      })
+      .mockResolvedValueOnce({
+        files: [{ id: '3', name: 'More Data' }],
+        nextPageToken: null,
+      });
+
+    const driveManager = {
+      findOrCreateConfiguredCharacterFolder: vi.fn().mockResolvedValue('folder'),
+      ensureAccessToken: vi.fn(),
+    };
+
+    const scope = effectScope();
+    let state;
+    scope.run(() => {
+      state = useDriveLoadPageState({ fetchImpl: fetchMock, requestDrivePage, driveManager });
+    });
+
+    await state.initialize();
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await state.revealMore();
+    expect(requestDrivePage).toHaveBeenCalledTimes(2);
+
+    scope.stop();
+  });
+});

--- a/tests/unit/imageManager.test.js
+++ b/tests/unit/imageManager.test.js
@@ -1,4 +1,4 @@
-import { describe, it, beforeAll, beforeEach, expect, vi } from 'vitest';
+import { describe, it, beforeAll, beforeEach, expect } from 'vitest';
 
 import { ImageManager } from '@/features/character-sheet/services/imageManager.js';
 import { messages } from '@/i18n/index.js';


### PR DESCRIPTION
## Summary
- implement DriveLoadPage logic for cached metadata, background Drive sync, and infinite scroll buffering
- add reusable composable plus localization strings to support sync status and error handling
- cover new loader behavior with unit tests and keep linting clean

## Testing
- npm test
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943e15c6b008326982880ca83a55133)