### PR TITLE
Align character info column height with scar/weakness column

### DIFF
--- a/src/features/character-sheet/components/sections/CharacterBasicInfo.vue
+++ b/src/features/character-sheet/components/sections/CharacterBasicInfo.vue
@@ -85,13 +85,19 @@ const handleSpeciesChange = () => {
   .character-info {
     display: flex;
     flex-direction: column;
+    min-height: 0;
   }
 
   .character-info .box-content {
     display: flex;
     flex-direction: column;
     flex: 1;
-    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .character-info .info-row {
+    flex-shrink: 0;
   }
 }
 </style>

--- a/src/features/character-sheet/components/ui/CharacterImageDisplay.vue
+++ b/src/features/character-sheet/components/ui/CharacterImageDisplay.vue
@@ -173,13 +173,13 @@ const handleImageUpload = async (event) => {
 }
 
 .image-display-area {
-  position: relative; 
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
   margin-bottom: 0;
   width: 100%;
-  min-height: 300px; 
+  min-height: 300px;
   flex: 1;
   background-color: var(--color-background);
   border: 1px solid var(--color-border-normal);
@@ -272,6 +272,7 @@ const handleImageUpload = async (event) => {
   flex-wrap: wrap;
   justify-content: center;
   padding: 10px 0;
+  flex-shrink: 0;
 }
 
 .imagefile-button--upload:hover {
@@ -304,8 +305,13 @@ const handleImageUpload = async (event) => {
 @media (min-width: 769px) {
   .character-image-container {
     flex: 1;
-    height: 100%;
+    min-height: 0;
     width: 100%;
+    overflow: hidden;
+  }
+
+  .image-display-area {
+    min-height: 0;
   }
 }
 </style>

--- a/src/shared/styles/_layout.css
+++ b/src/shared/styles/_layout.css
@@ -24,6 +24,14 @@
   gap: 10px;
 }
 
+@media (min-width: 769px) {
+  .character-info,
+  .scar-weakness-wrapper {
+    align-self: stretch;
+    min-height: 0;
+  }
+}
+
 .skills {
   grid-area: skills;
 }


### PR DESCRIPTION
## Summary
- stretch the desktop character and scar/weakness grid areas so their heights match
- let the character info content and form rows respect the available space without overflowing
- constrain the character image viewer to the remaining height while keeping controls fixed

## Testing
- npm run lint (passes with existing unused variable warnings)
- npm test *(fails: cannot resolve "hono" in tests/unit/functions/authApi.test.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944b675abf483268a40a7fac2ea156f)