### PR TITLE
Persist Drive file id across reloads and reset viewing mode

### DIFF
--- a/src/features/character-sheet/composables/useLocalCharacterPersistence.js
+++ b/src/features/character-sheet/composables/useLocalCharacterPersistence.js
@@ -1,4 +1,4 @@
-import { watch, onMounted } from 'vue';
+import { watch } from 'vue';
 
 export const LOCAL_CHARACTER_STORAGE_KEY = 'aionia-character';
 
@@ -35,6 +35,7 @@ export function useLocalCharacterPersistence(characterStore, uiStore, options = 
       specialSkills: characterStore.specialSkills,
       equipments: characterStore.equipments,
       histories: characterStore.histories,
+      currentDriveFileId: uiStore.currentDriveFileId,
     };
     try {
       storage.setItem(storageKey, JSON.stringify(payload));
@@ -85,6 +86,9 @@ export function useLocalCharacterPersistence(characterStore, uiStore, options = 
       }
       if (Array.isArray(parsed.histories)) {
         characterStore.histories.splice(0, characterStore.histories.length, ...parsed.histories);
+      }
+      if (Object.prototype.hasOwnProperty.call(parsed, 'currentDriveFileId')) {
+        uiStore.setCurrentDriveFileId(parsed.currentDriveFileId);
       }
       return true;
     } catch (error) {

--- a/src/features/character-sheet/composables/useLocalCharacterPersistence.js
+++ b/src/features/character-sheet/composables/useLocalCharacterPersistence.js
@@ -123,6 +123,13 @@ export function useLocalCharacterPersistence(characterStore, uiStore, options = 
     },
   );
 
+  const stopDriveFileWatch = watch(
+    () => uiStore.currentDriveFileId,
+    () => {
+      schedulePersist();
+    },
+  );
+
   const stop = () => {
     if (debounceHandle) {
       clearTimeout(debounceHandle);
@@ -130,6 +137,7 @@ export function useLocalCharacterPersistence(characterStore, uiStore, options = 
     }
     stopPersistenceWatch?.();
     stopSharedWatch?.();
+    stopDriveFileWatch?.();
   };
 
   return {

--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -172,6 +172,7 @@ export function useGoogleDrive(dataManager) {
             Object.assign(characterStore.equipments, parsedData.equipments);
             characterStore.histories.splice(0, characterStore.histories.length, ...parsedData.histories);
             uiStore.setCurrentDriveFileId(file.id);
+            uiStore.isViewingShared = false;
             removeStoredCharacterDraft();
             uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
             return parsedData;

--- a/tests/unit/composables/useGoogleDrive.test.js
+++ b/tests/unit/composables/useGoogleDrive.test.js
@@ -95,6 +95,35 @@ describe('useGoogleDrive', () => {
     expect(uiStore.lastSavedSnapshot).toBe(buildSnapshotFromStore(charStore));
   });
 
+  test('loadCharacterFromDrive clears viewing mode after loading own file', async () => {
+    const loadData = {
+      character: { name: 'Owner' },
+      skills: [],
+      specialSkills: [],
+      equipments: {},
+      histories: [],
+    };
+    const dataManager = {
+      saveCharacterToDrive: vi.fn(),
+      loadDataFromDrive: vi.fn().mockResolvedValue(loadData),
+      googleDriveManager: {
+        showFilePicker: (cb) => cb(null, { id: 'file-2', name: 'Owner.json' }),
+        findOrCreateConfiguredCharacterFolder: vi.fn().mockResolvedValue('folder-id'),
+      },
+      getDriveFileName: vi.fn().mockReturnValue('Owner.json'),
+    };
+
+    const { loadCharacterFromDrive } = useGoogleDrive(dataManager);
+    const uiStore = useUiStore();
+    uiStore.isGapiInitialized = true;
+    uiStore.isSignedIn = true;
+    uiStore.isViewingShared = true;
+
+    await loadCharacterFromDrive();
+
+    expect(uiStore.isViewingShared).toBe(false);
+  });
+
   test('promptForDriveFolder applies picker selection to drive path', async () => {
     const desiredPath = '慈悲なきアイオニア/PC/第一キャンペーン';
     const stubManager = createDriveManagerStub(desiredPath);

--- a/tests/unit/composables/useLocalCharacterPersistence.test.js
+++ b/tests/unit/composables/useLocalCharacterPersistence.test.js
@@ -111,6 +111,17 @@ describe('useLocalCharacterPersistence', () => {
     expect(saved.currentDriveFileId).toBe('drive-file-2');
   });
 
+  test('persists currentDriveFileId when it changes independently', async () => {
+    const { uiStore } = mountComposable();
+
+    uiStore.setCurrentDriveFileId('drive-file-only-change');
+    await nextTick();
+    vi.runAllTimers();
+
+    const saved = JSON.parse(storage.getItem(LOCAL_CHARACTER_STORAGE_KEY));
+    expect(saved.currentDriveFileId).toBe('drive-file-only-change');
+  });
+
   test('skips persistence when viewing shared sheet', async () => {
     const { characterStore, uiStore } = mountComposable();
     uiStore.isViewingShared = true;

--- a/tests/unit/composables/useLocalCharacterPersistence.test.js
+++ b/tests/unit/composables/useLocalCharacterPersistence.test.js
@@ -74,6 +74,7 @@ describe('useLocalCharacterPersistence', () => {
       specialSkills: [{ group: 'tactics', name: '隠密', note: '', showNote: false }],
       equipments: { weapon1: { group: 'sword', name: '剣' } },
       histories: [{ sessionName: 'Session 1', memo: 'notes' }],
+      currentDriveFileId: 'drive-file-1',
     };
     storage.setItem(LOCAL_CHARACTER_STORAGE_KEY, JSON.stringify(payload));
     const { characterStore } = mountComposable();
@@ -83,6 +84,7 @@ describe('useLocalCharacterPersistence', () => {
     expect(characterStore.specialSkills[0].name).toBe('隠密');
     expect(characterStore.equipments.weapon1.name).toBe('剣');
     expect(characterStore.histories[0].sessionName).toBe('Session 1');
+    expect(useUiStore().currentDriveFileId).toBe('drive-file-1');
   });
 
   test('persists changes with debounce to localStorage', async () => {
@@ -95,6 +97,18 @@ describe('useLocalCharacterPersistence', () => {
     expect(storage.setItem).toHaveBeenCalled();
     const saved = JSON.parse(storage.getItem(LOCAL_CHARACTER_STORAGE_KEY));
     expect(saved.character.name).toBe('Auto Save');
+  });
+
+  test('persists currentDriveFileId along with character data', async () => {
+    const { characterStore, uiStore } = mountComposable();
+    uiStore.setCurrentDriveFileId('drive-file-2');
+
+    characterStore.character.name = 'Linked Save';
+    await nextTick();
+    vi.runAllTimers();
+
+    const saved = JSON.parse(storage.getItem(LOCAL_CHARACTER_STORAGE_KEY));
+    expect(saved.currentDriveFileId).toBe('drive-file-2');
   });
 
   test('skips persistence when viewing shared sheet', async () => {


### PR DESCRIPTION
## Summary
- persist the current Google Drive file id alongside local character drafts and restore it during hydration
- clear shared-viewing mode after loading a character from Drive so personal files are editable
- add unit coverage for drive id persistence and viewing mode reset scenarios

## Testing
- npm run lint
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943e523af608326b113987e0b88c088)