### PR TITLE
Fix Google Drive thumbnail upload compliance

### DIFF
--- a/src/features/character-sheet/services/dataManager.js
+++ b/src/features/character-sheet/services/dataManager.js
@@ -119,7 +119,7 @@ export class DataManager {
       try {
         thumbnail = await ImageManager.createThumbnailFromDataUrl(images[0], {
           size: 256,
-          mimeType: 'image/jpeg',
+          mimeType: 'image/png',
         });
       } catch (error) {
         console.warn('Failed to build thumbnail from character images.', error);
@@ -135,7 +135,7 @@ export class DataManager {
       ...(thumbnail
         ? {
             thumbnail,
-            thumbnailMimeType: 'image/jpeg',
+            thumbnailMimeType: 'image/png',
           }
         : {}),
     };
@@ -144,7 +144,7 @@ export class DataManager {
       : undefined;
     const contentHints =
       thumbnail && this.googleDriveManager.buildContentHintsFromThumbnail
-        ? this.googleDriveManager.buildContentHintsFromThumbnail(thumbnail, 'image/jpeg')
+        ? this.googleDriveManager.buildContentHintsFromThumbnail(thumbnail, 'image/png')
         : null;
     const sanitizedFileName = `${sanitizedName}.zip`;
 

--- a/src/infrastructure/google-drive/googleDriveManager.js
+++ b/src/infrastructure/google-drive/googleDriveManager.js
@@ -94,7 +94,7 @@ function prepareMultipartPayload(fileContent) {
 }
 
 function toUrlSafeBase64(input) {
-  return input.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+  return input.replace(/\+/g, '-').replace(/\//g, '_');
 }
 
 function buildThumbnailContentHints(thumbnail, mimeType = 'image/png') {
@@ -576,7 +576,8 @@ export class GoogleDriveManager {
     await this.ensureAccessToken();
 
     const boundary = '-------314159265358979323846';
-    const delimiter = `\r\n--${boundary}\r\n`;
+    const delimiter = `--${boundary}\r\n`;
+    const delimiterWithLeadingBreak = `\r\n--${boundary}\r\n`;
     const closeDelim = `\r\n--${boundary}--`;
     const metadata = {
       name: fileName,
@@ -602,7 +603,7 @@ export class GoogleDriveManager {
           delimiter +
           'Content-Type: application/json; charset=UTF-8\r\n\r\n' +
           JSON.stringify(metadata) +
-          delimiter +
+          delimiterWithLeadingBreak +
           `Content-Type: ${mimeType}\r\n${payload.transferEncoding}\r\n` +
           payload.body +
           closeDelim;
@@ -610,12 +611,14 @@ export class GoogleDriveManager {
         const response = await gapi.client.request({
           path: `/upload/drive/v3/files/${fileId}`,
           method: 'PATCH',
-          params: { uploadType: 'multipart' },
+          params: { uploadType: 'multipart', fields: 'id,name,hasThumbnail,thumbnailLink' },
           headers: {
             'Content-Type': `multipart/related; boundary=${boundary}`,
           },
           body: multipartRequestBody,
         });
+        // Uncomment the line below to verify thumbnail acceptance during testing.
+        // console.log('Thumbnail status:', response.result?.hasThumbnail, response.result?.thumbnailLink);
         console.log('File updated successfully:', response.result);
         return { id: response.result.id, name: response.result.name };
       } catch (error) {
@@ -644,7 +647,7 @@ export class GoogleDriveManager {
         delimiter +
         'Content-Type: application/json; charset=UTF-8\r\n\r\n' +
         JSON.stringify(createMetadata) +
-        delimiter +
+        delimiterWithLeadingBreak +
         `Content-Type: ${mimeType}\r\n${payload.transferEncoding}\r\n` +
         payload.body +
         closeDelim;
@@ -652,10 +655,12 @@ export class GoogleDriveManager {
       const response = await gapi.client.request({
         path: '/upload/drive/v3/files',
         method: 'POST',
-        params: { uploadType: 'multipart', fields: 'id,name' },
+        params: { uploadType: 'multipart', fields: 'id,name,hasThumbnail,thumbnailLink' },
         headers: { 'Content-Type': `multipart/related; boundary=${boundary}` },
         body: multipartRequestBody,
       });
+      // Uncomment the line below to verify thumbnail acceptance during testing.
+      // console.log('Thumbnail status:', response.result?.hasThumbnail, response.result?.thumbnailLink);
       console.log('File created successfully:', response.result);
       return { id: response.result.id, name: response.result.name };
     } catch (error) {

--- a/tests/unit/googleDriveManager.test.js
+++ b/tests/unit/googleDriveManager.test.js
@@ -167,7 +167,7 @@ describe('GoogleDriveManager configuration and folder handling', () => {
     });
 
     const requestCall = gapi.client.request.mock.calls.at(-1)[0];
-    expect(requestCall.body).toContain('"contentHints":{"thumbnail":{"image":"a-b_","mimeType":"image/png"}}');
+    expect(requestCall.body).toContain('"contentHints":{"thumbnail":{"image":"a-b_=","mimeType":"image/png"}}');
   });
 
   test('updateCharacterFile patches existing file', async () => {


### PR DESCRIPTION
## Summary
- preserve URL-safe Base64 padding and start multipart uploads at the boundary while requesting thumbnail fields
- standardize thumbnail handling to image/png across Drive save flows and generated hints
- adjust thumbnail upload test expectations for padded Base64 values

## Testing
- npm run lint
- npm test *(fails: missing optional dependencies hono and vue-router in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944da3083948326a15c13b3de14b7db)