### PR TITLE
Refine Drive load page for zip-only character files

### DIFF
--- a/src/contents/ui_messages.csv
+++ b/src/contents/ui_messages.csv
@@ -113,6 +113,7 @@ driveLoadPage.status.error,一覧の取得に失敗しました,,Drive load page
 driveLoadPage.status.retryHint,再試行してください。ネットワークや認証状態をご確認ください,,Drive load page retry hint
 driveLoadPage.labels.untitled,無題のファイル,,Drive load page untitled label
 driveLoadPage.labels.unknownCharacter,キャラクター名未設定,,Drive load page unknown character label
+driveLoadPage.labels.created,作成日時,,Drive load page created label
 driveLoadPage.labels.modified,更新日時,,Drive load page modified label
 driveLoadPage.labels.hash,ハッシュ,,Drive load page hash label
 driveLoadPage.labels.driveHash,Drive上のハッシュ,,Drive load page drive hash label
@@ -124,6 +125,33 @@ driveLoadPage.labels.hashWarning,ハッシュが一致しません。外部で�
 driveLoadPage.labels.shared,共有中,,Drive load page shared badge
 driveLoadPage.labels.sharedAria,このファイルは共有されています,,Drive load page shared aria label
 driveLoadPage.labels.selectAction,このキャラクターを開く,,Drive load page select card aria label
+driveLoadPage.actions.load,読込,,Drive load page load action
+driveLoadPage.actions.delete,削除,,Drive load page delete action
+driveLoadPage.actions.share,共有,,Drive load page share action
+driveLoadPage.actions.download,保存,,Drive load page download action
+driveLoadPage.actions.loadAria,{name}を開く,,Drive load page load aria
+driveLoadPage.actions.deleteAria,{name}を削除する,,Drive load page delete aria
+driveLoadPage.actions.shareAria,{name}を共有する,,Drive load page share aria
+driveLoadPage.actions.downloadAria,{name}を端末に保存する,,Drive load page download aria
+driveLoadPage.confirmations.delete,{name}を削除しますか？この操作は元に戻せません。,,Drive load page delete confirmation
+driveLoadPage.toasts.share.loading.title,共有リンクを作成中,,Drive load page share loading title
+driveLoadPage.toasts.share.loading.message,公開リンクを準備しています…,,Drive load page share loading message
+driveLoadPage.toasts.share.success.title,共有リンクをコピーしました,,Drive load page share success title
+driveLoadPage.toasts.share.success.message,リンクをクリップボードにコピーしました,,Drive load page share success message
+driveLoadPage.toasts.share.error.title,共有に失敗しました,,Drive load page share error title
+driveLoadPage.toasts.share.error.message,共有リンクの作成に失敗しました,,Drive load page share error message
+driveLoadPage.toasts.download.loading.title,ダウンロードを準備中,,Drive load page download loading title
+driveLoadPage.toasts.download.loading.message,ファイルを取得しています…,,Drive load page download loading message
+driveLoadPage.toasts.download.success.title,ダウンロード開始,,Drive load page download success title
+driveLoadPage.toasts.download.success.message,端末への保存を開始しました,,Drive load page download success message
+driveLoadPage.toasts.download.error.title,ダウンロードに失敗しました,,Drive load page download error title
+driveLoadPage.toasts.download.error.message,ファイルを取得できませんでした,,Drive load page download error message
+driveLoadPage.toasts.delete.loading.title,削除中,,Drive load page delete loading title
+driveLoadPage.toasts.delete.loading.message,クラウド上のファイルを削除しています…,,Drive load page delete loading message
+driveLoadPage.toasts.delete.success.title,削除完了,,Drive load page delete success title
+driveLoadPage.toasts.delete.success.message,ファイルを削除しました,,Drive load page delete success message
+driveLoadPage.toasts.delete.error.title,削除に失敗しました,,Drive load page delete error title
+driveLoadPage.toasts.delete.error.message,ファイルの削除に失敗しました,,Drive load page delete error message
 driveLoadPage.errors.missingDriveManager,Driveの初期化が完了していません,,Drive load page missing manager error
 driveLoadPage.errors.folderUnavailable,キャラクターフォルダにアクセスできません,,Drive load page folder unavailable error
 driveLoadPage.errors.apiUnavailable,Google Drive APIが利用できません,,Drive load page api unavailable error

--- a/src/features/cloud-sync/composables/useDriveLoadPageState.js
+++ b/src/features/cloud-sync/composables/useDriveLoadPageState.js
@@ -8,6 +8,21 @@ const DISPLAY_BATCH = 10;
 const PREFETCH_BUFFER = 10;
 const INITIAL_PAGE_SIZE = 20;
 const NEXT_PAGE_SIZE = 10;
