### PR TITLE
Add Google Drive thumbnail handling

### DIFF
--- a/functions/api/[[route]].js
+++ b/functions/api/[[route]].js
@@ -337,7 +337,7 @@ app.get('/api/drive/metadata', async (c) => {
 
   try {
     const result = await c.env.DB.prepare(
-      'SELECT file_id, user_id, character_name, file_name, content_hash, last_modified_at_drive, synced_at FROM character_metadata WHERE user_id = ? ORDER BY synced_at DESC',
+      'SELECT file_id, user_id, character_name, file_name, content_hash, has_thumbnail, last_modified_at_drive, synced_at FROM character_metadata WHERE user_id = ? ORDER BY synced_at DESC',
     )
       .bind(auth.session.user_id)
       .all();
@@ -393,6 +393,7 @@ app.post('/api/drive/sync', async (c) => {
       const modifiedTime = file.modifiedTime || file.lastModifiedAtDrive || null;
       const lastModifiedMs = modifiedTime ? new Date(modifiedTime).getTime() : NaN;
       const lastModifiedAtDrive = Number.isFinite(lastModifiedMs) ? Math.floor(lastModifiedMs / 1000) : null;
+      const hasThumbnail = file.hasThumbnail || file.has_thumbnail ? 1 : 0;
 
       const previous = existingMap.get(fileId);
       const hashMismatch = Boolean(previous && previous.content_hash && contentHash && previous.content_hash !== contentHash);
@@ -402,16 +403,17 @@ app.post('/api/drive/sync', async (c) => {
 
       statements.push(
         c.env.DB.prepare(
-          `INSERT INTO character_metadata (file_id, user_id, character_name, file_name, content_hash, last_modified_at_drive, synced_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?)
+          `INSERT INTO character_metadata (file_id, user_id, character_name, file_name, content_hash, has_thumbnail, last_modified_at_drive, synced_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT(file_id) DO UPDATE SET
              user_id=excluded.user_id,
              character_name=excluded.character_name,
              file_name=excluded.file_name,
-             content_hash=excluded.content_hash,
+              content_hash=excluded.content_hash,
+             has_thumbnail=excluded.has_thumbnail,
              last_modified_at_drive=excluded.last_modified_at_drive,
              synced_at=excluded.synced_at`,
-        ).bind(fileId, auth.session.user_id, characterName, fileName, contentHash, lastModifiedAtDrive, nowSeconds),
+        ).bind(fileId, auth.session.user_id, characterName, fileName, contentHash, hasThumbnail, lastModifiedAtDrive, nowSeconds),
       );
 
       items.push({
@@ -419,6 +421,7 @@ app.post('/api/drive/sync', async (c) => {
         fileName,
         characterName,
         contentHash,
+        hasThumbnail: Boolean(hasThumbnail),
         lastModifiedAtDrive,
         outOfSync: hashMismatch || modifiedMismatch,
       });

--- a/schema.sql
+++ b/schema.sql
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS character_metadata (
   character_name TEXT,
   file_name TEXT,
   content_hash TEXT,
+  has_thumbnail INTEGER DEFAULT 0,
   last_modified_at_drive INTEGER,
   synced_at INTEGER
 );

--- a/src/features/character-sheet/services/dataManager.js
+++ b/src/features/character-sheet/services/dataManager.js
@@ -102,24 +102,7 @@ export class DataManager {
     event.target.value = null;
   }
 
-  /**
-   * Exports character data to a user selected Drive folder.
-   * @param {object} character - The character data.
-   * @param {Array} skills - The skills data.
-   * @param {Array} specialSkills - The special skills data.
-   * @param {object} equipments - The equipment data.
-   * @param {Array} histories - The histories data.
-   * @param {string} targetFolderId - The ID of the folder to save to.
-   * @param {string|null} currentFileId - The ID of the file if it exists (for updating).
-   * @param {string} fileName - The desired name for the file.
-   * @returns {Promise<object|null>} Result from GoogleDriveManager.saveFile or null on error.
-   */
-  async exportDataToDriveFolder(character, skills, specialSkills, equipments, histories, targetFolderId, currentFileId) {
-    if (!this.googleDriveManager) {
-      console.error('GoogleDriveManager not set in DataManager.');
-      throw new Error('GoogleDriveManager not configured. Please sign in or initialize the Drive manager.');
-    }
-
+  async _buildDriveSaveContext(character, skills, specialSkills, equipments, histories) {
     const { data, images } = serializeCharacterForExport({
       character,
       skills,
@@ -143,10 +126,11 @@ export class DataManager {
       }
     }
 
+    const sanitizedName = this._sanitizeFileName(character.name);
     const payload = {
       content: archive.content,
       mimeType: archive.mimeType,
-      name: this._sanitizeFileName(character.name),
+      name: sanitizedName,
       hashData,
       ...(thumbnail
         ? {
@@ -155,9 +139,43 @@ export class DataManager {
           }
         : {}),
     };
-    const sanitizedFileName = `${this._sanitizeFileName(character.name)}.zip`;
-    const appProperties = await this.googleDriveManager.buildAppPropertiesFromPayload(hashData);
-    const contentHints = thumbnail ? this.googleDriveManager.buildContentHintsFromThumbnail(thumbnail, 'image/jpeg') : null;
+    const appProperties = this.googleDriveManager.buildAppPropertiesFromPayload
+      ? await this.googleDriveManager.buildAppPropertiesFromPayload(hashData)
+      : undefined;
+    const contentHints =
+      thumbnail && this.googleDriveManager.buildContentHintsFromThumbnail
+        ? this.googleDriveManager.buildContentHintsFromThumbnail(thumbnail, 'image/jpeg')
+        : null;
+    const sanitizedFileName = `${sanitizedName}.zip`;
+
+    return { payload, sanitizedFileName, appProperties, contentHints };
+  }
+
+  /**
+   * Exports character data to a user selected Drive folder.
+   * @param {object} character - The character data.
+   * @param {Array} skills - The skills data.
+   * @param {Array} specialSkills - The special skills data.
+   * @param {object} equipments - The equipment data.
+   * @param {Array} histories - The histories data.
+   * @param {string} targetFolderId - The ID of the folder to save to.
+   * @param {string|null} currentFileId - The ID of the file if it exists (for updating).
+   * @param {string} fileName - The desired name for the file.
+   * @returns {Promise<object|null>} Result from GoogleDriveManager.saveFile or null on error.
+   */
+  async exportDataToDriveFolder(character, skills, specialSkills, equipments, histories, targetFolderId, currentFileId) {
+    if (!this.googleDriveManager) {
+      console.error('GoogleDriveManager not set in DataManager.');
+      throw new Error('GoogleDriveManager not configured. Please sign in or initialize the Drive manager.');
+    }
+
+    const { payload, sanitizedFileName, appProperties, contentHints } = await this._buildDriveSaveContext(
+      character,
+      skills,
+      specialSkills,
+      equipments,
+      histories,
+    );
 
     try {
       const result = await this.googleDriveManager.saveFile(
@@ -186,42 +204,7 @@ export class DataManager {
       throw new Error('GoogleDriveManager not configured. Please sign in or initialize the Drive manager.');
     }
 
-    const { data, images } = serializeCharacterForExport({
-      character,
-      skills,
-      specialSkills,
-      equipments,
-      histories,
-      includeImages: true,
-    });
-    const archive = await buildCharacterArchive({ data, images });
-    const hashData = data;
-    let thumbnail = null;
-
-    if (Array.isArray(images) && images.length > 0) {
-      try {
-        thumbnail = await ImageManager.createThumbnailFromDataUrl(images[0], {
-          size: 256,
-          mimeType: 'image/jpeg',
-        });
-      } catch (error) {
-        console.warn('Failed to build thumbnail from character images.', error);
-      }
-    }
-
-    const payload = {
-      content: archive.content,
-      mimeType: archive.mimeType,
-      name: this._sanitizeFileName(character.name),
-      hashData,
-      ...(thumbnail
-        ? {
-            thumbnail,
-            thumbnailMimeType: 'image/jpeg',
-          }
-        : {}),
-    };
-
+    const { payload } = await this._buildDriveSaveContext(character, skills, specialSkills, equipments, histories);
     let targetFileId = currentFileId;
     if (targetFileId) {
       const isInConfiguredFolder = await this.googleDriveManager.isFileInConfiguredFolder(targetFileId);

--- a/src/features/character-sheet/services/dataManager.js
+++ b/src/features/character-sheet/services/dataManager.js
@@ -6,6 +6,7 @@ import {
   serializeCharacterForExport,
   toTimestampString,
 } from '@/shared/utils/characterSerialization.js';
+import { ImageManager } from '@/features/character-sheet/services/imageManager.js';
 
 /**
  * データ管理系の機能を担当するクラス
@@ -128,15 +129,45 @@ export class DataManager {
       includeImages: true,
     });
     const archive = await buildCharacterArchive({ data, images });
+    const hashData = data;
+    let thumbnail = null;
+
+    if (Array.isArray(images) && images.length > 0) {
+      try {
+        thumbnail = await ImageManager.createThumbnailFromDataUrl(images[0], {
+          size: 256,
+          mimeType: 'image/jpeg',
+        });
+      } catch (error) {
+        console.warn('Failed to build thumbnail from character images.', error);
+      }
+    }
+
+    const payload = {
+      content: archive.content,
+      mimeType: archive.mimeType,
+      name: this._sanitizeFileName(character.name),
+      hashData,
+      ...(thumbnail
+        ? {
+            thumbnail,
+            thumbnailMimeType: 'image/jpeg',
+          }
+        : {}),
+    };
     const sanitizedFileName = `${this._sanitizeFileName(character.name)}.zip`;
+    const appProperties = await this.googleDriveManager.buildAppPropertiesFromPayload(hashData);
+    const contentHints = thumbnail ? this.googleDriveManager.buildContentHintsFromThumbnail(thumbnail, 'image/jpeg') : null;
 
     try {
       const result = await this.googleDriveManager.saveFile(
         targetFolderId,
         sanitizedFileName,
-        archive.content,
+        payload.content,
         currentFileId,
-        archive.mimeType,
+        payload.mimeType,
+        appProperties,
+        contentHints,
       );
       return result;
     } catch (error) {
@@ -164,6 +195,32 @@ export class DataManager {
       includeImages: true,
     });
     const archive = await buildCharacterArchive({ data, images });
+    const hashData = data;
+    let thumbnail = null;
+
+    if (Array.isArray(images) && images.length > 0) {
+      try {
+        thumbnail = await ImageManager.createThumbnailFromDataUrl(images[0], {
+          size: 256,
+          mimeType: 'image/jpeg',
+        });
+      } catch (error) {
+        console.warn('Failed to build thumbnail from character images.', error);
+      }
+    }
+
+    const payload = {
+      content: archive.content,
+      mimeType: archive.mimeType,
+      name: this._sanitizeFileName(character.name),
+      hashData,
+      ...(thumbnail
+        ? {
+            thumbnail,
+            thumbnailMimeType: 'image/jpeg',
+          }
+        : {}),
+    };
 
     let targetFileId = currentFileId;
     if (targetFileId) {
@@ -174,18 +231,10 @@ export class DataManager {
     }
 
     if (targetFileId) {
-      return this.googleDriveManager.updateCharacterFile(targetFileId, {
-        content: archive.content,
-        mimeType: archive.mimeType,
-        name: this._sanitizeFileName(character.name),
-      });
+      return this.googleDriveManager.updateCharacterFile(targetFileId, payload);
     }
 
-    return this.googleDriveManager.createCharacterFile({
-      content: archive.content,
-      mimeType: archive.mimeType,
-      name: this._sanitizeFileName(character.name),
-    });
+    return this.googleDriveManager.createCharacterFile(payload);
   }
 
   async findDriveFileByCharacterName(characterName) {

--- a/src/features/character-sheet/services/imageManager.js
+++ b/src/features/character-sheet/services/imageManager.js
@@ -75,21 +75,25 @@ export const ImageManager = {
       throw new Error('Canvas is not supported in this environment.');
     }
 
+    const targetSize = Math.max(1, Number.isFinite(size) ? size : 256);
     const canvas = document.createElement('canvas');
-    canvas.width = size;
-    canvas.height = size;
+    canvas.width = targetSize;
+    canvas.height = targetSize;
     const ctx = canvas.getContext('2d');
     if (!ctx) {
       throw new Error('Canvas context could not be created.');
     }
 
-    const scale = Math.min(size / (img.width || size), size / (img.height || size), 1);
-    const drawWidth = Math.max(1, Math.round((img.width || size) * scale));
-    const drawHeight = Math.max(1, Math.round((img.height || size) * scale));
-    const offsetX = Math.round((size - drawWidth) / 2);
-    const offsetY = Math.round((size - drawHeight) / 2);
+    const baseWidth = Math.max(1, Number.isFinite(img.width) ? img.width : 0);
+    const baseHeight = Math.max(1, Number.isFinite(img.height) ? img.height : 0);
+    const scale = Math.min(targetSize / baseWidth, targetSize / baseHeight, 1);
+    const safeScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
+    const drawWidth = Math.max(1, Math.round(baseWidth * safeScale));
+    const drawHeight = Math.max(1, Math.round(baseHeight * safeScale));
+    const offsetX = Math.round((targetSize - drawWidth) / 2);
+    const offsetY = Math.round((targetSize - drawHeight) / 2);
 
-    ctx.clearRect(0, 0, size, size);
+    ctx.clearRect(0, 0, targetSize, targetSize);
     ctx.drawImage(img, offsetX, offsetY, drawWidth, drawHeight);
 
     return canvas.toDataURL(mimeType);

--- a/src/features/character-sheet/services/imageManager.js
+++ b/src/features/character-sheet/services/imageManager.js
@@ -60,4 +60,38 @@ export const ImageManager = {
       return imagesArray; // Return original array if index is invalid
     }
   },
+
+  async createThumbnailFromDataUrl(imageSource, { size = 256, mimeType = 'image/png' } = {}) {
+    const dataUrl = typeof imageSource === 'string' ? imageSource : await this.loadImage(imageSource);
+
+    const img = await new Promise((resolve, reject) => {
+      const image = new Image();
+      image.onload = () => resolve(image);
+      image.onerror = () => reject(new Error(messages.image.uploadErrors.readError));
+      image.src = dataUrl;
+    });
+
+    if (!globalThis.document?.createElement) {
+      throw new Error('Canvas is not supported in this environment.');
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      throw new Error('Canvas context could not be created.');
+    }
+
+    const scale = Math.min(size / (img.width || size), size / (img.height || size), 1);
+    const drawWidth = Math.max(1, Math.round((img.width || size) * scale));
+    const drawHeight = Math.max(1, Math.round((img.height || size) * scale));
+    const offsetX = Math.round((size - drawWidth) / 2);
+    const offsetY = Math.round((size - drawHeight) / 2);
+
+    ctx.clearRect(0, 0, size, size);
+    ctx.drawImage(img, offsetX, offsetY, drawWidth, drawHeight);
+
+    return canvas.toDataURL(mimeType);
+  },
 };

--- a/src/features/cloud-sync/composables/useDriveLoadPageState.js
+++ b/src/features/cloud-sync/composables/useDriveLoadPageState.js
@@ -57,6 +57,8 @@ export function normalizeMetadataItem(raw) {
   const createdAt = toSeconds(raw?.createdTime || raw?.created_time);
   const syncedAt = raw?.syncedAt || raw?.synced_at || null;
   const shared = raw?.shared == null ? null : Boolean(raw.shared);
+  const hasThumbnail = raw?.hasThumbnail ?? raw?.has_thumbnail ?? null;
+  const thumbnailLink = raw?.thumbnailLink || raw?.thumbnail_link || null;
   const outOfSync = Boolean(raw?.outOfSync || raw?.out_of_sync || raw?.hashMismatch || raw?.modifiedMismatch);
   const lastModifiedAtDrive = driveModifiedAt ?? cachedModifiedAt;
   const contentHash = driveHash || cachedHash || null;
@@ -74,6 +76,8 @@ export function normalizeMetadataItem(raw) {
     createdAt,
     syncedAt,
     shared,
+    hasThumbnail: hasThumbnail == null ? null : Boolean(hasThumbnail),
+    thumbnailLink,
     outOfSync,
   };
 }
@@ -155,7 +159,7 @@ async function defaultRequestDrivePage(driveManager, { pageSize, pageToken, abor
 
   const response = await gapi.client.drive.files.list({
     q: `'${folderId}' in parents and (mimeType='application/zip' or mimeType='application/x-zip-compressed' or mimeType='multipart/x-zip' or mimeType contains 'zip') and trashed=false`,
-    fields: 'nextPageToken, files(id, name, createdTime, modifiedTime, appProperties, shared, mimeType)',
+    fields: 'nextPageToken, files(id, name, createdTime, modifiedTime, appProperties, shared, mimeType, hasThumbnail, thumbnailLink)',
     spaces: 'drive',
     pageSize,
     pageToken,
@@ -215,6 +219,7 @@ export function useDriveLoadPageState(options = {}) {
         (entry.contentHash || entry.characterName
           ? { last_app_hash: entry.contentHash || undefined, character_name: entry.characterName || undefined }
           : undefined),
+      hasThumbnail: entry.hasThumbnail || undefined,
     }));
   }
 
@@ -244,6 +249,8 @@ export function useDriveLoadPageState(options = {}) {
         createdAt: normalized.createdAt ?? existing.createdAt ?? null,
         syncedAt: normalized.syncedAt ?? existing.syncedAt ?? null,
         shared: normalized.shared ?? existing.shared ?? false,
+        hasThumbnail: normalized.hasThumbnail ?? existing.hasThumbnail ?? false,
+        thumbnailLink: normalized.thumbnailLink ?? existing.thumbnailLink ?? null,
       };
       merged.outOfSync = determineOutOfSync(merged);
       merged.syncSource = existing.syncSource || raw.syncSource || buildSyncSource(raw);

--- a/src/features/modals/components/contents/DriveLoadContent.vue
+++ b/src/features/modals/components/contents/DriveLoadContent.vue
@@ -100,6 +100,16 @@ function getDownloadName(item) {
   return item.fileName.toLowerCase().endsWith('.zip') ? item.fileName : `${item.fileName}.zip`;
 }
 
+function getThumbnailUrl(item) {
+  const link = item?.thumbnailLink;
+  if (!link) return null;
+  if (/([?&]sz=)/.test(link)) {
+    return link;
+  }
+  const separator = link.includes('?') ? '&' : '?';
+  return `${link}${separator}sz=w256`;
+}
+
 function requireDriveManager() {
   if (!driveManager) {
     throw new Error(messages.driveLoadPage.errors.missingDriveManager);
@@ -215,80 +225,89 @@ onBeforeUnmount(() => {
         data-test="drive-row"
         :title="item.fileName || messages.driveLoadPage.labels.untitled"
       >
-        <div class="drive-row__main">
-          <div class="drive-row__heading">
-            <h2 class="drive-row__title" data-test="drive-row-title">{{ getCharacterName(item) }}</h2>
-            <div class="drive-row__badges">
-              <span v-if="item.shared" class="drive-row__badge drive-row__badge--muted" role="status">
-                {{ messages.driveLoadPage.labels.shared }}
-              </span>
-              <span v-if="item.outOfSync" class="drive-row__badge drive-row__badge--warning" role="status">
-                {{ messages.driveLoadPage.labels.outOfSync }}
-              </span>
-            </div>
+        <div class="drive-row__layout">
+          <div v-if="getThumbnailUrl(item)" class="drive-row__thumb">
+            <img :src="getThumbnailUrl(item)" loading="lazy" decoding="async" :alt="getCharacterName(item)" />
           </div>
-          <p v-if="item.outOfSync" class="drive-row__warning" data-test="drive-row-warning" role="status">
-            {{ messages.driveLoadPage.labels.hashWarning }}
-          </p>
-        </div>
-        <div class="drive-row__meta">
-          <dl class="drive-row__meta-grid">
-            <div class="drive-row__meta-item" data-test="drive-row-field">
-              <dt>{{ messages.driveLoadPage.labels.created }}</dt>
-              <dd>{{ formatTimestamp(item.createdAt) }}</dd>
+          <div v-else-if="item.hasThumbnail" class="drive-row__thumb drive-row__thumb--placeholder" aria-hidden="true" />
+
+          <div class="drive-row__content">
+            <div class="drive-row__main">
+              <div class="drive-row__heading">
+                <h2 class="drive-row__title" data-test="drive-row-title">{{ getCharacterName(item) }}</h2>
+                <div class="drive-row__badges">
+                  <span v-if="item.shared" class="drive-row__badge drive-row__badge--muted" role="status">
+                    {{ messages.driveLoadPage.labels.shared }}
+                  </span>
+                  <span v-if="item.outOfSync" class="drive-row__badge drive-row__badge--warning" role="status">
+                    {{ messages.driveLoadPage.labels.outOfSync }}
+                  </span>
+                </div>
+              </div>
+              <p v-if="item.outOfSync" class="drive-row__warning" data-test="drive-row-warning" role="status">
+                {{ messages.driveLoadPage.labels.hashWarning }}
+              </p>
             </div>
-            <div class="drive-row__meta-item" data-test="drive-row-field">
-              <dt>{{ messages.driveLoadPage.labels.modified }}</dt>
-              <dd>{{ formatTimestamp(item.lastModifiedAtDrive) }}</dd>
+            <div class="drive-row__meta">
+              <dl class="drive-row__meta-grid">
+                <div class="drive-row__meta-item" data-test="drive-row-field">
+                  <dt>{{ messages.driveLoadPage.labels.created }}</dt>
+                  <dd>{{ formatTimestamp(item.createdAt) }}</dd>
+                </div>
+                <div class="drive-row__meta-item" data-test="drive-row-field">
+                  <dt>{{ messages.driveLoadPage.labels.modified }}</dt>
+                  <dd>{{ formatTimestamp(item.lastModifiedAtDrive) }}</dd>
+                </div>
+              </dl>
+              <div class="drive-row__actions">
+                <button
+                  class="button-base button-base--primary"
+                  type="button"
+                  :aria-label="messages.driveLoadPage.actions.loadAria(getCharacterName(item))"
+                  data-test="drive-row-load"
+                  @click="handleLoad(item.id)"
+                >
+                  {{ messages.driveLoadPage.actions.load }}
+                </button>
+                <button
+                  class="button-base button-base--danger"
+                  type="button"
+                  :aria-label="messages.driveLoadPage.actions.deleteAria(getCharacterName(item))"
+                  data-test="drive-row-delete"
+                  @click="handleDelete(item)"
+                >
+                  {{ messages.driveLoadPage.actions.delete }}
+                </button>
+                <button
+                  class="button-base button-base--ghost"
+                  type="button"
+                  :aria-label="messages.driveLoadPage.actions.shareAria(getCharacterName(item))"
+                  data-test="drive-row-share"
+                  @click="handleShare(item)"
+                >
+                  {{ messages.driveLoadPage.actions.share }}
+                </button>
+                <button
+                  class="button-base button-base--ghost drive-row__unshare"
+                  type="button"
+                  :disabled="!item.shared"
+                  :aria-label="messages.driveLoadPage.actions.unshareAria(getCharacterName(item))"
+                  data-test="drive-row-unshare"
+                  @click="handleUnshare(item)"
+                >
+                  {{ item.shared ? messages.driveLoadPage.actions.unshare : messages.driveLoadPage.actions.unshareDisabled }}
+                </button>
+                <button
+                  class="button-base button-base--ghost"
+                  type="button"
+                  :aria-label="messages.driveLoadPage.actions.downloadAria(getDownloadName(item))"
+                  data-test="drive-row-download"
+                  @click="handleDownload(item)"
+                >
+                  {{ messages.driveLoadPage.actions.download }}
+                </button>
+              </div>
             </div>
-          </dl>
-          <div class="drive-row__actions">
-            <button
-              class="button-base button-base--primary"
-              type="button"
-              :aria-label="messages.driveLoadPage.actions.loadAria(getCharacterName(item))"
-              data-test="drive-row-load"
-              @click="handleLoad(item.id)"
-            >
-              {{ messages.driveLoadPage.actions.load }}
-            </button>
-            <button
-              class="button-base button-base--danger"
-              type="button"
-              :aria-label="messages.driveLoadPage.actions.deleteAria(getCharacterName(item))"
-              data-test="drive-row-delete"
-              @click="handleDelete(item)"
-            >
-              {{ messages.driveLoadPage.actions.delete }}
-            </button>
-            <button
-              class="button-base button-base--ghost"
-              type="button"
-              :aria-label="messages.driveLoadPage.actions.shareAria(getCharacterName(item))"
-              data-test="drive-row-share"
-              @click="handleShare(item)"
-            >
-              {{ messages.driveLoadPage.actions.share }}
-            </button>
-            <button
-              class="button-base button-base--ghost drive-row__unshare"
-              type="button"
-              :disabled="!item.shared"
-              :aria-label="messages.driveLoadPage.actions.unshareAria(getCharacterName(item))"
-              data-test="drive-row-unshare"
-              @click="handleUnshare(item)"
-            >
-              {{ item.shared ? messages.driveLoadPage.actions.unshare : messages.driveLoadPage.actions.unshareDisabled }}
-            </button>
-            <button
-              class="button-base button-base--ghost"
-              type="button"
-              :aria-label="messages.driveLoadPage.actions.downloadAria(getDownloadName(item))"
-              data-test="drive-row-download"
-              @click="handleDownload(item)"
-            >
-              {{ messages.driveLoadPage.actions.download }}
-            </button>
           </div>
         </div>
       </article>
@@ -370,16 +389,46 @@ onBeforeUnmount(() => {
   border-radius: 10px;
   padding: 14px;
   background: linear-gradient(145deg, rgba(39, 39, 52, 0.9), rgba(26, 26, 36, 0.9));
+}
+
+.drive-row__layout {
   display: grid;
-  grid-template-columns: 2fr 3fr;
+  grid-template-columns: 140px 1fr;
   gap: 12px;
-  align-items: center;
+  align-items: stretch;
 }
 
 @media (max-width: 900px) {
-  .drive-row {
+  .drive-row__layout {
     grid-template-columns: 1fr;
   }
+}
+
+.drive-row__thumb {
+  width: 100%;
+  min-height: 140px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--color-border-muted, #3a3a4a);
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.05), rgba(0, 0, 0, 0.35));
+}
+
+.drive-row__thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.drive-row__thumb--placeholder {
+  display: block;
+  background: repeating-linear-gradient(45deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.05) 10px, rgba(0, 0, 0, 0.15) 10px, rgba(0, 0, 0, 0.15) 20px);
+}
+
+.drive-row__content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .drive-row__main {

--- a/src/infrastructure/google-drive/googleDriveManager.js
+++ b/src/infrastructure/google-drive/googleDriveManager.js
@@ -1002,11 +1002,7 @@ export class GoogleDriveManager {
     }
   }
 
-  /**
-   * Creates a character data file inside the configured Drive folder.
-   * @param {{content: string|ArrayBuffer|ArrayBufferView, mimeType?: string, name?: string}} payload
-   */
-  async createCharacterFile(payload) {
+  async _buildCharacterFileParams(payload) {
     const mimeType = payload?.mimeType || 'application/zip';
     const extension = mimeType === 'application/zip' ? 'zip' : 'json';
     const fileName = `${sanitizeFileName(payload?.name)}.${extension}`;
@@ -1016,6 +1012,18 @@ export class GoogleDriveManager {
     const contentHints = payload?.thumbnail
       ? this.buildContentHintsFromThumbnail(payload.thumbnail, payload.thumbnailMimeType)
       : payload?.contentHints;
+
+    return { mimeType, fileName, folderId, appProperties, contentHints };
+  }
+
+  /**
+   * Creates a character data file inside the configured Drive folder.
+   * @param {{content: string|ArrayBuffer|ArrayBufferView, mimeType?: string, name?: string}} payload
+   */
+  async createCharacterFile(payload) {
+    const params = await this._buildCharacterFileParams(payload);
+    if (!params) return null;
+    const { mimeType, fileName, folderId, appProperties, contentHints } = params;
     return this.saveFile(folderId, fileName, payload?.content || '', null, mimeType, appProperties, contentHints);
   }
 
@@ -1025,15 +1033,9 @@ export class GoogleDriveManager {
    * @param {{content: string|ArrayBuffer|ArrayBufferView, mimeType?: string, name?: string}} payload
    */
   async updateCharacterFile(id, payload) {
-    const mimeType = payload?.mimeType || 'application/zip';
-    const extension = mimeType === 'application/zip' ? 'zip' : 'json';
-    const fileName = `${sanitizeFileName(payload?.name)}.${extension}`;
-    const folderId = await this.findOrCreateConfiguredCharacterFolder();
-    if (!folderId) return null;
-    const appProperties = payload?.hashData ? await this.buildAppPropertiesFromPayload(payload.hashData) : undefined;
-    const contentHints = payload?.thumbnail
-      ? this.buildContentHintsFromThumbnail(payload.thumbnail, payload.thumbnailMimeType)
-      : payload?.contentHints;
+    const params = await this._buildCharacterFileParams(payload);
+    if (!params) return null;
+    const { mimeType, fileName, folderId, appProperties, contentHints } = params;
     return this.saveFile(folderId, fileName, payload?.content || '', id, mimeType, appProperties, contentHints);
   }
 

--- a/src/infrastructure/google-drive/googleDriveManager.js
+++ b/src/infrastructure/google-drive/googleDriveManager.js
@@ -16,6 +16,9 @@ function stripImageData(payload) {
     return payload;
   }
   const sanitized = JSON.parse(JSON.stringify(payload));
+  if (sanitized.contentHints) {
+    delete sanitized.contentHints;
+  }
   if (sanitized.character && typeof sanitized.character === 'object') {
     delete sanitized.character.images;
   }
@@ -88,6 +91,25 @@ function prepareMultipartPayload(fileContent) {
     return { body: uint8ArrayToBase64(bytes), transferEncoding: 'Content-Transfer-Encoding: base64\r\n' };
   }
   throw new Error('Unsupported file content type for Drive upload');
+}
+
+function toUrlSafeBase64(input) {
+  return input.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function buildThumbnailContentHints(thumbnail, mimeType = 'image/png') {
+  if (typeof thumbnail !== 'string' || thumbnail.length === 0) {
+    return null;
+  }
+  const commaIndex = thumbnail.indexOf(',');
+  const base64 = commaIndex >= 0 ? thumbnail.slice(commaIndex + 1) : thumbnail;
+  const safeBase64 = toUrlSafeBase64(base64);
+  return {
+    thumbnail: {
+      image: safeBase64,
+      mimeType,
+    },
+  };
 }
 
 function sanitizeFileName(name) {
@@ -527,7 +549,7 @@ export class GoogleDriveManager {
     try {
       const response = await gapi.client.drive.files.list({
         q: `'${folderId}' in parents and mimeType='${mimeType}' and trashed=false`,
-        fields: 'files(id, name, modifiedTime, appProperties, shared)',
+        fields: 'files(id, name, modifiedTime, appProperties, shared, hasThumbnail, thumbnailLink)',
         spaces: 'drive',
       });
       return response.result.files || [];
@@ -545,7 +567,7 @@ export class GoogleDriveManager {
    * @param {string|null} fileId - The ID of the file to update, or null to create a new file.
    * @returns {Promise<{id: string, name: string}|null>} File ID and name, or null on error.
    */
-  async saveFile(folderId, fileName, fileContent, fileId = null, mimeType = 'application/json', appProperties = null) {
+  async saveFile(folderId, fileName, fileContent, fileId = null, mimeType = 'application/json', appProperties = null, contentHints = null) {
     if (!gapi.client || !gapi.client.drive) {
       console.error('GAPI client or Drive API not loaded for saveFile.');
       return null;
@@ -562,6 +584,9 @@ export class GoogleDriveManager {
     };
     if (appProperties) {
       metadata.appProperties = appProperties;
+    }
+    if (contentHints) {
+      metadata.contentHints = contentHints;
     }
     let payload;
     try {
@@ -968,6 +993,15 @@ export class GoogleDriveManager {
     }
   }
 
+  buildContentHintsFromThumbnail(thumbnail, mimeType = 'image/png') {
+    try {
+      return buildThumbnailContentHints(thumbnail, mimeType);
+    } catch (error) {
+      console.error('Failed to build thumbnail content hints:', error);
+      return null;
+    }
+  }
+
   /**
    * Creates a character data file inside the configured Drive folder.
    * @param {{content: string|ArrayBuffer|ArrayBufferView, mimeType?: string, name?: string}} payload
@@ -979,7 +1013,10 @@ export class GoogleDriveManager {
     const folderId = await this.findOrCreateConfiguredCharacterFolder();
     if (!folderId) return null;
     const appProperties = payload?.hashData ? await this.buildAppPropertiesFromPayload(payload.hashData) : undefined;
-    return this.saveFile(folderId, fileName, payload?.content || '', null, mimeType, appProperties);
+    const contentHints = payload?.thumbnail
+      ? this.buildContentHintsFromThumbnail(payload.thumbnail, payload.thumbnailMimeType)
+      : payload?.contentHints;
+    return this.saveFile(folderId, fileName, payload?.content || '', null, mimeType, appProperties, contentHints);
   }
 
   /**
@@ -994,7 +1031,10 @@ export class GoogleDriveManager {
     const folderId = await this.findOrCreateConfiguredCharacterFolder();
     if (!folderId) return null;
     const appProperties = payload?.hashData ? await this.buildAppPropertiesFromPayload(payload.hashData) : undefined;
-    return this.saveFile(folderId, fileName, payload?.content || '', id, mimeType, appProperties);
+    const contentHints = payload?.thumbnail
+      ? this.buildContentHintsFromThumbnail(payload.thumbnail, payload.thumbnailMimeType)
+      : payload?.contentHints;
+    return this.saveFile(folderId, fileName, payload?.content || '', id, mimeType, appProperties, contentHints);
   }
 
   async renameFile(fileId, newName) {

--- a/tests/unit/dataManager.test.js
+++ b/tests/unit/dataManager.test.js
@@ -269,6 +269,8 @@ describe('DataManager', () => {
         updateCharacterFile: vi.fn().mockResolvedValue({ id: '1', name: 'c.zip' }),
         findOrCreateConfiguredCharacterFolder: vi.fn().mockResolvedValue('folder-id'),
         isFileInConfiguredFolder: vi.fn().mockResolvedValue(true),
+        buildAppPropertiesFromPayload: vi.fn().mockResolvedValue(undefined),
+        buildContentHintsFromThumbnail: vi.fn().mockReturnValue(null),
       };
     });
 

--- a/tests/unit/googleDriveManager.test.js
+++ b/tests/unit/googleDriveManager.test.js
@@ -152,6 +152,24 @@ describe('GoogleDriveManager configuration and folder handling', () => {
     expect(requestCall.body).toContain('Content-Type: application/zip');
   });
 
+  test('saveFile injects url-safe thumbnail content hints when provided', async () => {
+    gapi.client.drive.files.list.mockResolvedValue({ result: { files: [] } });
+    gapi.client.request.mockResolvedValueOnce({ result: { id: 'cfg-thumb', name: 'aioniacs.cfg' } });
+    gapi.client.drive.files.create.mockResolvedValue({ result: { id: 'folder-thumb', name: '慈悲なきアイオニア' } });
+    gapi.client.request.mockResolvedValueOnce({ result: { id: 'file-thumb', name: 'Hero.zip' } });
+
+    await gdm.createCharacterFile({
+      content: '{}',
+      mimeType: 'application/zip',
+      name: 'Hero',
+      thumbnail: 'data:image/png;base64,a+b/=',
+      thumbnailMimeType: 'image/png',
+    });
+
+    const requestCall = gapi.client.request.mock.calls.at(-1)[0];
+    expect(requestCall.body).toContain('"contentHints":{"thumbnail":{"image":"a-b_","mimeType":"image/png"}}');
+  });
+
   test('updateCharacterFile patches existing file', async () => {
     gapi.client.drive.files.list.mockResolvedValue({ result: { files: [] } });
     gapi.client.request.mockResolvedValueOnce({ result: { id: 'cfg-6', name: 'aioniacs.cfg' } });
@@ -290,5 +308,26 @@ describe('GoogleDriveManager configuration and folder handling', () => {
       .join('');
 
     expect(hash).toBe(expectedHash);
+  });
+
+  test('calculateMetadataHash ignores contentHints.thumbnail data', async () => {
+    const basePayload = {
+      character: { name: 'Thumbnail Tester' },
+      skills: [],
+      specialSkills: [],
+      equipments: {},
+      histories: [],
+    };
+
+    const withThumbnail = {
+      ...basePayload,
+      contentHints: {
+        thumbnail: { image: 'abc123', mimeType: 'image/png' },
+      },
+    };
+
+    const [hashBase, hashWithThumbnail] = await Promise.all([calculateMetadataHash(basePayload), calculateMetadataHash(withThumbnail)]);
+
+    expect(hashWithThumbnail).toBe(hashBase);
   });
 });

--- a/tests/unit/imageManager.test.js
+++ b/tests/unit/imageManager.test.js
@@ -1,84 +1,63 @@
-import { describe, it, beforeAll, beforeEach, expect } from 'vitest';
-
+import { describe, expect, vi, beforeEach, afterEach, test } from 'vitest';
 import { ImageManager } from '@/features/character-sheet/services/imageManager.js';
-import { messages } from '@/i18n/index.js';
 
-let fileReaderBehavior;
+describe('ImageManager thumbnail generation', () => {
+  let originalImage;
+  let originalDocument;
+  let canvasMock;
 
-class MockFileReader {
-  constructor() {
-    this.onload = null;
-    this.onerror = null;
-  }
+  beforeEach(() => {
+    originalImage = global.Image;
+    originalDocument = global.document;
 
-  readAsDataURL() {
-    if (fileReaderBehavior?.type === 'error') {
-      this.onerror?.(fileReaderBehavior.error || new Error('Mock read error'));
-      return;
+    class FakeImage {
+      constructor() {
+        this.width = 800;
+        this.height = 400;
+        this.onload = null;
+        this.onerror = null;
+      }
+
+      set src(value) {
+        this._src = value;
+        if (this.onload) {
+          this.onload();
+        }
+      }
     }
 
-    const result = fileReaderBehavior?.result || 'data:image/mock;base64,default';
-    this.onload?.({ target: { result } });
-  }
-}
+    canvasMock = {
+      width: 0,
+      height: 0,
+      ctx: {
+        clearRect: vi.fn(),
+        drawImage: vi.fn(),
+      },
+      getContext: vi.fn(function () {
+        return this.ctx;
+      }),
+      toDataURL: vi.fn(() => 'data:image/png;base64,fake'),
+    };
 
-beforeAll(() => {
-  global.FileReader = MockFileReader;
-});
-
-beforeEach(() => {
-  fileReaderBehavior = { type: 'success', result: 'data:image/png;base64,mock-data' };
-});
-
-describe('ImageManager', () => {
-  describe('loadImage', () => {
-    const validFile = { name: 'sample.png', type: 'image/png', size: 1024 };
-
-    it('resolves with FileReader data when reading succeeds', async () => {
-      fileReaderBehavior = { type: 'success', result: 'data:image/png;base64,success' };
-
-      await expect(ImageManager.loadImage(validFile)).resolves.toBe('data:image/png;base64,success');
-    });
-
-    it('rejects with readError message when FileReader fails', async () => {
-      fileReaderBehavior = { type: 'error', error: new Error('FileReader failure') };
-
-      await expect(ImageManager.loadImage(validFile)).rejects.toThrow(messages.image.uploadErrors.readError);
-    });
-
-    it('rejects with noFile message when no file is provided', async () => {
-      await expect(ImageManager.loadImage(null)).rejects.toThrow(messages.image.uploadErrors.noFile);
-    });
-
-    it('rejects with unsupportedType message when MIME type is not allowed', async () => {
-      const unsupportedFile = { name: 'sample.txt', type: 'text/plain', size: 1024 };
-
-      await expect(ImageManager.loadImage(unsupportedFile)).rejects.toThrow(messages.image.uploadErrors.unsupportedType);
-    });
-
-    it('rejects with tooLarge message when file size exceeds 10MB', async () => {
-      const oversizedFile = { name: 'huge.png', type: 'image/png', size: 11 * 1024 * 1024 };
-
-      await expect(ImageManager.loadImage(oversizedFile)).rejects.toThrow(messages.image.uploadErrors.tooLarge);
-    });
+    global.Image = FakeImage;
+    global.document = {
+      createElement: vi.fn(() => canvasMock),
+    };
   });
 
-  describe('removeImage', () => {
-    it('returns a new array without the removed image when index is valid', () => {
-      const images = ['a', 'b', 'c'];
+  afterEach(() => {
+    global.Image = originalImage;
+    global.document = originalDocument;
+  });
 
-      const result = ImageManager.removeImage(images, 1);
+  test('createThumbnailFromDataUrl resizes and centers within 256px square', async () => {
+    const dataUrl = 'data:image/png;base64,aaaa';
+    const result = await ImageManager.createThumbnailFromDataUrl(dataUrl);
 
-      expect(result).toEqual(['a', 'c']);
-      expect(result).not.toBe(images);
-    });
-
-    it('returns the original array when index is invalid', () => {
-      const images = ['a', 'b'];
-
-      const result = ImageManager.removeImage(images, 5);
-
-      expect(result).toBe(images);
-    });
+    expect(canvasMock.width).toBe(256);
+    expect(canvasMock.height).toBe(256);
+    expect(canvasMock.ctx.drawImage).toHaveBeenCalledWith(expect.any(Object), 0, 64, 256, 128);
+    expect(result).toBe('data:image/png;base64,fake');
+    expect(canvasMock.toDataURL).toHaveBeenCalledWith('image/png');
   });
 });

--- a/tests/unit/imageManager.test.js
+++ b/tests/unit/imageManager.test.js
@@ -1,63 +1,172 @@
-import { describe, expect, vi, beforeEach, afterEach, test } from 'vitest';
+import { describe, it, beforeAll, beforeEach, afterEach, afterAll, expect, test, vi } from 'vitest';
 import { ImageManager } from '@/features/character-sheet/services/imageManager.js';
+import { messages } from '@/i18n/index.js';
 
-describe('ImageManager thumbnail generation', () => {
-  let originalImage;
-  let originalDocument;
-  let canvasMock;
+let fileReaderBehavior;
+let originalFileReader;
 
-  beforeEach(() => {
-    originalImage = global.Image;
-    originalDocument = global.document;
+class MockFileReader {
+  constructor() {
+    this.onload = null;
+    this.onerror = null;
+  }
 
-    class FakeImage {
-      constructor() {
-        this.width = 800;
-        this.height = 400;
-        this.onload = null;
-        this.onerror = null;
-      }
-
-      set src(value) {
-        this._src = value;
-        if (this.onload) {
-          this.onload();
-        }
-      }
+  readAsDataURL() {
+    if (fileReaderBehavior?.type === 'error') {
+      this.onerror?.(fileReaderBehavior.error || new Error('Mock read error'));
+      return;
     }
 
-    canvasMock = {
-      width: 0,
-      height: 0,
-      ctx: {
-        clearRect: vi.fn(),
-        drawImage: vi.fn(),
-      },
-      getContext: vi.fn(function () {
-        return this.ctx;
-      }),
-      toDataURL: vi.fn(() => 'data:image/png;base64,fake'),
-    };
+    const result = fileReaderBehavior?.result || 'data:image/mock;base64,default';
+    this.onload?.({ target: { result } });
+  }
+}
 
-    global.Image = FakeImage;
-    global.document = {
-      createElement: vi.fn(() => canvasMock),
-    };
+beforeAll(() => {
+  originalFileReader = global.FileReader;
+  global.FileReader = MockFileReader;
+});
+
+afterAll(() => {
+  global.FileReader = originalFileReader;
+});
+
+beforeEach(() => {
+  fileReaderBehavior = { type: 'success', result: 'data:image/png;base64,mock-data' };
+});
+
+describe('ImageManager', () => {
+  describe('loadImage', () => {
+    const validFile = { name: 'sample.png', type: 'image/png', size: 1024 };
+
+    it('resolves with FileReader data when reading succeeds', async () => {
+      fileReaderBehavior = { type: 'success', result: 'data:image/png;base64,success' };
+
+      await expect(ImageManager.loadImage(validFile)).resolves.toBe('data:image/png;base64,success');
+    });
+
+    it('rejects with readError message when FileReader fails', async () => {
+      fileReaderBehavior = { type: 'error', error: new Error('FileReader failure') };
+
+      await expect(ImageManager.loadImage(validFile)).rejects.toThrow(messages.image.uploadErrors.readError);
+    });
+
+    it('rejects with noFile message when no file is provided', async () => {
+      await expect(ImageManager.loadImage(null)).rejects.toThrow(messages.image.uploadErrors.noFile);
+    });
+
+    it('rejects with unsupportedType message when MIME type is not allowed', async () => {
+      const unsupportedFile = { name: 'sample.txt', type: 'text/plain', size: 1024 };
+
+      await expect(ImageManager.loadImage(unsupportedFile)).rejects.toThrow(messages.image.uploadErrors.unsupportedType);
+    });
+
+    it('rejects with tooLarge message when file size exceeds 10MB', async () => {
+      const oversizedFile = { name: 'huge.png', type: 'image/png', size: 11 * 1024 * 1024 };
+
+      await expect(ImageManager.loadImage(oversizedFile)).rejects.toThrow(messages.image.uploadErrors.tooLarge);
+    });
   });
 
-  afterEach(() => {
-    global.Image = originalImage;
-    global.document = originalDocument;
+  describe('removeImage', () => {
+    it('returns a new array without the removed image when index is valid', () => {
+      const images = ['a', 'b', 'c'];
+
+      const result = ImageManager.removeImage(images, 1);
+
+      expect(result).toEqual(['a', 'c']);
+      expect(result).not.toBe(images);
+    });
+
+    it('returns the original array when index is invalid', () => {
+      const images = ['a', 'b'];
+
+      const result = ImageManager.removeImage(images, 5);
+
+      expect(result).toBe(images);
+    });
   });
 
-  test('createThumbnailFromDataUrl resizes and centers within 256px square', async () => {
-    const dataUrl = 'data:image/png;base64,aaaa';
-    const result = await ImageManager.createThumbnailFromDataUrl(dataUrl);
+  describe('thumbnail generation', () => {
+    let originalImage;
+    let originalDocument;
+    let canvasMock;
+    let nextImageDimensions;
 
-    expect(canvasMock.width).toBe(256);
-    expect(canvasMock.height).toBe(256);
-    expect(canvasMock.ctx.drawImage).toHaveBeenCalledWith(expect.any(Object), 0, 64, 256, 128);
-    expect(result).toBe('data:image/png;base64,fake');
-    expect(canvasMock.toDataURL).toHaveBeenCalledWith('image/png');
+    beforeEach(() => {
+      originalImage = global.Image;
+      originalDocument = global.document;
+      nextImageDimensions = { width: 800, height: 400 };
+
+      class FakeImage {
+        constructor() {
+          this.width = nextImageDimensions.width;
+          this.height = nextImageDimensions.height;
+          this.onload = null;
+          this.onerror = null;
+        }
+
+        set src(value) {
+          this.width = nextImageDimensions.width;
+          this.height = nextImageDimensions.height;
+          this._src = value;
+          if (this.onload) {
+            this.onload();
+          }
+        }
+      }
+
+      canvasMock = {
+        width: 0,
+        height: 0,
+        ctx: {
+          clearRect: vi.fn(),
+          drawImage: vi.fn(),
+        },
+        getContext: vi.fn(function () {
+          return this.ctx;
+        }),
+        toDataURL: vi.fn(() => 'data:image/png;base64,fake'),
+      };
+
+      global.Image = FakeImage;
+      global.document = {
+        createElement: vi.fn(() => canvasMock),
+      };
+    });
+
+    afterEach(() => {
+      global.Image = originalImage;
+      global.document = originalDocument;
+    });
+
+    test('createThumbnailFromDataUrl resizes and centers within 256px square', async () => {
+      const dataUrl = 'data:image/png;base64,aaaa';
+      const result = await ImageManager.createThumbnailFromDataUrl(dataUrl);
+
+      expect(canvasMock.width).toBe(256);
+      expect(canvasMock.height).toBe(256);
+      expect(canvasMock.ctx.drawImage).toHaveBeenCalledWith(expect.any(Object), 0, 64, 256, 128);
+      expect(result).toBe('data:image/png;base64,fake');
+      expect(canvasMock.toDataURL).toHaveBeenCalledWith('image/png');
+    });
+
+    test('createThumbnailFromDataUrl guards against zero or invalid dimensions', async () => {
+      nextImageDimensions = { width: 0, height: 0 };
+      const dataUrl = 'data:image/png;base64,bbbb';
+
+      const result = await ImageManager.createThumbnailFromDataUrl(dataUrl, { size: 128 });
+
+      const drawArgs = canvasMock.ctx.drawImage.mock.calls[0];
+      expect(drawArgs[1]).toBeGreaterThanOrEqual(0);
+      expect(drawArgs[2]).toBeGreaterThanOrEqual(0);
+      expect(drawArgs[3]).toBeGreaterThan(0);
+      expect(drawArgs[4]).toBeGreaterThan(0);
+      expect(Number.isFinite(drawArgs[3])).toBe(true);
+      expect(Number.isFinite(drawArgs[4])).toBe(true);
+      expect(result).toBe('data:image/png;base64,fake');
+      expect(canvasMock.width).toBe(128);
+      expect(canvasMock.height).toBe(128);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- generate 256px thumbnails on the client and attach them to Drive uploads via contentHints
- cache Drive thumbnail flags in D1, sync them through the worker, and surface them in the Drive load view
- lazy-load Drive thumbnails in the character list and expand tests for hashing and thumbnail generation

## Testing
- npm test
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944c5e27444832686da76fc1fba692a)