### PR TITLE
Add Drive metadata sync on load and update warning icon

### DIFF
--- a/src/features/cloud-sync/composables/useDriveLoadPageState.js
+++ b/src/features/cloud-sync/composables/useDriveLoadPageState.js
@@ -310,7 +310,8 @@ export function useDriveLoadPageState(options = {}) {
 
       const response = await postSync(syncPayload, { allowEmpty: true });
       applySyncResponse(response);
-      return response;
+      uiStore.setPrefetchedDriveData(id, payload);
+      return { payload, syncItems: response };
     } catch (error) {
       handleError(error, 'syncItemMetadata');
       return null;
@@ -420,8 +421,11 @@ export function useDriveLoadPageState(options = {}) {
     syncFromDrive();
   }
 
-  function selectCharacter(id) {
+  function selectCharacter(id, initialData) {
     if (!id) return;
+    if (initialData) {
+      uiStore.setPrefetchedDriveData(id, initialData);
+    }
     uiStore.setCurrentDriveFileId(id);
   }
 

--- a/src/features/cloud-sync/composables/useDriveLoadPageState.js
+++ b/src/features/cloud-sync/composables/useDriveLoadPageState.js
@@ -1,8 +1,9 @@
 import { computed, ref } from 'vue';
-import { getGoogleDriveManagerInstance } from '@/infrastructure/google-drive/googleDriveManager.js';
+import { calculateMetadataHash, getGoogleDriveManagerInstance } from '@/infrastructure/google-drive/googleDriveManager.js';
 import { useNotifications } from '@/features/notifications/composables/useNotifications.js';
 import { messages } from '@/i18n/index.js';
 import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
+import { deserializeCharacterPayload } from '@/shared/utils/characterSerialization.js';
 
 const DISPLAY_BATCH = 10;
 const PREFETCH_BUFFER = 10;
@@ -285,6 +286,37 @@ export function useDriveLoadPageState(options = {}) {
     storeItems(mapped, { cachedOnly: false });
   }
 
+  async function syncItemMetadata(id) {
+    if (!id) return null;
+    const target = cacheMap.get(id) || {};
+    try {
+      const content = await driveManager.loadFileContent(id);
+      const payload = await deserializeCharacterPayload(content);
+      const hash = await calculateMetadataHash(payload);
+
+      const characterName =
+        target.characterName || payload?.character?.name || payload?.character?.characterName || payload?.character?.character_name || '';
+
+      const syncPayload = [
+        {
+          id,
+          name: target.fileName,
+          modifiedTime: target.lastModifiedAtDrive ? new Date(target.lastModifiedAtDrive * 1000).toISOString() : undefined,
+          appProperties:
+            hash || characterName ? { last_app_hash: hash || undefined, character_name: characterName || undefined } : undefined,
+          hasThumbnail: target.hasThumbnail || undefined,
+        },
+      ];
+
+      const response = await postSync(syncPayload, { allowEmpty: true });
+      applySyncResponse(response);
+      return response;
+    } catch (error) {
+      handleError(error, 'syncItemMetadata');
+      return null;
+    }
+  }
+
   async function postSync(payload, { allowEmpty = false } = {}) {
     if (!payload || payload.length === 0) {
       if (!allowEmpty) return [];
@@ -406,5 +438,6 @@ export function useDriveLoadPageState(options = {}) {
     cleanup,
     refresh: () => syncFromDrive(),
     selectCharacter,
+    syncItemMetadata,
   };
 }

--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -115,7 +115,7 @@ export function useGoogleDrive(dataManager) {
     }
   }
 
-  async function loadCharacterFromDrive(fileId = uiStore.currentDriveFileId) {
+  async function loadCharacterFromDrive(fileId = uiStore.currentDriveFileId, initialData = null) {
     if (!isDriveReady.value) {
       showToast({ type: 'error', ...messages.googleDrive.initPending() });
       return null;
@@ -128,21 +128,25 @@ export function useGoogleDrive(dataManager) {
       return null;
     }
 
-    const loadPromise = dataManager
-      .loadDataFromDrive(targetId)
+    const providedData = initialData ?? uiStore.consumePrefetchedDriveData(targetId);
+    const loadPromise = Promise.resolve(providedData ?? dataManager.loadDataFromDrive(targetId))
       .then((parsedData) => {
+        const normalizedData = providedData ? dataManager.parseLoadedData(parsedData) : parsedData;
+        if (!normalizedData) {
+          throw new Error(messages.googleDrive.load.missingData().message);
+        }
         if (!parsedData) {
           throw new Error(messages.googleDrive.load.missingData().message);
         }
-        Object.assign(characterStore.character, parsedData.character);
-        characterStore.skills.splice(0, characterStore.skills.length, ...parsedData.skills);
-        characterStore.specialSkills.splice(0, characterStore.specialSkills.length, ...parsedData.specialSkills);
-        Object.assign(characterStore.equipments, parsedData.equipments);
-        characterStore.histories.splice(0, characterStore.histories.length, ...parsedData.histories);
+        Object.assign(characterStore.character, normalizedData.character);
+        characterStore.skills.splice(0, characterStore.skills.length, ...normalizedData.skills);
+        characterStore.specialSkills.splice(0, characterStore.specialSkills.length, ...normalizedData.specialSkills);
+        Object.assign(characterStore.equipments, normalizedData.equipments);
+        characterStore.histories.splice(0, characterStore.histories.length, ...normalizedData.histories);
         uiStore.setCurrentDriveFileId(targetId);
         removeStoredCharacterDraft();
         uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
-        return parsedData;
+        return normalizedData;
       })
       .catch((err) => {
         logAndToastError(err, (caught) => messages.googleDrive.load.error(caught), 'loadCharacterFromDrive');

--- a/src/features/cloud-sync/stores/uiStore.js
+++ b/src/features/cloud-sync/stores/uiStore.js
@@ -8,6 +8,7 @@ export const useUiStore = defineStore('ui', {
     isLoading: false,
     driveFolderPath: '慈悲なきアイオニア',
     currentDriveFileId: null,
+    prefetchedDriveData: {},
     isViewingShared: false,
     showSpecialSkillDescriptions: false,
     showItemDescriptions: false,
@@ -33,6 +34,18 @@ export const useUiStore = defineStore('ui', {
     },
     setCurrentDriveFileId(id) {
       this.currentDriveFileId = id;
+    },
+    setPrefetchedDriveData(id, data) {
+      if (!id || data == null) return;
+      this.prefetchedDriveData = { ...this.prefetchedDriveData, [id]: data };
+    },
+    consumePrefetchedDriveData(id) {
+      if (!id || !this.prefetchedDriveData[id]) return null;
+      const data = this.prefetchedDriveData[id];
+      const rest = { ...this.prefetchedDriveData };
+      delete rest[id];
+      this.prefetchedDriveData = rest;
+      return data;
     },
     clearCurrentDriveFileId() {
       this.currentDriveFileId = null;

--- a/src/features/modals/components/contents/DriveLoadContent.vue
+++ b/src/features/modals/components/contents/DriveLoadContent.vue
@@ -118,14 +118,14 @@ function requireDriveManager() {
   return driveManager;
 }
 
-function handleLoad(item) {
+async function handleLoad(item) {
   if (!item?.id) return;
+  let prefetchedData = null;
   if (item.outOfSync) {
-    syncItemMetadata(item.id).catch((error) =>
-      logAndToastError(error, { title: messages.driveLoadPage.title, message: messages.driveLoadPage.errors.syncFailed }, 'sync-item-metadata'),
-    );
+    const result = await syncItemMetadata(item.id);
+    prefetchedData = result?.payload || null;
   }
-  selectCharacter(item.id);
+  selectCharacter(item.id, prefetchedData);
   modalStore.hideModal();
 }
 

--- a/src/features/modals/components/contents/DriveLoadContent.vue
+++ b/src/features/modals/components/contents/DriveLoadContent.vue
@@ -23,6 +23,7 @@ const {
   refresh,
   cleanup,
   selectCharacter,
+  syncItemMetadata,
 } = useDriveLoadPageState();
 
 const { showAsyncToast, logAndToastError } = useNotifications();
@@ -117,9 +118,14 @@ function requireDriveManager() {
   return driveManager;
 }
 
-function handleLoad(fileId) {
-  if (!fileId) return;
-  selectCharacter(fileId);
+function handleLoad(item) {
+  if (!item?.id) return;
+  if (item.outOfSync) {
+    syncItemMetadata(item.id).catch((error) =>
+      logAndToastError(error, { title: messages.driveLoadPage.title, message: messages.driveLoadPage.errors.syncFailed }, 'sync-item-metadata'),
+    );
+  }
+  selectCharacter(item.id);
   modalStore.hideModal();
 }
 
@@ -236,17 +242,21 @@ onBeforeUnmount(() => {
               <div class="drive-row__heading">
                 <h2 class="drive-row__title" data-test="drive-row-title">{{ getCharacterName(item) }}</h2>
                 <div class="drive-row__badges">
+                  <span
+                    v-if="item.outOfSync"
+                    class="drive-row__indicator drive-row__indicator--warning"
+                    role="img"
+                    :title="messages.driveLoadPage.labels.hashWarning"
+                    :aria-label="messages.driveLoadPage.labels.hashWarning"
+                    data-test="drive-row-warning"
+                  >
+                    ▲
+                  </span>
                   <span v-if="item.shared" class="drive-row__badge drive-row__badge--muted" role="status">
                     {{ messages.driveLoadPage.labels.shared }}
                   </span>
-                  <span v-if="item.outOfSync" class="drive-row__badge drive-row__badge--warning" role="status">
-                    {{ messages.driveLoadPage.labels.outOfSync }}
-                  </span>
                 </div>
               </div>
-              <p v-if="item.outOfSync" class="drive-row__warning" data-test="drive-row-warning" role="status">
-                {{ messages.driveLoadPage.labels.hashWarning }}
-              </p>
             </div>
             <div class="drive-row__meta">
               <dl class="drive-row__meta-grid">
@@ -265,7 +275,7 @@ onBeforeUnmount(() => {
                   type="button"
                   :aria-label="messages.driveLoadPage.actions.loadAria(getCharacterName(item))"
                   data-test="drive-row-load"
-                  @click="handleLoad(item.id)"
+                  @click="handleLoad(item)"
                 >
                   {{ messages.driveLoadPage.actions.load }}
                 </button>
@@ -457,6 +467,25 @@ onBeforeUnmount(() => {
   align-items: center;
 }
 
+.drive-row__indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 200, 70, 0.55);
+  background: radial-gradient(circle at 30% 30%, rgba(255, 220, 120, 0.18), rgba(40, 30, 10, 0.85));
+  color: #f6d76b;
+  font-weight: 800;
+  font-size: 0.85rem;
+  box-shadow: 0 0 12px rgba(255, 200, 70, 0.15);
+}
+
+.drive-row__indicator--warning {
+  background: radial-gradient(circle at 30% 30%, rgba(255, 220, 120, 0.2), rgba(60, 45, 20, 0.9));
+}
+
 .drive-row__badge {
   background: #ffb347;
   color: #1a1a24;
@@ -467,25 +496,10 @@ onBeforeUnmount(() => {
   border: 1px solid transparent;
 }
 
-.drive-row__badge--warning {
-  background: #ff6b6b;
-  color: #1a1a24;
-}
-
 .drive-row__badge--muted {
   background: rgba(255, 255, 255, 0.08);
   color: var(--color-text-primary);
   border-color: var(--color-border-muted, #3a3a4a);
-}
-
-.drive-row__warning {
-  margin: 0;
-  padding: 8px 10px;
-  border-radius: 6px;
-  border: 1px solid rgba(255, 107, 107, 0.4);
-  background: rgba(255, 107, 107, 0.08);
-  color: #ffdede;
-  font-size: 0.9rem;
 }
 
 .drive-row__meta {

--- a/tests/unit/components/DriveLoadContent.test.js
+++ b/tests/unit/components/DriveLoadContent.test.js
@@ -67,6 +67,7 @@ const initialize = vi.fn();
 const refresh = vi.fn();
 const cleanup = vi.fn();
 const selectCharacter = vi.fn();
+const syncItemMetadata = vi.fn().mockResolvedValue();
 
 vi.mock('@/features/cloud-sync/composables/useDriveLoadPageState.js', () => {
   return {
@@ -82,6 +83,7 @@ vi.mock('@/features/cloud-sync/composables/useDriveLoadPageState.js', () => {
       refresh,
       cleanup,
       selectCharacter,
+      syncItemMetadata,
     }),
   };
 });
@@ -91,6 +93,8 @@ describe('DriveLoadContent', () => {
     revealMore.mockClear();
     initialize.mockClear();
     selectCharacter.mockClear();
+    syncItemMetadata.mockClear();
+    syncItemMetadata.mockResolvedValue();
     hideModalMock.mockClear();
     managerMock.deleteCharacterFile.mockReset();
     managerMock.ensureFilePublic.mockReset();
@@ -124,6 +128,26 @@ describe('DriveLoadContent', () => {
     expect(hideModalMock).toHaveBeenCalled();
   });
 
+  it('syncs metadata for out-of-sync items without blocking load', async () => {
+    displayedItems.value = [
+      {
+        id: 'file-sync',
+        fileName: 'Hero.zip',
+        characterName: 'ロードテスト',
+        lastModifiedAtDrive: 1700,
+        createdAt: 1600,
+        outOfSync: true,
+      },
+    ];
+
+    const wrapper = mount(DriveLoadContent);
+    await wrapper.find('[data-test="drive-row-load"]').trigger('click');
+
+    expect(syncItemMetadata).toHaveBeenCalledWith('file-sync');
+    expect(selectCharacter).toHaveBeenCalledWith('file-sync');
+    expect(hideModalMock).toHaveBeenCalled();
+  });
+
   it('renders character info with timestamps and warnings', () => {
     displayedItems.value = [
       {
@@ -142,7 +166,9 @@ describe('DriveLoadContent', () => {
     const fields = wrapper.findAll('[data-test="drive-row-field"]');
     expect(fields[0].text()).toContain(messages.driveLoadPage.labels.created);
     expect(fields[1].text()).toContain(messages.driveLoadPage.labels.modified);
-    expect(wrapper.find('[data-test="drive-row-warning"]').text()).toBe(messages.driveLoadPage.labels.hashWarning);
+    const warning = wrapper.find('[data-test="drive-row-warning"]');
+    expect(warning.text()).toBe('▲');
+    expect(warning.attributes('title')).toBe(messages.driveLoadPage.labels.hashWarning);
   });
 
   it('omits non-zip entries from the rendered list', () => {

--- a/tests/unit/components/DriveLoadContent.test.js
+++ b/tests/unit/components/DriveLoadContent.test.js
@@ -67,7 +67,7 @@ const initialize = vi.fn();
 const refresh = vi.fn();
 const cleanup = vi.fn();
 const selectCharacter = vi.fn();
-const syncItemMetadata = vi.fn().mockResolvedValue();
+const syncItemMetadata = vi.fn().mockResolvedValue({ payload: null, syncItems: [] });
 
 vi.mock('@/features/cloud-sync/composables/useDriveLoadPageState.js', () => {
   return {
@@ -124,7 +124,8 @@ describe('DriveLoadContent', () => {
     ];
     const wrapper = mount(DriveLoadContent);
     await wrapper.find('[data-test="drive-row-load"]').trigger('click');
-    expect(selectCharacter).toHaveBeenCalledWith('file-1');
+    await flushPromises();
+    expect(selectCharacter).toHaveBeenCalledWith('file-1', null);
     expect(hideModalMock).toHaveBeenCalled();
   });
 
@@ -139,12 +140,22 @@ describe('DriveLoadContent', () => {
         outOfSync: true,
       },
     ];
+    syncItemMetadata.mockResolvedValue({
+      payload: { character: { name: 'Synced' }, skills: [], specialSkills: [], equipments: {}, histories: [] },
+    });
 
     const wrapper = mount(DriveLoadContent);
     await wrapper.find('[data-test="drive-row-load"]').trigger('click');
+    await flushPromises();
 
     expect(syncItemMetadata).toHaveBeenCalledWith('file-sync');
-    expect(selectCharacter).toHaveBeenCalledWith('file-sync');
+    expect(selectCharacter).toHaveBeenCalledWith('file-sync', {
+      character: { name: 'Synced' },
+      skills: [],
+      specialSkills: [],
+      equipments: {},
+      histories: [],
+    });
     expect(hideModalMock).toHaveBeenCalled();
   });
 

--- a/tests/unit/composables/useDriveLoadPageState.test.js
+++ b/tests/unit/composables/useDriveLoadPageState.test.js
@@ -3,6 +3,7 @@ import { effectScope, nextTick } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
 import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
 import { useDriveLoadPageState } from '@/features/cloud-sync/composables/useDriveLoadPageState.js';
+import { calculateMetadataHash } from '@/infrastructure/google-drive/googleDriveManager.js';
 
 vi.mock('@/features/notifications/composables/useNotifications.js', () => ({
   useNotifications: () => ({
@@ -247,6 +248,49 @@ describe('useDriveLoadPageState', () => {
 
     expect(state.displayedItems.value[0].outOfSync).toBe(true);
     expect(state.displayedItems.value[0].lastModifiedAtDrive).toBe(1200);
+
+    scope.stop();
+  });
+
+  it('recalculates metadata hash and posts sync payload for a single item', async () => {
+    const payload = {
+      character: { name: 'Sync Hero' },
+      skills: [],
+      specialSkills: [],
+      equipments: {},
+      histories: [],
+    };
+    const expectedHash = await calculateMetadataHash(payload);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse({ items: [{ file_id: 'sync-1', file_name: 'Sync.zip', last_modified_at_drive: 1000 }] }))
+      .mockResolvedValue(createResponse({ items: [{ id: 'sync-1', fileName: 'Sync.zip', content_hash: expectedHash }] }));
+
+    const requestDrivePage = vi.fn().mockResolvedValue({ files: [], nextPageToken: null });
+
+    const driveManager = {
+      findOrCreateConfiguredCharacterFolder: vi.fn().mockResolvedValue('folder'),
+      ensureAccessToken: vi.fn(),
+      loadFileContent: vi.fn().mockResolvedValue(JSON.stringify(payload)),
+    };
+
+    const scope = effectScope();
+    let state;
+    scope.run(() => {
+      state = useDriveLoadPageState({ fetchImpl: fetchMock, requestDrivePage, driveManager });
+    });
+
+    await state.initialize();
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await state.syncItemMetadata('sync-1');
+
+    const syncRequest = fetchMock.mock.calls.at(-1);
+    const body = JSON.parse(syncRequest[1].body);
+    expect(body.files[0].appProperties.last_app_hash).toBe(expectedHash);
+    expect(driveManager.loadFileContent).toHaveBeenCalledWith('sync-1');
+    expect(state.displayedItems.value[0].contentHash).toBe(expectedHash);
 
     scope.stop();
   });

--- a/tests/unit/composables/useDriveLoadPageState.test.js
+++ b/tests/unit/composables/useDriveLoadPageState.test.js
@@ -284,13 +284,17 @@ describe('useDriveLoadPageState', () => {
     await state.initialize();
     await nextTick();
     await new Promise((resolve) => setTimeout(resolve, 0));
-    await state.syncItemMetadata('sync-1');
+    const result = await state.syncItemMetadata('sync-1');
 
     const syncRequest = fetchMock.mock.calls.at(-1);
     const body = JSON.parse(syncRequest[1].body);
     expect(body.files[0].appProperties.last_app_hash).toBe(expectedHash);
     expect(driveManager.loadFileContent).toHaveBeenCalledWith('sync-1');
     expect(state.displayedItems.value[0].contentHash).toBe(expectedHash);
+    expect(result.payload).toEqual(payload);
+
+    const uiStore = useUiStore();
+    expect(uiStore.prefetchedDriveData['sync-1']).toEqual(payload);
 
     scope.stop();
   });
@@ -310,8 +314,10 @@ describe('useDriveLoadPageState', () => {
     });
 
     const uiStore = useUiStore();
-    state.selectCharacter('abc');
+    const preload = { character: { name: 'Cache' } };
+    state.selectCharacter('abc', preload);
     expect(uiStore.currentDriveFileId).toBe('abc');
+    expect(uiStore.prefetchedDriveData.abc).toEqual(preload);
 
     scope.stop();
   });

--- a/tests/unit/composables/useGoogleDrive.test.js
+++ b/tests/unit/composables/useGoogleDrive.test.js
@@ -61,6 +61,7 @@ describe('useGoogleDrive', () => {
     const dataManager = {
       saveCharacterToDrive: vi.fn(),
       loadDataFromDrive: vi.fn().mockResolvedValue(loadData),
+      parseLoadedData: vi.fn(),
       googleDriveManager: {},
       getDriveFileName: vi.fn().mockReturnValue('Explorer.json'),
     };
@@ -77,6 +78,36 @@ describe('useGoogleDrive', () => {
     expect(charStore.character.name).toBe('Explorer');
     expect(uiStore.currentDriveFileId).toBe('file-1');
     expect(uiStore.lastSavedSnapshot).toBe(buildSnapshotFromStore(charStore));
+  });
+
+  test('loadCharacterFromDrive uses initial data without downloading', async () => {
+    const initialData = {
+      character: { name: 'Prefetched' },
+      skills: [],
+      specialSkills: [],
+      equipments: {},
+      histories: [],
+    };
+    const normalized = { ...initialData, character: { name: 'Normalized Prefetched' } };
+    const dataManager = {
+      saveCharacterToDrive: vi.fn(),
+      loadDataFromDrive: vi.fn(),
+      parseLoadedData: vi.fn().mockReturnValue(normalized),
+      googleDriveManager: {},
+      getDriveFileName: vi.fn().mockReturnValue('Prefetched.json'),
+    };
+    const { loadCharacterFromDrive } = useGoogleDrive(dataManager);
+    const charStore = useCharacterStore();
+    const uiStore = useUiStore();
+    uiStore.isGapiInitialized = true;
+    uiStore.isSignedIn = true;
+
+    const result = await loadCharacterFromDrive('file-prefetch', initialData);
+
+    expect(dataManager.loadDataFromDrive).not.toHaveBeenCalled();
+    expect(dataManager.parseLoadedData).toHaveBeenCalledWith(initialData);
+    expect(result).toEqual(normalized);
+    expect(charStore.character.name).toBe('Normalized Prefetched');
   });
 
   test('saveCharacterToDrive renames file when saved name differs from character name', async () => {


### PR DESCRIPTION
## Summary
- add a syncItemMetadata helper to load Drive files, recompute hashes, and send sync updates
- invoke metadata sync when loading out-of-sync items and swap the warning badge for a tooltip icon
- extend unit coverage for the new sync flow and toned-down Drive load UI

## Testing
- npm run lint
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944d93c0520832694a03cce5a4a1645)