### PR TITLE
Remove legacy Drive picker flow

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -43,7 +43,6 @@ const {
   handleSignOutClick,
   saveCharacterToDrive,
   loadCharacterFromDrive,
-  promptForDriveFolder,
   updateDriveFolderPath,
 } = useGoogleDrive(dataManager);
 
@@ -114,8 +113,6 @@ const { openLoadModal, openIoModal, openShareModal } = useAppModals({
   copyEditCallback: () => {
     uiStore.isViewingShared = false;
   },
-  loadCharacterFromDrive,
-  promptForDriveFolder,
   updateDriveFolderPath,
   canSignInToGoogle,
   isDriveReady,
@@ -152,6 +149,18 @@ watch(
     } else {
       document.body.classList.remove('is-modal-open');
     }
+  },
+);
+
+const lastLoadedDriveId = ref(uiStore.currentDriveFileId);
+watch(
+  () => uiStore.currentDriveFileId,
+  async (id) => {
+    if (!id || id === lastLoadedDriveId.value) {
+      return;
+    }
+    lastLoadedDriveId.value = id;
+    await loadCharacterFromDrive(id);
   },
 );
 

--- a/src/contents/ui_messages.csv
+++ b/src/contents/ui_messages.csv
@@ -4,10 +4,6 @@ googleDrive.auth.connected.title,Google Drive,,Drive auth connected title
 googleDrive.auth.connected.message,接続しました,,Drive auth connected body
 googleDrive.signOut.success.title,サインアウトしました,,Drive sign out success title
 googleDrive.signOut.success.message,,,Drive sign out success body (empty)
-googleDrive.folderPicker.unavailable.title,Google Drive,,Drive folder picker unavailable title
-googleDrive.folderPicker.unavailable.message,フォルダピッカーを利用できません,,Drive folder picker unavailable body
-googleDrive.folderPicker.error.title,Google Drive,,Drive folder picker error title
-googleDrive.folderPicker.error.message,フォルダ選択をキャンセルしました,,Drive folder picker default error body
 googleDrive.save.loading.title,Google Drive,,Drive save loading title
 googleDrive.save.loading.message,保存中...,,Drive save loading body
 googleDrive.save.newLoading.title,新規キャラクター,,Drive save new character loading title
@@ -119,9 +115,14 @@ driveLoadPage.labels.untitled,無題のファイル,,Drive load page untitled la
 driveLoadPage.labels.unknownCharacter,キャラクター名未設定,,Drive load page unknown character label
 driveLoadPage.labels.modified,更新日時,,Drive load page modified label
 driveLoadPage.labels.hash,ハッシュ,,Drive load page hash label
+driveLoadPage.labels.driveHash,Drive上のハッシュ,,Drive load page drive hash label
+driveLoadPage.labels.cachedHash,キャッシュのハッシュ,,Drive load page cached hash label
 driveLoadPage.labels.notAvailable,なし,,Drive load page not available label
 driveLoadPage.labels.unknownDate,日時不明,,Drive load page unknown date label
 driveLoadPage.labels.outOfSync,要同期,,Drive load page out-of-sync badge
+driveLoadPage.labels.hashWarning,ハッシュが一致しません。外部で編集された可能性があります,,Drive load page hash mismatch warning
+driveLoadPage.labels.shared,共有中,,Drive load page shared badge
+driveLoadPage.labels.sharedAria,このファイルは共有されています,,Drive load page shared aria label
 driveLoadPage.labels.selectAction,このキャラクターを開く,,Drive load page select card aria label
 driveLoadPage.errors.missingDriveManager,Driveの初期化が完了していません,,Drive load page missing manager error
 driveLoadPage.errors.folderUnavailable,キャラクターフォルダにアクセスできません,,Drive load page folder unavailable error

--- a/src/features/cloud-sync/composables/useDriveLoadPageState.js
+++ b/src/features/cloud-sync/composables/useDriveLoadPageState.js
@@ -9,6 +9,18 @@ const PREFETCH_BUFFER = 10;
 const INITIAL_PAGE_SIZE = 20;
 const NEXT_PAGE_SIZE = 10;
 