+const ZIP_MIME_TYPES = new Set(['application/zip', 'application/x-zip-compressed', 'multipart/x-zip', 'application/x-zip']);
+
+function isZipEntry(raw) {
+  const fileName = raw?.fileName || raw?.file_name || raw?.name || '';
+  const mimeType = raw?.mimeType || raw?.mime_type;
+  const hasZipExtension = typeof fileName === 'string' && fileName.toLowerCase().endsWith('.zip');
+  if (hasZipExtension) return true;
+  if (typeof mimeType === 'string') {
+    const normalized = mimeType.toLowerCase();
+    if (ZIP_MIME_TYPES.has(normalized) || normalized.includes('zip')) {
+      return true;
+    }
+  }
+  return false;
+}
 
 function toSeconds(value) {
   if (value == null) return null;
@@ -24,14 +39,22 @@ function toSeconds(value) {
 export function normalizeMetadataItem(raw) {
   const id = raw?.fileId || raw?.file_id || raw?.id;
   if (!id) return null;
+  if (!isZipEntry(raw)) return null;
 
-  const characterName =
-    raw?.characterName || raw?.character_name || raw?.appProperties?.character_name || raw?.app_properties?.character_name || '';
   const fileName = raw?.fileName || raw?.file_name || raw?.name || '';
+  const baseName = typeof fileName === 'string' ? fileName.replace(/\.zip$/i, '') : '';
+  const characterName =
+    baseName ||
+    raw?.characterName ||
+    raw?.character_name ||
+    raw?.appProperties?.character_name ||
+    raw?.app_properties?.character_name ||
+    '';
   const driveHash = raw?.appProperties?.last_app_hash || raw?.app_properties?.last_app_hash || null;
   const cachedHash = raw?.contentHash || raw?.content_hash || null;
   const driveModifiedAt = toSeconds(raw?.modifiedTime);
   const cachedModifiedAt = toSeconds(raw?.lastModifiedAtDrive || raw?.last_modified_at_drive);
+  const createdAt = toSeconds(raw?.createdTime || raw?.created_time);
   const syncedAt = raw?.syncedAt || raw?.synced_at || null;
   const shared = raw?.shared == null ? null : Boolean(raw.shared);
   const outOfSync = Boolean(raw?.outOfSync || raw?.out_of_sync || raw?.hashMismatch || raw?.modifiedMismatch);
@@ -48,6 +71,7 @@ export function normalizeMetadataItem(raw) {
     driveModifiedAt,
     cachedModifiedAt,
     lastModifiedAtDrive,
+    createdAt,
     syncedAt,
     shared,
     outOfSync,
@@ -130,8 +154,8 @@ async function defaultRequestDrivePage(driveManager, { pageSize, pageToken, abor
   }
 
   const response = await gapi.client.drive.files.list({
-    q: `'${folderId}' in parents and mimeType='application/json' and trashed=false`,
-    fields: 'nextPageToken, files(id, name, modifiedTime, appProperties, shared)',
+    q: `'${folderId}' in parents and (mimeType='application/zip' or mimeType='application/x-zip-compressed' or mimeType='multipart/x-zip' or mimeType contains 'zip') and trashed=false`,
+    fields: 'nextPageToken, files(id, name, createdTime, modifiedTime, appProperties, shared, mimeType)',
     spaces: 'drive',
     pageSize,
     pageToken,
@@ -217,6 +241,7 @@ export function useDriveLoadPageState(options = {}) {
         driveModifiedAt: normalized.driveModifiedAt ?? existing.driveModifiedAt ?? null,
         cachedModifiedAt: normalized.cachedModifiedAt ?? existing.cachedModifiedAt ?? null,
         lastModifiedAtDrive: normalized.lastModifiedAtDrive ?? existing.lastModifiedAtDrive ?? null,
+        createdAt: normalized.createdAt ?? existing.createdAt ?? null,
         syncedAt: normalized.syncedAt ?? existing.syncedAt ?? null,
         shared: normalized.shared ?? existing.shared ?? false,
       };

--- a/src/features/cloud-sync/pages/DriveLoadPage.vue
+++ b/src/features/cloud-sync/pages/DriveLoadPage.vue
@@ -3,6 +3,9 @@ import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { messages } from '@/i18n/index.js';
 import { useDriveLoadPageState } from '@/features/cloud-sync/composables/useDriveLoadPageState.js';
+import { getGoogleDriveManagerInstance } from '@/infrastructure/google-drive/googleDriveManager.js';
+import { copyText } from '@/shared/utils/clipboard.js';
+import { useNotifications } from '@/features/notifications/composables/useNotifications.js';
 
 const router = useRouter();
 const sentinelRef = ref(null);
@@ -22,7 +25,19 @@ const {
   selectCharacter,
 } = useDriveLoadPageState();
 
-const isEmpty = computed(() => !isLoadingCache.value && displayedItems.value.length === 0);
+const { showAsyncToast, logAndToastError } = useNotifications();
+
+let driveManager = null;
+try {
+  driveManager = getGoogleDriveManagerInstance();
+} catch (error) {
+  logAndToastError(error, { title: messages.driveLoadPage.title, message: messages.driveLoadPage.errors.missingDriveManager });
+}
+
+const filteredItems = computed(() =>
+  displayedItems.value.filter((item) => typeof item?.fileName === 'string' && item.fileName.toLowerCase().endsWith('.zip')),
+);
+const isEmpty = computed(() => !isLoadingCache.value && filteredItems.value.length === 0);
 const isBusy = computed(() => isSyncing.value || isFetchingMore.value);
 const statusLabel = computed(() => statusMessage.value);
 const statusDetail = computed(() => (errorMessage.value ? messages.driveLoadPage.status.retryHint : ''));
@@ -31,16 +46,15 @@ function goBackToSheet() {
   router.push({ name: 'character-sheet' });
 }
 
-function onSelectCharacter(fileId) {
-  if (!fileId) return;
-  selectCharacter(fileId);
-  router.push({ name: 'character-sheet' });
+function getDisplayName(item) {
+  if (!item?.fileName) return messages.driveLoadPage.labels.untitled;
+  const name = item.fileName.replace(/\.zip$/i, '');
+  return name || messages.driveLoadPage.labels.untitled;
 }
 
-function formatHash(hash) {
-  if (!hash) return messages.driveLoadPage.labels.notAvailable;
-  const shortHash = hash.slice(0, 8);
-  return hash.length > 8 ? `${shortHash}...` : shortHash;
+function getDownloadName(item) {
+  if (!item?.fileName) return `${messages.driveLoadPage.labels.untitled}.zip`;
+  return item.fileName.toLowerCase().endsWith('.zip') ? item.fileName : `${item.fileName}.zip`;
 }
 
 function formatTimestamp(seconds) {
@@ -79,6 +93,76 @@ function setupObserver() {
   observer.value.observe(sentinelRef.value);
 }
 
+function requireDriveManager() {
+  if (!driveManager) {
+    throw new Error(messages.driveLoadPage.errors.missingDriveManager);
+  }
+  return driveManager;
+}
+
+function handleLoad(fileId) {
+  if (!fileId) return;
+  selectCharacter(fileId);
+  router.push({ name: 'character-sheet' });
+}
+
+async function handleDelete(item) {
+  if (!item?.id) return;
+  const confirmed = window.confirm(messages.driveLoadPage.confirmations.delete(getDisplayName(item)));
+  if (!confirmed) return;
+  const manager = requireDriveManager();
+  try {
+    await showAsyncToast(manager.deleteCharacterFile(item.id), messages.driveLoadPage.toasts.delete, 'drive-delete');
+    await refresh();
+  } catch (error) {
+    logAndToastError(error, messages.driveLoadPage.toasts.delete.error, 'drive-delete');
+  }
+}
+
+async function handleShare(item) {
+  if (!item?.id) return;
+  const manager = requireDriveManager();
+  const task = (async () => {
+    const link = await manager.ensureFilePublic(item.id);
+    if (!link) {
+      throw new Error(messages.share.errors.shareFailed);
+    }
+    await copyText(link);
+    return link;
+  })();
+
+  try {
+    await showAsyncToast(task, messages.driveLoadPage.toasts.share, 'drive-share');
+  } catch (error) {
+    logAndToastError(error, messages.driveLoadPage.toasts.share.error, 'drive-share');
+  }
+}
+
+async function handleDownload(item) {
+  if (!item?.id) return;
+  const manager = requireDriveManager();
+  const task = (async () => {
+    const content = await manager.loadFileContent(item.id);
+    if (!content) {
+      throw new Error(messages.driveLoadPage.toasts.download.error.message);
+    }
+    const blob = content instanceof Blob ? content : new Blob([content], { type: 'application/zip' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = getDownloadName(item);
+    link.click();
+    URL.revokeObjectURL(url);
+    return url;
+  })();
+
+  try {
+    await showAsyncToast(task, messages.driveLoadPage.toasts.download, 'drive-download');
+  } catch (error) {
+    logAndToastError(error, messages.driveLoadPage.toasts.download.error, 'drive-download');
+  }
+}
+
 onMounted(() => {
   initialize();
   setupObserver();
@@ -114,56 +198,82 @@ onBeforeUnmount(() => {
       <p v-if="isEmpty" class="drive-load-page__placeholder">{{ messages.driveLoadPage.placeholder }}</p>
 
       <div v-else class="drive-load-page__list" role="list">
-        <button
-          v-for="item in displayedItems"
+        <article
+          v-for="item in filteredItems"
           :key="item.id"
-          class="drive-load-page__card"
-          type="button"
+          class="drive-card"
           role="listitem"
-          :aria-label="`${messages.driveLoadPage.labels.selectAction}: ${item.fileName || messages.driveLoadPage.labels.untitled}`"
           data-test="drive-card"
-          @click="onSelectCharacter(item.id)"
         >
-          <header class="drive-load-page__card-header">
-            <div>
-              <p class="drive-load-page__file-name">{{ item.fileName || messages.driveLoadPage.labels.untitled }}</p>
-              <p class="drive-load-page__character-name">{{ item.characterName || messages.driveLoadPage.labels.unknownCharacter }}</p>
+          <header class="drive-card__header">
+            <div class="drive-card__title-block">
+              <h2 class="drive-card__title" data-test="drive-card-title">{{ getDisplayName(item) }}</h2>
+              <p class="drive-card__filename">{{ item.fileName || messages.driveLoadPage.labels.untitled }}</p>
             </div>
-            <div class="drive-load-page__indicators" aria-live="polite">
-              <span
-                v-if="item.shared"
-                class="drive-load-page__badge drive-load-page__badge--muted"
-                :aria-label="messages.driveLoadPage.labels.sharedAria"
-              >
+            <div class="drive-card__indicators">
+              <span v-if="item.shared" class="drive-card__badge drive-card__badge--muted" role="status">
                 {{ messages.driveLoadPage.labels.shared }}
               </span>
-              <span v-if="item.outOfSync" class="drive-load-page__badge drive-load-page__badge--warning" role="status">
+              <span v-if="item.outOfSync" class="drive-card__badge drive-card__badge--warning" role="status">
                 {{ messages.driveLoadPage.labels.outOfSync }}
               </span>
             </div>
           </header>
-          <dl class="drive-load-page__details">
-            <div class="drive-load-page__row">
+
+          <dl class="drive-card__meta">
+            <div class="drive-card__meta-row" data-test="drive-card-field">
+              <dt>{{ messages.driveLoadPage.labels.created }}</dt>
+              <dd>{{ formatTimestamp(item.createdAt) }}</dd>
+            </div>
+            <div class="drive-card__meta-row" data-test="drive-card-field">
               <dt>{{ messages.driveLoadPage.labels.modified }}</dt>
               <dd>{{ formatTimestamp(item.lastModifiedAtDrive) }}</dd>
             </div>
-            <div class="drive-load-page__row">
-              <dt>{{ messages.driveLoadPage.labels.driveHash }}</dt>
-              <dd :title="item.driveHash || messages.driveLoadPage.labels.notAvailable">
-                {{ formatHash(item.driveHash) }}
-              </dd>
-            </div>
-            <div class="drive-load-page__row">
-              <dt>{{ messages.driveLoadPage.labels.cachedHash }}</dt>
-              <dd :title="item.cachedHash || messages.driveLoadPage.labels.notAvailable">
-                {{ formatHash(item.cachedHash) }}
-              </dd>
-            </div>
           </dl>
-          <p v-if="item.outOfSync" class="drive-load-page__warning" role="status">
+
+          <p v-if="item.outOfSync" class="drive-card__warning" data-test="drive-card-warning" role="status">
             {{ messages.driveLoadPage.labels.hashWarning }}
           </p>
-        </button>
+
+          <div class="drive-card__actions">
+            <button
+              class="button-base button-base--primary"
+              type="button"
+              :aria-label="messages.driveLoadPage.actions.loadAria(getDisplayName(item))"
+              data-test="drive-card-load"
+              @click="handleLoad(item.id)"
+            >
+              {{ messages.driveLoadPage.actions.load }}
+            </button>
+            <button
+              class="button-base button-base--ghost"
+              type="button"
+              :aria-label="messages.driveLoadPage.actions.shareAria(getDisplayName(item))"
+              data-test="drive-card-share"
+              @click="handleShare(item)"
+            >
+              {{ messages.driveLoadPage.actions.share }}
+            </button>
+            <button
+              class="button-base button-base--ghost"
+              type="button"
+              :aria-label="messages.driveLoadPage.actions.downloadAria(getDownloadName(item))"
+              data-test="drive-card-download"
+              @click="handleDownload(item)"
+            >
+              {{ messages.driveLoadPage.actions.download }}
+            </button>
+            <button
+              class="button-base button-base--danger"
+              type="button"
+              :aria-label="messages.driveLoadPage.actions.deleteAria(getDisplayName(item))"
+              data-test="drive-card-delete"
+              @click="handleDelete(item)"
+            >
+              {{ messages.driveLoadPage.actions.delete }}
+            </button>
+          </div>
+        </article>
       </div>
 
       <div ref="sentinelRef" class="drive-load-page__sentinel" aria-hidden="true">
@@ -261,106 +371,96 @@ onBeforeUnmount(() => {
 
 .drive-load-page__list {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 12px;
 }
 
-.drive-load-page__card {
-  appearance: none;
-  border: none;
-  text-align: left;
-  width: 100%;
+.drive-card {
   border: 1px solid var(--color-border-muted, #3a3a4a);
-  border-radius: 6px;
-  padding: 12px;
+  border-radius: 8px;
+  padding: 14px;
   background: linear-gradient(145deg, rgba(39, 39, 52, 0.9), rgba(26, 26, 36, 0.9));
   display: flex;
   flex-direction: column;
   gap: 10px;
-  color: inherit;
-  cursor: pointer;
-  transition: border-color 0.15s ease, transform 0.15s ease;
 }
 
-.drive-load-page__card:hover {
-  border-color: var(--color-border-normal);
-  transform: translateY(-1px);
-}
-
-.drive-load-page__card:focus-visible {
-  outline: 2px solid #4da3ff;
-  outline-offset: 2px;
-}
-
-.drive-load-page__card-header {
+.drive-card__header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
   gap: 8px;
 }
 
-.drive-load-page__indicators {
+.drive-card__title-block {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.drive-card__title {
+  margin: 0;
+  font-weight: 800;
+  font-size: 1.05rem;
+}
+
+.drive-card__filename {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.drive-card__indicators {
   display: flex;
   gap: 6px;
   align-items: center;
 }
 
-.drive-load-page__file-name {
-  margin: 0;
-  font-weight: 700;
-  font-size: 1rem;
-}
-
-.drive-load-page__character-name {
-  margin: 4px 0 0;
-  color: var(--color-text-muted);
-  font-size: 0.9rem;
-}
-
-.drive-load-page__badge {
+.drive-card__badge {
   background: #ffb347;
   color: #1a1a24;
   border-radius: 12px;
   padding: 4px 8px;
   font-size: 0.75rem;
   font-weight: 700;
+  border: 1px solid transparent;
 }
 
-.drive-load-page__badge--warning {
+.drive-card__badge--warning {
   background: #ff6b6b;
   color: #1a1a24;
 }
 
-.drive-load-page__badge--muted {
-  background: rgba(255, 255, 255, 0.1);
+.drive-card__badge--muted {
+  background: rgba(255, 255, 255, 0.08);
   color: var(--color-text-primary);
-  border: 1px solid var(--color-border-muted, #3a3a4a);
+  border-color: var(--color-border-muted, #3a3a4a);
 }
 
-.drive-load-page__details {
+.drive-card__meta {
   margin: 0;
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 
-.drive-load-page__row {
+.drive-card__meta-row {
   display: flex;
   justify-content: space-between;
   gap: 12px;
 }
 
-.drive-load-page__row dt {
+.drive-card__meta-row dt {
   color: var(--color-text-muted);
 }
 
-.drive-load-page__row dd {
+.drive-card__meta-row dd {
   margin: 0;
   text-align: right;
   color: var(--color-text-primary);
 }
 
-.drive-load-page__warning {
+.drive-card__warning {
   margin: 4px 0 0;
   padding: 8px 10px;
   border-radius: 6px;
@@ -368,6 +468,12 @@ onBeforeUnmount(() => {
   background: rgba(255, 107, 107, 0.08);
   color: #ffdede;
   font-size: 0.9rem;
+}
+
+.drive-card__actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
 }
 
 .drive-load-page__sentinel {

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -259,6 +259,7 @@ export const messages = {
     labels: {
       untitled: t('driveLoadPage.labels.untitled'),
       unknownCharacter: t('driveLoadPage.labels.unknownCharacter'),
+      created: t('driveLoadPage.labels.created'),
       modified: t('driveLoadPage.labels.modified'),
       hash: t('driveLoadPage.labels.hash'),
       driveHash: t('driveLoadPage.labels.driveHash'),
@@ -270,6 +271,63 @@ export const messages = {
       shared: t('driveLoadPage.labels.shared'),
       sharedAria: t('driveLoadPage.labels.sharedAria'),
       selectAction: t('driveLoadPage.labels.selectAction'),
+    },
+    actions: {
+      load: t('driveLoadPage.actions.load'),
+      delete: t('driveLoadPage.actions.delete'),
+      share: t('driveLoadPage.actions.share'),
+      download: t('driveLoadPage.actions.download'),
+      loadAria: (name) => t('driveLoadPage.actions.loadAria', { name }),
+      deleteAria: (name) => t('driveLoadPage.actions.deleteAria', { name }),
+      shareAria: (name) => t('driveLoadPage.actions.shareAria', { name }),
+      downloadAria: (name) => t('driveLoadPage.actions.downloadAria', { name }),
+    },
+    confirmations: {
+      delete: (name) => t('driveLoadPage.confirmations.delete', { name }),
+    },
+    toasts: {
+      share: {
+        loading: () => ({
+          title: t('driveLoadPage.toasts.share.loading.title'),
+          message: t('driveLoadPage.toasts.share.loading.message'),
+        }),
+        success: () => ({
+          title: t('driveLoadPage.toasts.share.success.title'),
+          message: t('driveLoadPage.toasts.share.success.message'),
+        }),
+        error: (err) => ({
+          title: t('driveLoadPage.toasts.share.error.title'),
+          message: err?.message || t('driveLoadPage.toasts.share.error.message'),
+        }),
+      },
+      download: {
+        loading: () => ({
+          title: t('driveLoadPage.toasts.download.loading.title'),
+          message: t('driveLoadPage.toasts.download.loading.message'),
+        }),
+        success: () => ({
+          title: t('driveLoadPage.toasts.download.success.title'),
+          message: t('driveLoadPage.toasts.download.success.message'),
+        }),
+        error: (err) => ({
+          title: t('driveLoadPage.toasts.download.error.title'),
+          message: err?.message || t('driveLoadPage.toasts.download.error.message'),
+        }),
+      },
+      delete: {
+        loading: () => ({
+          title: t('driveLoadPage.toasts.delete.loading.title'),
+          message: t('driveLoadPage.toasts.delete.loading.message'),
+        }),
+        success: () => ({
+          title: t('driveLoadPage.toasts.delete.success.title'),
+          message: t('driveLoadPage.toasts.delete.success.message'),
+        }),
+        error: (err) => ({
+          title: t('driveLoadPage.toasts.delete.error.title'),
+          message: err?.message || t('driveLoadPage.toasts.delete.error.message'),
+        }),
+      },
     },
     errors: {
       missingDriveManager: t('driveLoadPage.errors.missingDriveManager'),

--- a/tests/unit/components/DriveLoadPage.test.js
+++ b/tests/unit/components/DriveLoadPage.test.js
@@ -1,14 +1,38 @@
 /* @vitest-environment jsdom */
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import { computed, ref } from 'vue';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import DriveLoadPage from '@/features/cloud-sync/pages/DriveLoadPage.vue';
 import { messages } from '@/i18n/index.js';
 
+const managerMock = {
+  deleteCharacterFile: vi.fn(),
+  ensureFilePublic: vi.fn(),
+  loadFileContent: vi.fn(),
+};
+
 const pushMock = vi.fn();
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock('@/infrastructure/google-drive/googleDriveManager.js', () => ({
+  getGoogleDriveManagerInstance: () => managerMock,
+}));
+
+const copyTextMock = vi.fn();
+
+vi.mock('@/shared/utils/clipboard.js', () => ({
+  copyText: (...args) => copyTextMock(...args),
+}));
+
+vi.mock('@/features/notifications/composables/useNotifications.js', () => ({
+  useNotifications: () => ({
+    showToast: vi.fn(),
+    showAsyncToast: (promise) => promise,
+    logAndToastError: vi.fn(),
+  }),
 }));
 
 let observerCallback;
@@ -54,6 +78,10 @@ describe('DriveLoadPage', () => {
     initialize.mockClear();
     selectCharacter.mockClear();
     pushMock.mockClear();
+    managerMock.deleteCharacterFile.mockReset();
+    managerMock.ensureFilePublic.mockReset();
+    managerMock.loadFileContent.mockReset();
+    copyTextMock.mockReset();
     displayedItems.value = [];
   });
 
@@ -64,45 +92,94 @@ describe('DriveLoadPage', () => {
     expect(initialize).toHaveBeenCalled();
   });
 
-  it('selects a character and navigates back to the sheet', async () => {
+  it('loads a character through the load button without card click', async () => {
     displayedItems.value = [
       {
         id: 'file-1',
-        fileName: 'Sample',
-        characterName: 'Hero',
-        driveHash: 'abcd1234ef',
-        cachedHash: 'abcd1234ef',
-        lastModifiedAtDrive: 1000,
+        fileName: 'Hero.zip',
+        lastModifiedAtDrive: 1700,
+        createdAt: 1600,
       },
     ];
     const wrapper = mount(DriveLoadPage);
-    await wrapper.find('[data-test="drive-card"]').trigger('click');
+    await wrapper.find('[data-test="drive-card-load"]').trigger('click');
     expect(selectCharacter).toHaveBeenCalledWith('file-1');
     expect(pushMock).toHaveBeenCalledWith({ name: 'character-sheet' });
   });
 
-  it('shows sharing and integrity indicators with truncated hashes', () => {
+  it('renders character info from file name with timestamps and warnings', () => {
     displayedItems.value = [
       {
         id: 'file-2',
-        fileName: 'Shared File',
-        characterName: 'Sentinel',
-        driveHash: 'abcd1234efgh',
-        cachedHash: 'abcd1234ijkl',
+        fileName: 'Shared File.zip',
         lastModifiedAtDrive: 2000,
+        createdAt: 1900,
         shared: true,
         outOfSync: true,
       },
     ];
 
     const wrapper = mount(DriveLoadPage);
-    const badges = wrapper.findAll('.drive-load-page__badge');
-    expect(badges[0].text()).toBe(messages.driveLoadPage.labels.shared);
-    expect(badges[1].text()).toBe(messages.driveLoadPage.labels.outOfSync);
+    expect(wrapper.find('[data-test="drive-card-title"]').text()).toContain('Shared File');
+    const fields = wrapper.findAll('[data-test="drive-card-field"]');
+    expect(fields[0].text()).toContain(messages.driveLoadPage.labels.created);
+    expect(fields[1].text()).toContain(messages.driveLoadPage.labels.modified);
+    expect(wrapper.find('[data-test="drive-card-warning"]').text()).toBe(messages.driveLoadPage.labels.hashWarning);
+  });
 
-    const hashTexts = wrapper.findAll('.drive-load-page__row dd').map((node) => node.text());
-    expect(hashTexts[1]).toBe('abcd1234...');
-    expect(hashTexts[2]).toBe('abcd1234...');
-    expect(wrapper.find('.drive-load-page__warning').text()).toBe(messages.driveLoadPage.labels.hashWarning);
+  it('omits non-zip entries from the rendered list', () => {
+    displayedItems.value = [
+      { id: 'zip-1', fileName: 'Playable.zip', lastModifiedAtDrive: 1200, createdAt: 1000 },
+      { id: 'legacy', fileName: 'legacy.json', lastModifiedAtDrive: 1300, createdAt: 900 },
+    ];
+
+    const wrapper = mount(DriveLoadPage);
+    const cards = wrapper.findAll('[data-test="drive-card"]');
+    expect(cards).toHaveLength(1);
+    expect(cards[0].text()).toContain('Playable');
+  });
+
+  it('shares a file through the share button and copies the link', async () => {
+    managerMock.ensureFilePublic.mockResolvedValue('https://example.com/share');
+    displayedItems.value = [{ id: 'file-3', fileName: 'Shareable.zip', lastModifiedAtDrive: 1500, createdAt: 1400 }];
+
+    const wrapper = mount(DriveLoadPage);
+    await wrapper.find('[data-test="drive-card-share"]').trigger('click');
+    await flushPromises();
+
+    expect(managerMock.ensureFilePublic).toHaveBeenCalledWith('file-3');
+    expect(copyTextMock).toHaveBeenCalledWith('https://example.com/share');
+  });
+
+  it('downloads a file with a readable filename', async () => {
+    const content = new Uint8Array([1, 2, 3]).buffer;
+    managerMock.loadFileContent.mockResolvedValue(content);
+    const createObjectURLSpy = vi.fn(() => 'blob:url');
+    const revokeSpy = vi.fn();
+    global.URL.createObjectURL = createObjectURLSpy;
+    global.URL.revokeObjectURL = revokeSpy;
+
+    displayedItems.value = [{ id: 'file-4', fileName: 'Archive.zip', lastModifiedAtDrive: 1600, createdAt: 1500 }];
+
+    const wrapper = mount(DriveLoadPage);
+    await wrapper.find('[data-test="drive-card-download"]').trigger('click');
+    await flushPromises();
+
+    expect(managerMock.loadFileContent).toHaveBeenCalledWith('file-4');
+    expect(createObjectURLSpy).toHaveBeenCalledWith(expect.any(Blob));
+    expect(revokeSpy).toHaveBeenCalledWith('blob:url');
+  });
+
+  it('deletes a file after confirmation', async () => {
+    managerMock.deleteCharacterFile.mockResolvedValue();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    displayedItems.value = [{ id: 'file-5', fileName: 'ToRemove.zip', lastModifiedAtDrive: 1700, createdAt: 1600 }];
+
+    const wrapper = mount(DriveLoadPage);
+    await wrapper.find('[data-test="drive-card-delete"]').trigger('click');
+    await flushPromises();
+
+    expect(window.confirm).toHaveBeenCalled();
+    expect(managerMock.deleteCharacterFile).toHaveBeenCalledWith('file-5');
   });
 });

--- a/tests/unit/composables/useDriveLoadPageState.test.js
+++ b/tests/unit/composables/useDriveLoadPageState.test.js
@@ -25,16 +25,20 @@ describe('useDriveLoadPageState', () => {
   it('loads cached metadata immediately and starts drive sync', async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(createResponse({ items: [{ file_id: '1', file_name: 'Cached', last_modified_at_drive: 1000 }] }))
+      .mockResolvedValueOnce(
+        createResponse({ items: [{ file_id: '1', file_name: 'Cached.zip', last_modified_at_drive: 1000, createdTime: 900 }] }),
+      )
       .mockResolvedValue(createResponse({ items: [] }));
 
     const requestDrivePage = vi.fn().mockResolvedValue({
       files: [
         {
           id: '2',
-          name: 'Drive',
+          name: 'Drive.zip',
           modifiedTime: '2024-01-01T00:00:00.000Z',
+          createdTime: '2023-12-31T00:00:00.000Z',
           appProperties: { character_name: 'Drive', last_app_hash: 'hash' },
+          mimeType: 'application/zip',
         },
       ],
       nextPageToken: 'next',
@@ -52,7 +56,8 @@ describe('useDriveLoadPageState', () => {
     });
 
     await state.initialize();
-    expect(state.displayedItems.value[0].fileName).toBe('Cached');
+    expect(state.displayedItems.value[0].fileName).toBe('Cached.zip');
+    expect(state.displayedItems.value[0].characterName).toBe('Cached');
     await nextTick();
     expect(requestDrivePage).toHaveBeenCalledWith({ pageSize: 20, pageToken: null, abortSignal: null });
 
@@ -62,17 +67,17 @@ describe('useDriveLoadPageState', () => {
   it('prefetches the next page when the visible buffer is low', async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(createResponse({ items: [{ file_id: '1', file_name: 'Cached', last_modified_at_drive: 1000 }] }))
+      .mockResolvedValueOnce(createResponse({ items: [{ file_id: '1', file_name: 'Cached.zip', last_modified_at_drive: 1000 }] }))
       .mockResolvedValue(createResponse({ items: [] }));
 
     const requestDrivePage = vi
       .fn()
       .mockResolvedValueOnce({
-        files: Array.from({ length: 2 }).map((_, idx) => ({ id: `${idx + 1}`, name: `Drive ${idx + 1}` })),
+        files: Array.from({ length: 2 }).map((_, idx) => ({ id: `${idx + 1}`, name: `Drive-${idx + 1}.zip`, mimeType: 'application/zip' })),
         nextPageToken: 'next-token',
       })
       .mockResolvedValueOnce({
-        files: [{ id: '3', name: 'More Data' }],
+        files: [{ id: '3', name: 'More-Data.zip', mimeType: 'application/zip' }],
         nextPageToken: null,
       });
 
@@ -96,10 +101,45 @@ describe('useDriveLoadPageState', () => {
     scope.stop();
   });
 
+  it('ignores non-zip entries from cache and drive responses', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse({ items: [{ file_id: '1', file_name: 'legacy.json', last_modified_at_drive: 800 }] }))
+      .mockResolvedValue(createResponse({ items: [] }));
+
+    const requestDrivePage = vi.fn().mockResolvedValue({
+      files: [
+        { id: '2', name: 'Valid.zip', mimeType: 'application/zip' },
+        { id: '3', name: 'Ignore.me', mimeType: 'text/plain' },
+      ],
+      nextPageToken: null,
+    });
+
+    const driveManager = {
+      findOrCreateConfiguredCharacterFolder: vi.fn().mockResolvedValue('folder'),
+      ensureAccessToken: vi.fn(),
+    };
+
+    const scope = effectScope();
+    let state;
+    scope.run(() => {
+      state = useDriveLoadPageState({ fetchImpl: fetchMock, requestDrivePage, driveManager });
+    });
+
+    await state.initialize();
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(state.displayedItems.value).toHaveLength(1);
+    expect(state.displayedItems.value[0].fileName).toBe('Valid.zip');
+
+    scope.stop();
+  });
+
   it('cleans up missing files on 404 errors', async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(createResponse({ items: [{ file_id: '1', file_name: 'Cached', last_modified_at_drive: 1000 }] }))
+      .mockResolvedValueOnce(createResponse({ items: [{ file_id: '1', file_name: 'Cached.zip', last_modified_at_drive: 1000 }] }))
       .mockResolvedValue(createResponse({ items: [] }));
 
     const requestDrivePage = vi.fn().mockRejectedValue({ status: 404, fileId: '1' });
@@ -128,7 +168,7 @@ describe('useDriveLoadPageState', () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
-        createResponse({ items: [{ file_id: '1', file_name: 'Cached', content_hash: 'cache-hash', last_modified_at_drive: 1000 }] }),
+        createResponse({ items: [{ file_id: '1', file_name: 'Cached.zip', content_hash: 'cache-hash', last_modified_at_drive: 1000 }] }),
       )
       .mockResolvedValue(createResponse({ items: [] }));
 
@@ -136,10 +176,11 @@ describe('useDriveLoadPageState', () => {
       files: [
         {
           id: '1',
-          name: 'Drive',
+          name: 'Drive.zip',
           modifiedTime: '2024-01-01T00:00:00.000Z',
           appProperties: { last_app_hash: 'drive-hash', character_name: 'Drive' },
           shared: true,
+          mimeType: 'application/zip',
         },
       ],
       nextPageToken: null,
@@ -172,7 +213,7 @@ describe('useDriveLoadPageState', () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
-        createResponse({ items: [{ file_id: '1', file_name: 'Cached', content_hash: 'match', last_modified_at_drive: 1000 }] }),
+        createResponse({ items: [{ file_id: '1', file_name: 'Cached.zip', content_hash: 'match', last_modified_at_drive: 1000 }] }),
       )
       .mockResolvedValue(createResponse({ items: [] }));
 
@@ -180,9 +221,10 @@ describe('useDriveLoadPageState', () => {
       files: [
         {
           id: '1',
-          name: 'Drive',
+          name: 'Drive.zip',
           modifiedTime: '1970-01-01T00:20:00.000Z',
           appProperties: { last_app_hash: 'match', character_name: 'Drive' },
+          mimeType: 'application/zip',
         },
       ],
       nextPageToken: null,


### PR DESCRIPTION
## Summary
- restrict Drive metadata handling to zip character archives, capturing created times and treating file names as canonical titles
- redesign Drive load cards with explicit load/share/download/delete actions and user-friendly timestamps while preserving out-of-sync warnings
- update i18n strings and tests to enforce zip-only filtering and the new UI layout

## Testing
- npm run lint
- npm test *(fails: missing optional dev dependencies like `vue-router`/`hono` in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944aa78019883269604544c3059c394)