+function toSeconds(value) {
+  if (value == null) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value >= 1_000_000_000_000 ? Math.floor(value / 1000) : Math.floor(value);
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return Math.floor(date.getTime() / 1000);
+}
+
 export function normalizeMetadataItem(raw) {
   const id = raw?.fileId || raw?.file_id || raw?.id;
   if (!id) return null;
@@ -16,27 +28,59 @@ export function normalizeMetadataItem(raw) {
   const characterName =
     raw?.characterName || raw?.character_name || raw?.appProperties?.character_name || raw?.app_properties?.character_name || '';
   const fileName = raw?.fileName || raw?.file_name || raw?.name || '';
-  const contentHash =
-    raw?.contentHash || raw?.content_hash || raw?.appProperties?.last_app_hash || raw?.app_properties?.last_app_hash || null;
-  const modified = raw?.lastModifiedAtDrive || raw?.last_modified_at_drive || raw?.modifiedTime;
-  const lastModifiedAtDrive = modified ? Math.floor(new Date(modified).getTime() / 1000) : null;
+  const driveHash = raw?.appProperties?.last_app_hash || raw?.app_properties?.last_app_hash || null;
+  const cachedHash = raw?.contentHash || raw?.content_hash || null;
+  const driveModifiedAt = toSeconds(raw?.modifiedTime);
+  const cachedModifiedAt = toSeconds(raw?.lastModifiedAtDrive || raw?.last_modified_at_drive);
   const syncedAt = raw?.syncedAt || raw?.synced_at || null;
+  const shared = Boolean(raw?.shared);
   const outOfSync = Boolean(raw?.outOfSync || raw?.out_of_sync || raw?.hashMismatch || raw?.modifiedMismatch);
+  const lastModifiedAtDrive = driveModifiedAt ?? cachedModifiedAt;
+  const contentHash = driveHash || cachedHash || null;
 
-  return { id, characterName, fileName, contentHash, lastModifiedAtDrive, syncedAt, outOfSync };
+  return {
+    id,
+    characterName,
+    fileName,
+    driveHash,
+    cachedHash,
+    contentHash,
+    driveModifiedAt,
+    cachedModifiedAt,
+    lastModifiedAtDrive,
+    syncedAt,
+    shared,
+    outOfSync,
+  };
+}
+
+function determineOutOfSync(entry) {
+  if (!entry) return false;
+  if (entry.outOfSync) return true;
+  const driveHash = entry.driveHash;
+  const cachedHash = entry.cachedHash;
+  if (driveHash && cachedHash && driveHash !== cachedHash) return true;
+
+  const driveModifiedAt = entry.driveModifiedAt;
+  const baselineModifiedAt = entry.cachedModifiedAt ?? entry.syncedAt ?? null;
+  if (driveModifiedAt && baselineModifiedAt && driveModifiedAt > baselineModifiedAt) {
+    return true;
+  }
+  return false;
 }
 
 function buildSyncSource(item) {
   const normalized = normalizeMetadataItem(item);
   if (!normalized) return null;
+  const lastAppHash = normalized.driveHash || normalized.cachedHash || normalized.contentHash || null;
   return {
     id: normalized.id,
     name: normalized.fileName,
     modifiedTime: normalized.lastModifiedAtDrive ? new Date(normalized.lastModifiedAtDrive * 1000).toISOString() : undefined,
     appProperties:
-      normalized.contentHash || normalized.characterName
+      lastAppHash || normalized.characterName
         ? {
-            last_app_hash: normalized.contentHash || undefined,
+            last_app_hash: lastAppHash || undefined,
             character_name: normalized.characterName || undefined,
           }
         : undefined,
@@ -87,13 +131,14 @@ async function defaultRequestDrivePage(driveManager, { pageSize, pageToken, abor
 
   const response = await gapi.client.drive.files.list({
     q: `'${folderId}' in parents and mimeType='application/json' and trashed=false`,
-    fields: 'nextPageToken, files(id, name, modifiedTime, appProperties)',
+    fields: 'nextPageToken, files(id, name, modifiedTime, appProperties, shared)',
     spaces: 'drive',
     pageSize,
     pageToken,
   });
 
   return { files: response.result.files || [], nextPageToken: response.result.nextPageToken || null };
+}
 
 export function useDriveLoadPageState(options = {}) {
   const fetchImpl = options.fetchImpl || fetch;
@@ -161,11 +206,23 @@ export function useDriveLoadPageState(options = {}) {
     for (const raw of list) {
       const normalized = normalizeMetadataItem(raw);
       if (!normalized) continue;
-      cacheMap.set(normalized.id, {
+      const existing = cacheMap.get(normalized.id) || {};
+      const merged = {
+        ...existing,
         ...normalized,
         cachedOnly,
-        syncSource: raw.syncSource || buildSyncSource(raw),
-      });
+        contentHash: normalized.contentHash ?? existing.contentHash ?? null,
+        driveHash: normalized.driveHash ?? existing.driveHash ?? null,
+        cachedHash: normalized.cachedHash ?? existing.cachedHash ?? null,
+        driveModifiedAt: normalized.driveModifiedAt ?? existing.driveModifiedAt ?? null,
+        cachedModifiedAt: normalized.cachedModifiedAt ?? existing.cachedModifiedAt ?? null,
+        lastModifiedAtDrive: normalized.lastModifiedAtDrive ?? existing.lastModifiedAtDrive ?? null,
+        syncedAt: normalized.syncedAt ?? existing.syncedAt ?? null,
+        shared: normalized.shared ?? existing.shared ?? false,
+      };
+      merged.outOfSync = determineOutOfSync(merged);
+      merged.syncSource = existing.syncSource || raw.syncSource || buildSyncSource(raw);
+      cacheMap.set(normalized.id, merged);
     }
     updateItemsFromCacheMap();
   }

--- a/src/features/cloud-sync/composables/useDriveLoadPageState.js
+++ b/src/features/cloud-sync/composables/useDriveLoadPageState.js
@@ -33,7 +33,7 @@ export function normalizeMetadataItem(raw) {
   const driveModifiedAt = toSeconds(raw?.modifiedTime);
   const cachedModifiedAt = toSeconds(raw?.lastModifiedAtDrive || raw?.last_modified_at_drive);
   const syncedAt = raw?.syncedAt || raw?.synced_at || null;
-  const shared = Boolean(raw?.shared);
+  const shared = raw?.shared == null ? null : Boolean(raw.shared);
   const outOfSync = Boolean(raw?.outOfSync || raw?.out_of_sync || raw?.hashMismatch || raw?.modifiedMismatch);
   const lastModifiedAtDrive = driveModifiedAt ?? cachedModifiedAt;
   const contentHash = driveHash || cachedHash || null;

--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -69,33 +69,6 @@ export function useGoogleDrive(dataManager) {
     showToast({ type: 'success', ...messages.googleDrive.signOut.success() });
   }
 
-  async function promptForDriveFolder() {
-    if (!uiStore.isSignedIn) {
-      showToast({ type: 'error', ...messages.googleDrive.config.requiresSignIn() });
-      return uiStore.driveFolderPath;
-    }
-    const gdm = dataManager.googleDriveManager;
-    if (!gdm || typeof gdm.showFolderPicker !== 'function') {
-      const pickerError = new Error(messages.googleDrive.folderPicker.unavailable().message);
-      logAndToastError(pickerError, () => messages.googleDrive.folderPicker.unavailable(), 'promptForDriveFolder');
-      return uiStore.driveFolderPath;
-    }
-
-    return new Promise((resolve) => {
-      gdm.showFolderPicker(async (err, folder) => {
-        if (err || !folder) {
-          const pickerError = err || new Error(messages.googleDrive.folderPicker.error().message);
-          logAndToastError(pickerError, (caught) => messages.googleDrive.folderPicker.error(caught), 'promptForDriveFolder');
-          resolve(uiStore.driveFolderPath);
-          return;
-        }
-        const targetPath = folder.path || folder.name;
-        const normalized = await updateDriveFolderPath(targetPath);
-        resolve(normalized);
-      });
-    });
-  }
-
   async function refreshDriveFolderPath() {
     if (!googleDriveManager.value || !uiStore.isSignedIn) {
       return;
@@ -142,57 +115,51 @@ export function useGoogleDrive(dataManager) {
     }
   }
 
-  async function loadCharacterFromDrive() {
+  async function loadCharacterFromDrive(fileId = uiStore.currentDriveFileId) {
     if (!isDriveReady.value) {
       showToast({ type: 'error', ...messages.googleDrive.initPending() });
       return null;
     }
     if (!dataManager.googleDriveManager) return null;
 
-    const folderId = await dataManager.googleDriveManager.findOrCreateConfiguredCharacterFolder();
+    const targetId = fileId || uiStore.currentDriveFileId;
+    if (!targetId) {
+      showToast({ type: 'error', ...messages.googleDrive.load.noSelection() });
+      return null;
+    }
 
-    return new Promise((resolve) => {
-      dataManager.googleDriveManager.showFilePicker(
-        (err, file) => {
-          if (err || !file) {
-            const pickerError = err || new Error(messages.googleDrive.load.noSelection().message);
-            const toastFactory = err ? (caught) => messages.googleDrive.load.error(caught) : () => messages.googleDrive.load.noSelection();
-            logAndToastError(pickerError, toastFactory, 'loadCharacterFromDrive');
-            resolve(null);
-            return;
-          }
+    const loadPromise = dataManager
+      .loadDataFromDrive(targetId)
+      .then((parsedData) => {
+        if (!parsedData) {
+          throw new Error(messages.googleDrive.load.missingData().message);
+        }
+        Object.assign(characterStore.character, parsedData.character);
+        characterStore.skills.splice(0, characterStore.skills.length, ...parsedData.skills);
+        characterStore.specialSkills.splice(0, characterStore.specialSkills.length, ...parsedData.specialSkills);
+        Object.assign(characterStore.equipments, parsedData.equipments);
+        characterStore.histories.splice(0, characterStore.histories.length, ...parsedData.histories);
+        uiStore.setCurrentDriveFileId(targetId);
+        removeStoredCharacterDraft();
+        uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
+        return parsedData;
+      })
+      .catch((err) => {
+        logAndToastError(err, (caught) => messages.googleDrive.load.error(caught), 'loadCharacterFromDrive');
+        return null;
+      });
 
-          const loadPromise = dataManager.loadDataFromDrive(file.id).then((parsedData) => {
-            if (!parsedData) {
-              throw new Error(messages.googleDrive.load.missingData().message);
-            }
-            Object.assign(characterStore.character, parsedData.character);
-            characterStore.skills.splice(0, characterStore.skills.length, ...parsedData.skills);
-            characterStore.specialSkills.splice(0, characterStore.specialSkills.length, ...parsedData.specialSkills);
-            Object.assign(characterStore.equipments, parsedData.equipments);
-            characterStore.histories.splice(0, characterStore.histories.length, ...parsedData.histories);
-            uiStore.setCurrentDriveFileId(file.id);
-            removeStoredCharacterDraft();
-            uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
-            return parsedData;
-          });
+    showAsyncToast(
+      loadPromise,
+      {
+        loading: messages.googleDrive.load.loading(targetId),
+        success: messages.googleDrive.load.success(targetId),
+        error: (loadErr) => messages.googleDrive.load.error(loadErr),
+      },
+      'loadCharacterFromDrive',
+    );
 
-          showAsyncToast(
-            loadPromise,
-            {
-              loading: messages.googleDrive.load.loading(file.name),
-              success: messages.googleDrive.load.success(file.name),
-              error: (loadErr) => messages.googleDrive.load.error(loadErr),
-            },
-            'loadCharacterFromDrive',
-          );
-
-          loadPromise.then((result) => resolve(result)).catch(() => resolve(null));
-        },
-        folderId,
-        ['application/json', 'application/zip'],
-      );
-    });
+    return loadPromise;
   }
 
   async function saveCharacterToDrive(option = false) {
@@ -331,7 +298,6 @@ export function useGoogleDrive(dataManager) {
     isDriveReady,
     handleSignInClick,
     handleSignOutClick,
-    promptForDriveFolder,
     refreshDriveFolderPath,
     updateDriveFolderPath,
     loadCharacterFromDrive,

--- a/src/features/cloud-sync/pages/DriveLoadPage.vue
+++ b/src/features/cloud-sync/pages/DriveLoadPage.vue
@@ -129,7 +129,18 @@ onBeforeUnmount(() => {
               <p class="drive-load-page__file-name">{{ item.fileName || messages.driveLoadPage.labels.untitled }}</p>
               <p class="drive-load-page__character-name">{{ item.characterName || messages.driveLoadPage.labels.unknownCharacter }}</p>
             </div>
-            <span v-if="item.outOfSync" class="drive-load-page__badge">{{ messages.driveLoadPage.labels.outOfSync }}</span>
+            <div class="drive-load-page__indicators" aria-live="polite">
+              <span
+                v-if="item.shared"
+                class="drive-load-page__badge drive-load-page__badge--muted"
+                :aria-label="messages.driveLoadPage.labels.sharedAria"
+              >
+                {{ messages.driveLoadPage.labels.shared }}
+              </span>
+              <span v-if="item.outOfSync" class="drive-load-page__badge drive-load-page__badge--warning" role="status">
+                {{ messages.driveLoadPage.labels.outOfSync }}
+              </span>
+            </div>
           </header>
           <dl class="drive-load-page__details">
             <div class="drive-load-page__row">
@@ -137,12 +148,21 @@ onBeforeUnmount(() => {
               <dd>{{ formatTimestamp(item.lastModifiedAtDrive) }}</dd>
             </div>
             <div class="drive-load-page__row">
-              <dt>{{ messages.driveLoadPage.labels.hash }}</dt>
-              <dd :title="item.contentHash || messages.driveLoadPage.labels.notAvailable">
-                {{ formatHash(item.contentHash) }}
+              <dt>{{ messages.driveLoadPage.labels.driveHash }}</dt>
+              <dd :title="item.driveHash || messages.driveLoadPage.labels.notAvailable">
+                {{ formatHash(item.driveHash) }}
+              </dd>
+            </div>
+            <div class="drive-load-page__row">
+              <dt>{{ messages.driveLoadPage.labels.cachedHash }}</dt>
+              <dd :title="item.cachedHash || messages.driveLoadPage.labels.notAvailable">
+                {{ formatHash(item.cachedHash) }}
               </dd>
             </div>
           </dl>
+          <p v-if="item.outOfSync" class="drive-load-page__warning" role="status">
+            {{ messages.driveLoadPage.labels.hashWarning }}
+          </p>
         </button>
       </div>
 
@@ -279,6 +299,12 @@ onBeforeUnmount(() => {
   gap: 8px;
 }
 
+.drive-load-page__indicators {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
 .drive-load-page__file-name {
   margin: 0;
   font-weight: 700;
@@ -298,6 +324,17 @@ onBeforeUnmount(() => {
   padding: 4px 8px;
   font-size: 0.75rem;
   font-weight: 700;
+}
+
+.drive-load-page__badge--warning {
+  background: #ff6b6b;
+  color: #1a1a24;
+}
+
+.drive-load-page__badge--muted {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border-muted, #3a3a4a);
 }
 
 .drive-load-page__details {
@@ -321,6 +358,16 @@ onBeforeUnmount(() => {
   margin: 0;
   text-align: right;
   color: var(--color-text-primary);
+}
+
+.drive-load-page__warning {
+  margin: 4px 0 0;
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 107, 107, 0.4);
+  background: rgba(255, 107, 107, 0.08);
+  color: #ffdede;
+  font-size: 0.9rem;
 }
 
 .drive-load-page__sentinel {

--- a/src/features/modals/components/contents/LoadModal.vue
+++ b/src/features/modals/components/contents/LoadModal.vue
@@ -7,15 +7,7 @@
       </button>
     </section>
     <section class="load-modal__section load-modal__section--drive">
-      <button class="button-base load-modal__button" v-if="canUseDrive" data-test="load-modal-drive-button" @click="$emit('load-drive')">
-        {{ loadDriveLabel }}
-      </button>
-      <button
-        class="button-base load-modal__button load-modal__button--secondary"
-        type="button"
-        data-test="load-modal-select-character"
-        @click="$emit('select-character')"
-      >
+      <button class="button-base load-modal__button" type="button" :disabled="!canUseDrive" data-test="load-modal-select-character" @click="$emit('select-character')">
         {{ selectCharacterLabel }}
       </button>
       <div class="load-modal__config">
@@ -31,14 +23,6 @@
             @blur="commitFolderPath"
             @keyup.enter.prevent="commitFolderPath"
           />
-          <button
-            type="button"
-            class="button-base load-modal__change-button"
-            :disabled="isFolderPickerDisabled"
-            @click="$emit('choose-drive-folder')"
-          >
-            {{ changeFolderLabel }}
-          </button>
         </div>
       </div>
     </section>
@@ -61,9 +45,7 @@ const props = defineProps({
   driveFolderPath: String,
   driveFolderLabel: String,
   driveFolderPlaceholder: String,
-  changeFolderLabel: String,
   loadLocalLabel: String,
-  loadDriveLabel: String,
   selectCharacterLabel: String,
   signInLabel: String,
   signInMessage: String,
@@ -71,10 +53,8 @@ const props = defineProps({
 
 const emit = defineEmits([
   'load-local',
-  'load-drive',
   'sign-in',
   'update-drive-folder-path',
-  'choose-drive-folder',
   'select-character',
 ]);
 
@@ -99,7 +79,6 @@ watch(
 
 const canUseDrive = computed(() => props.isSignedIn && props.isDriveReady);
 const isDriveControlsDisabled = computed(() => !props.isSignedIn);
-const isFolderPickerDisabled = computed(() => !canUseDrive.value);
 
 function commitFolderPath() {
   if (!props.isSignedIn) {
@@ -150,11 +129,6 @@ function handleLocalChange(event) {
   font-weight: 600;
 }
 
-.load-modal__input-group {
-  display: flex;
-  width: 100%;
-}
-
 .load-modal__input {
   flex: 1;
   padding: 8px 10px;
@@ -167,11 +141,6 @@ function handleLocalChange(event) {
 .load-modal__input:disabled {
   opacity: 0.6;
   cursor: not-allowed;
-}
-
-.load-modal__change-button {
-  border-radius: 0 4px 4px 0;
-  padding-inline: 12px;
 }
 
 .load-modal__section--local {

--- a/src/features/modals/composables/useAppModals.js
+++ b/src/features/modals/composables/useAppModals.js
@@ -25,8 +25,6 @@ export function useAppModals(options) {
     printCharacterSheet,
     openPreviewPage,
     copyEditCallback,
-    loadCharacterFromDrive,
-    promptForDriveFolder,
     updateDriveFolderPath,
     canSignInToGoogle,
     isDriveReady,
@@ -40,9 +38,7 @@ export function useAppModals(options) {
       driveFolderPath: uiStore.driveFolderPath,
       driveFolderLabel: messages.characterHub.driveFolder.label,
       driveFolderPlaceholder: messages.characterHub.driveFolder.placeholder,
-      changeFolderLabel: messages.characterHub.driveFolder.changeButton,
       loadLocalLabel: messages.ui.modal.load.buttons.loadLocal,
-      loadDriveLabel: messages.ui.modal.load.buttons.loadDrive,
       selectCharacterLabel: messages.ui.modal.load.buttons.selectCharacter,
       signInLabel: messages.characterHub.buttons.signIn,
       signInMessage: messages.ui.modal.load.signInMessage,
@@ -55,10 +51,8 @@ export function useAppModals(options) {
       buttons: [],
       on: {
         'load-local': handleFileUpload,
-        'load-drive': loadCharacterFromDrive,
         'sign-in': handleSignInClick,
         'update-drive-folder-path': updateDriveFolderPath,
-        'choose-drive-folder': promptForDriveFolder,
         'select-character': () => {
           modalStore.resolveModal({ value: 'drive-load' });
           router.push({ name: 'drive-load' });

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -27,16 +27,6 @@ export const messages = {
         message: t('googleDrive.signOut.success.message'),
       }),
     },
-    folderPicker: {
-      unavailable: () => ({
-        title: t('googleDrive.folderPicker.unavailable.title'),
-        message: t('googleDrive.folderPicker.unavailable.message'),
-      }),
-      error: (err) => ({
-        title: t('googleDrive.folderPicker.error.title'),
-        message: err?.message || t('googleDrive.folderPicker.error.message'),
-      }),
-    },
     save: {
       loading: () => ({
         title: t('googleDrive.save.loading.title'),
@@ -271,9 +261,14 @@ export const messages = {
       unknownCharacter: t('driveLoadPage.labels.unknownCharacter'),
       modified: t('driveLoadPage.labels.modified'),
       hash: t('driveLoadPage.labels.hash'),
+      driveHash: t('driveLoadPage.labels.driveHash'),
+      cachedHash: t('driveLoadPage.labels.cachedHash'),
       notAvailable: t('driveLoadPage.labels.notAvailable'),
       unknownDate: t('driveLoadPage.labels.unknownDate'),
       outOfSync: t('driveLoadPage.labels.outOfSync'),
+      hashWarning: t('driveLoadPage.labels.hashWarning'),
+      shared: t('driveLoadPage.labels.shared'),
+      sharedAria: t('driveLoadPage.labels.sharedAria'),
       selectAction: t('driveLoadPage.labels.selectAction'),
     },
     errors: {

--- a/src/infrastructure/google-drive/googleDriveManager.js
+++ b/src/infrastructure/google-drive/googleDriveManager.js
@@ -106,7 +106,6 @@ export class GoogleDriveManager {
     this.discoveryDocs = ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'];
     this.scope = 'https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive.file';
     this.gapiLoadedCallback = null;
-    this.pickerApiLoaded = false;
     this.aioniaFolderId = null;
     this.gapiLoadPromise = null;
     this.currentTokenInfo = null;
@@ -297,7 +296,8 @@ export class GoogleDriveManager {
         console.error('GDM: ' + err.message);
         return reject(err);
       }
-      gapi.load('client:picker', () => {
+      // Picker API removed; initialize only the Drive client for in-app loaders.
+      gapi.load('client', () => {
         if (typeof gapi.client === 'undefined' || !gapi.client.init) {
           const err = new Error('GAPI client script not available for gapi.client.init.');
           console.error('GDM: ' + err.message);
@@ -310,8 +310,7 @@ export class GoogleDriveManager {
             // scope: this.scope, // Scope is handled by GIS token client for Drive data access
           })
           .then(() => {
-            this.pickerApiLoaded = true;
-            console.log('GDM: GAPI client and Picker initialized.');
+            console.log('GDM: GAPI client initialized.');
             resolve();
           })
           .catch((error) => {
@@ -895,125 +894,6 @@ export class GoogleDriveManager {
       console.error('Failed to fetch share link from Drive:', error);
       return null;
     }
-  }
-
-  /**
-   * Shows the Google File Picker to select a file.
-   * @param {function} callback - Function to call with the result (error, {id, name}).
-   * @param {string|null} parentFolderId - Optional ID of the folder to start in.
-   * @param {Array<string>} mimeTypes - Array of MIME types to filter by.
-   */
-  async showFilePicker(callback, parentFolderId = null, mimeTypes = ['application/json']) {
-    if (!this.pickerApiLoaded) {
-      console.error('Picker API not loaded yet.');
-      if (callback) callback(new Error('Picker API not loaded.'));
-      return;
-    }
-
-    try {
-      await this.ensureAccessToken();
-    } catch (error) {
-      console.error('Failed to prepare Picker token:', error);
-      if (callback) callback(new Error('Authentication required.'));
-      return;
-    }
-
-    const token = gapi.client.getToken();
-    if (!token) {
-      console.error('User not signed in or token not available for Picker.');
-      if (callback) callback(new Error('Not signed in or token unavailable.'));
-      return;
-    }
-
-    const pickerCallback = (data) => {
-      if (data[google.picker.Response.ACTION] === google.picker.Action.PICKED) {
-        const doc = data[google.picker.Response.DOCUMENTS][0];
-        if (callback) callback(null, { id: doc.id, name: doc.name });
-      } else if (data[google.picker.Response.ACTION] === google.picker.Action.CANCEL) {
-        console.log('Picker cancelled by user.');
-        if (callback) callback(new Error('Picker cancelled by user.'));
-      }
-    };
-
-    const view = new google.picker.View(google.picker.ViewId.DOCS);
-    if (parentFolderId) {
-      view.setParent(parentFolderId);
-    }
-    if (mimeTypes && mimeTypes.length > 0) {
-      view.setMimeTypes(mimeTypes.join(','));
-    }
-
-    const pickerBuilder = new google.picker.PickerBuilder()
-      .setOrigin(window.location.origin)
-      .addView(view)
-      .enableFeature(google.picker.Feature.NAV_HIDDEN)
-      .setOAuthToken(token.access_token)
-      .setCallback(pickerCallback);
-
-    const picker = pickerBuilder.build();
-    picker.setVisible(true);
-  }
-
-  /**
-   * Shows the Google Folder Picker to select a folder.
-   * @param {function} callback - Function to call with the result (error, {id, name}).
-   */
-  /**
-   * Shows the Google Folder Picker to select a folder.
-   * @param {function} callback - Function to call with the result (error, {id, name}).
-   */
-  async showFolderPicker(callback) {
-    if (!this.pickerApiLoaded) {
-      console.error('Picker API not loaded yet for folder picker.');
-      if (callback) callback(new Error('Picker API not loaded.'));
-      return;
-    }
-
-    try {
-      await this.ensureAccessToken();
-    } catch (error) {
-      console.error('Failed to prepare Folder Picker token:', error);
-      if (callback) callback(new Error('Authentication required.'));
-      return;
-    }
-
-    const token = gapi.client.getToken();
-    if (!token) {
-      console.error('User not signed in or token not available for Folder Picker.');
-      if (callback) callback(new Error('Not signed in or token unavailable.'));
-      return;
-    }
-
-    const pickerCallback = async (data) => {
-      if (data[google.picker.Response.ACTION] === google.picker.Action.PICKED) {
-        const folder = data[google.picker.Response.DOCUMENTS][0];
-        try {
-          const path = await this.buildFolderPathFromId(folder.id);
-          if (callback) callback(null, { id: folder.id, name: folder.name, path: path || folder.name });
-        } catch (error) {
-          console.error('Error resolving selected folder path:', error);
-          if (callback) callback(error);
-        }
-      } else if (data[google.picker.Response.ACTION] === google.picker.Action.CANCEL) {
-        console.log('Folder Picker cancelled by user.');
-        if (callback) callback(new Error('Folder Picker cancelled by user.'));
-      }
-    };
-
-    const view = new google.picker.DocsView();
-    view.setIncludeFolders(true);
-    view.setSelectFolderEnabled(true);
-    view.setMimeTypes('application/vnd.google-apps.folder');
-
-    const pickerBuilder = new google.picker.PickerBuilder()
-      .setOrigin(window.location.origin)
-      .addView(view)
-      .setTitle('Select a folder')
-      .setOAuthToken(token.access_token)
-      .setCallback(pickerCallback);
-
-    const picker = pickerBuilder.build();
-    picker.setVisible(true);
   }
 
   async isFileInConfiguredFolder(fileId) {

--- a/src/infrastructure/google-drive/mockGoogleDriveManager.js
+++ b/src/infrastructure/google-drive/mockGoogleDriveManager.js
@@ -16,7 +16,6 @@ export class MockGoogleDriveManager {
     this.clientId = clientId;
     this.storageKey = 'mockGoogleDriveData';
     this.configFileId = 'mock-config';
-    this.pickerApiLoaded = true;
     this._loadState();
     singletonInstance = this;
   }
@@ -29,7 +28,6 @@ export class MockGoogleDriveManager {
       folderCounter: 1,
       signedIn: false,
       config: this.getDefaultConfig(),
-      folderPickerQueue: [],
     };
 
     try {
@@ -38,10 +36,6 @@ export class MockGoogleDriveManager {
     } catch (error) {
       console.error('Failed to load mock state from localStorage, resetting.', error);
       this.state = defaultState;
-    }
-
-    if (!Array.isArray(this.state.folderPickerQueue)) {
-      this.state.folderPickerQueue = [];
     }
 
     this.configuredFolderId = null;
@@ -61,7 +55,6 @@ export class MockGoogleDriveManager {
       folderCounter: 1,
       signedIn: false,
       config: this.getDefaultConfig(),
-      folderPickerQueue: [],
     };
     this.configuredFolderId = null;
     this.cachedFolderPath = null;
@@ -242,46 +235,6 @@ export class MockGoogleDriveManager {
     file.shared = true;
     this._saveState();
     return `https://drive.mock/${fileId}`;
-  }
-
-  showFilePicker(callback, parentFolderId = null) {
-    const files = Object.values(this.state.files).filter((file) => (parentFolderId ? file.parentId === parentFolderId : true));
-    const first = files[0];
-    if (first) {
-      callback?.(null, { id: first.id, name: first.name });
-    } else {
-      callback?.(new Error('No files available.'));
-    }
-  }
-
-  showFolderPicker(callback) {
-    const queue = Array.isArray(this.state.folderPickerQueue) ? this.state.folderPickerQueue : [];
-    if (queue.length > 0) {
-      const targetPath = this.normalizeFolderPath(queue.shift());
-      this.state.folderPickerQueue = queue;
-      this._saveState();
-      this.ensureFolderPath(targetPath)
-        .then(({ folder, normalized }) => {
-          if (!folder) {
-            callback?.(new Error('No folders available.'));
-            return;
-          }
-          callback?.(null, { id: folder.id, name: folder.name, path: normalized });
-        })
-        .catch((error) => {
-          callback?.(error);
-        });
-      return;
-    }
-
-    const folderId = this.configuredFolderId;
-    if (folderId) {
-      const folder = this.state.folders[folderId];
-      const path = this.cachedFolderPath || this.buildFolderPath(folderId);
-      callback?.(null, { id: folder.id, name: folder.name, path: path || folder.name });
-    } else {
-      callback?.(new Error('No folders available.'));
-    }
   }
 
   async findFileByName(fileName) {

--- a/tests/unit/components/DriveLoadPage.test.js
+++ b/tests/unit/components/DriveLoadPage.test.js
@@ -3,6 +3,7 @@ import { mount } from '@vue/test-utils';
 import { computed, ref } from 'vue';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import DriveLoadPage from '@/features/cloud-sync/pages/DriveLoadPage.vue';
+import { messages } from '@/i18n/index.js';
 
 const pushMock = vi.fn();
 
@@ -65,11 +66,43 @@ describe('DriveLoadPage', () => {
 
   it('selects a character and navigates back to the sheet', async () => {
     displayedItems.value = [
-      { id: 'file-1', fileName: 'Sample', characterName: 'Hero', contentHash: 'abcd1234ef', lastModifiedAtDrive: 1000 },
+      {
+        id: 'file-1',
+        fileName: 'Sample',
+        characterName: 'Hero',
+        driveHash: 'abcd1234ef',
+        cachedHash: 'abcd1234ef',
+        lastModifiedAtDrive: 1000,
+      },
     ];
     const wrapper = mount(DriveLoadPage);
     await wrapper.find('[data-test="drive-card"]').trigger('click');
     expect(selectCharacter).toHaveBeenCalledWith('file-1');
     expect(pushMock).toHaveBeenCalledWith({ name: 'character-sheet' });
+  });
+
+  it('shows sharing and integrity indicators with truncated hashes', () => {
+    displayedItems.value = [
+      {
+        id: 'file-2',
+        fileName: 'Shared File',
+        characterName: 'Sentinel',
+        driveHash: 'abcd1234efgh',
+        cachedHash: 'abcd1234ijkl',
+        lastModifiedAtDrive: 2000,
+        shared: true,
+        outOfSync: true,
+      },
+    ];
+
+    const wrapper = mount(DriveLoadPage);
+    const badges = wrapper.findAll('.drive-load-page__badge');
+    expect(badges[0].text()).toBe(messages.driveLoadPage.labels.shared);
+    expect(badges[1].text()).toBe(messages.driveLoadPage.labels.outOfSync);
+
+    const hashTexts = wrapper.findAll('.drive-load-page__row dd').map((node) => node.text());
+    expect(hashTexts[1]).toBe('abcd1234...');
+    expect(hashTexts[2]).toBe('abcd1234...');
+    expect(wrapper.find('.drive-load-page__warning').text()).toBe(messages.driveLoadPage.labels.hashWarning);
   });
 });

--- a/tests/unit/components/LoadModal.test.js
+++ b/tests/unit/components/LoadModal.test.js
@@ -11,9 +11,7 @@ function baseProps(overrides = {}) {
     driveFolderPath: 'path',
     driveFolderLabel: 'label',
     driveFolderPlaceholder: 'placeholder',
-    changeFolderLabel: 'change',
     loadLocalLabel: 'local',
-    loadDriveLabel: 'drive',
     selectCharacterLabel: 'select',
     signInLabel: 'signin',
     signInMessage: 'message',
@@ -40,7 +38,7 @@ describe('LoadModal', () => {
   test('disables drive controls when signed out', async () => {
     const wrapper = mount(LoadModal, { props: baseProps({ isSignedIn: false }) });
     expect(wrapper.find('.load-modal__input').attributes('disabled')).toBeDefined();
-    expect(wrapper.find('[data-test="load-modal-drive-button"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="load-modal-select-character"]').attributes('disabled')).toBeDefined();
   });
 
   test('emits select-character when selector button clicked', async () => {

--- a/tests/unit/composables/useAppModals.test.js
+++ b/tests/unit/composables/useAppModals.test.js
@@ -44,8 +44,6 @@ describe('useAppModals', () => {
       printCharacterSheet: vi.fn(),
       openPreviewPage: vi.fn(),
       copyEditCallback: vi.fn(),
-      loadCharacterFromDrive: vi.fn(),
-      promptForDriveFolder: vi.fn(),
       updateDriveFolderPath: vi.fn(),
       canSignInToGoogle: ref(true),
       isDriveReady: ref(true),

--- a/tests/unit/composables/useDriveLoadPageState.test.js
+++ b/tests/unit/composables/useDriveLoadPageState.test.js
@@ -124,6 +124,91 @@ describe('useDriveLoadPageState', () => {
     scope.stop();
   });
 
+  it('marks entries as out of sync when hashes differ', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        createResponse({ items: [{ file_id: '1', file_name: 'Cached', content_hash: 'cache-hash', last_modified_at_drive: 1000 }] }),
+      )
+      .mockResolvedValue(createResponse({ items: [] }));
+
+    const requestDrivePage = vi.fn().mockResolvedValue({
+      files: [
+        {
+          id: '1',
+          name: 'Drive',
+          modifiedTime: '2024-01-01T00:00:00.000Z',
+          appProperties: { last_app_hash: 'drive-hash', character_name: 'Drive' },
+          shared: true,
+        },
+      ],
+      nextPageToken: null,
+    });
+
+    const driveManager = {
+      findOrCreateConfiguredCharacterFolder: vi.fn().mockResolvedValue('folder'),
+      ensureAccessToken: vi.fn(),
+    };
+
+    const scope = effectScope();
+    let state;
+    scope.run(() => {
+      state = useDriveLoadPageState({ fetchImpl: fetchMock, requestDrivePage, driveManager });
+    });
+
+    await state.initialize();
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(state.displayedItems.value[0].driveHash).toBe('drive-hash');
+    expect(state.displayedItems.value[0].cachedHash).toBe('cache-hash');
+    expect(state.displayedItems.value[0].outOfSync).toBe(true);
+    expect(state.displayedItems.value[0].shared).toBe(true);
+
+    scope.stop();
+  });
+
+  it('detects newer drive modifications even when hashes match', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        createResponse({ items: [{ file_id: '1', file_name: 'Cached', content_hash: 'match', last_modified_at_drive: 1000 }] }),
+      )
+      .mockResolvedValue(createResponse({ items: [] }));
+
+    const requestDrivePage = vi.fn().mockResolvedValue({
+      files: [
+        {
+          id: '1',
+          name: 'Drive',
+          modifiedTime: '1970-01-01T00:20:00.000Z',
+          appProperties: { last_app_hash: 'match', character_name: 'Drive' },
+        },
+      ],
+      nextPageToken: null,
+    });
+
+    const driveManager = {
+      findOrCreateConfiguredCharacterFolder: vi.fn().mockResolvedValue('folder'),
+      ensureAccessToken: vi.fn(),
+    };
+
+    const scope = effectScope();
+    let state;
+    scope.run(() => {
+      state = useDriveLoadPageState({ fetchImpl: fetchMock, requestDrivePage, driveManager });
+    });
+
+    await state.initialize();
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(state.displayedItems.value[0].outOfSync).toBe(true);
+    expect(state.displayedItems.value[0].lastModifiedAtDrive).toBe(1200);
+
+    scope.stop();
+  });
+
   it('stores the selected file id in the ui store', () => {
     const fetchMock = vi.fn().mockResolvedValue(createResponse({ items: [] }));
     const requestDrivePage = vi.fn().mockResolvedValue({ files: [], nextPageToken: null });

--- a/tests/unit/composables/useGoogleDrive.test.js
+++ b/tests/unit/composables/useGoogleDrive.test.js
@@ -17,20 +17,6 @@ vi.mock('@/features/notifications/composables/useNotifications.js', () => ({
   }),
 }));
 
-function createDriveManagerStub(normalizedPath = '慈悲なきアイオニア/PC/第一キャンペーン') {
-  const showFolderPicker = vi.fn();
-  const setCharacterFolderPath = vi.fn().mockResolvedValue(normalizedPath);
-  const findOrCreateConfiguredCharacterFolder = vi.fn().mockResolvedValue('folder-id');
-  const normalizeFolderPath = vi.fn((path) => path.replace(/\\/g, '/'));
-
-  return {
-    showFolderPicker,
-    setCharacterFolderPath,
-    findOrCreateConfiguredCharacterFolder,
-    normalizeFolderPath,
-  };
-}
-
 describe('useGoogleDrive', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
@@ -75,10 +61,7 @@ describe('useGoogleDrive', () => {
     const dataManager = {
       saveCharacterToDrive: vi.fn(),
       loadDataFromDrive: vi.fn().mockResolvedValue(loadData),
-      googleDriveManager: {
-        showFilePicker: (cb) => cb(null, { id: 'file-1', name: 'Explorer.json' }),
-        findOrCreateConfiguredCharacterFolder: vi.fn().mockResolvedValue('folder-id'),
-      },
+      googleDriveManager: {},
       getDriveFileName: vi.fn().mockReturnValue('Explorer.json'),
     };
     const { loadCharacterFromDrive } = useGoogleDrive(dataManager);
@@ -86,43 +69,14 @@ describe('useGoogleDrive', () => {
     const uiStore = useUiStore();
     uiStore.isGapiInitialized = true;
     uiStore.isSignedIn = true;
+    uiStore.setCurrentDriveFileId('file-1');
 
-    const result = await loadCharacterFromDrive();
+    const result = await loadCharacterFromDrive('file-1');
 
     expect(result).toEqual(loadData);
     expect(charStore.character.name).toBe('Explorer');
     expect(uiStore.currentDriveFileId).toBe('file-1');
     expect(uiStore.lastSavedSnapshot).toBe(buildSnapshotFromStore(charStore));
-  });
-
-  test('promptForDriveFolder applies picker selection to drive path', async () => {
-    const desiredPath = '慈悲なきアイオニア/PC/第一キャンペーン';
-    const stubManager = createDriveManagerStub(desiredPath);
-    stubManager.showFolderPicker.mockImplementation((cb) => cb(null, { id: 'folder-1', name: '第一キャンペーン', path: desiredPath }));
-
-    const dataManager = {
-      googleDriveManager: stubManager,
-      setGoogleDriveManager(manager) {
-        Object.assign(manager, stubManager);
-        this.googleDriveManager = manager;
-      },
-      loadDataFromDrive: vi.fn(),
-      saveCharacterToDrive: vi.fn(),
-      getDriveFileName: vi.fn().mockReturnValue('Hero.json'),
-    };
-
-    const { promptForDriveFolder } = useGoogleDrive(dataManager);
-    const uiStore = useUiStore();
-    uiStore.isSignedIn = true;
-    uiStore.isGapiInitialized = true;
-    uiStore.setDriveFolderPath('慈悲なきアイオニア');
-
-    const selected = await promptForDriveFolder();
-
-    expect(stubManager.showFolderPicker).toHaveBeenCalled();
-    expect(stubManager.setCharacterFolderPath).toHaveBeenCalledWith(desiredPath);
-    expect(uiStore.driveFolderPath).toBe(desiredPath);
-    expect(selected).toBe(desiredPath);
   });
 
   test('saveCharacterToDrive renames file when saved name differs from character name', async () => {


### PR DESCRIPTION
## Summary
- remove the deprecated Google Picker-based Drive loading paths and route load actions through the Drive load page
- simplify the load modal to a single Drive navigation button while retaining folder path editing
- clean up Drive manager implementations and tests to operate without picker utilities

## Testing
- npm run lint --silent
- CI=true npm test --silent

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943fd19b71c8326adc0e6b4e9bec506)