### PR TITLE
Ensure deterministic metadata hashing for Drive metadata

### DIFF
--- a/src/infrastructure/google-drive/googleDriveManager.js
+++ b/src/infrastructure/google-drive/googleDriveManager.js
@@ -32,7 +32,7 @@ function sortObjectKeys(value) {
   if (Array.isArray(value)) {
     return value.map((item) => sortObjectKeys(item));
   }
-  if (value && typeof value === 'object') {
+  if (Object.prototype.toString.call(value) === '[object Object]') {
     return Object.keys(value)
       .sort()
       .reduce((sorted, key) => {

--- a/src/infrastructure/google-drive/googleDriveManager.js
+++ b/src/infrastructure/google-drive/googleDriveManager.js
@@ -28,6 +28,21 @@ function stripImageData(payload) {
   return sanitized;
 }
 
+function sortObjectKeys(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortObjectKeys(item));
+  }
+  if (value && typeof value === 'object') {
+    return Object.keys(value)
+      .sort()
+      .reduce((sorted, key) => {
+        sorted[key] = sortObjectKeys(value[key]);
+        return sorted;
+      }, {});
+  }
+  return value;
+}
+
 function parseHashPayload(payload) {
   if (payload == null) {
     return null;
@@ -64,7 +79,8 @@ export async function calculateMetadataHash(payload) {
     return null;
   }
   const sanitized = stripImageData(parsed);
-  const jsonString = JSON.stringify(sanitized);
+  const sorted = sortObjectKeys(sanitized);
+  const jsonString = JSON.stringify(sorted);
   const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(jsonString));
   return bufferToHex(digest);
 }

--- a/tests/unit/googleDriveManager.test.js
+++ b/tests/unit/googleDriveManager.test.js
@@ -205,6 +205,41 @@ describe('GoogleDriveManager configuration and folder handling', () => {
     expect(requestCall.body).toContain(`"appProperties":{"last_app_hash":"${expectedHash}"`);
   });
 
+  test('calculateMetadataHash returns consistent value for differently ordered objects', async () => {
+    const payloadA = {
+      character: { name: 'Order Hero', attributes: { agility: 8, strength: 10 } },
+      equipments: { shield: 'Wooden', weapon: 'Sword' },
+      histories: [
+        { year: 2, note: 'Traveled' },
+        { year: 1, note: 'Started' },
+      ],
+      skills: [
+        { level: 1, name: 'Slash', details: { power: 7, speed: 5 } },
+        { level: 2, name: 'Block', details: { duration: 3, stability: 4 } },
+      ],
+      specialSkills: [],
+    };
+
+    const payloadB = {
+      specialSkills: [],
+      skills: [
+        { name: 'Slash', details: { speed: 5, power: 7 }, level: 1 },
+        { name: 'Block', details: { stability: 4, duration: 3 }, level: 2 },
+      ],
+      histories: [
+        { note: 'Traveled', year: 2 },
+        { note: 'Started', year: 1 },
+      ],
+      equipments: { weapon: 'Sword', shield: 'Wooden' },
+      character: { attributes: { strength: 10, agility: 8 }, name: 'Order Hero' },
+    };
+
+    const hashA = await calculateMetadataHash(payloadA);
+    const hashB = await calculateMetadataHash(payloadB);
+
+    expect(hashA).toBe(hashB);
+  });
+
   test('renameFile updates file metadata without uploading content', async () => {
     gapi.client.drive.files.update.mockResolvedValue({ result: { id: 'file-rename', name: 'Knight.zip' } });
 
@@ -302,10 +337,7 @@ describe('GoogleDriveManager configuration and folder handling', () => {
       histories: [],
     };
 
-    const buffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(JSON.stringify(expectedPayload)));
-    const expectedHash = Array.from(new Uint8Array(buffer))
-      .map((byte) => byte.toString(16).padStart(2, '0'))
-      .join('');
+    const expectedHash = await calculateMetadataHash(expectedPayload);
 
     expect(hash).toBe(expectedHash);
   });


### PR DESCRIPTION
## Summary
- add recursive key sorting before hashing Drive metadata payloads
- apply deterministic sorting within calculateMetadataHash while preserving image stripping
- extend metadata hash tests to cover varying key order and updated expectations

## Testing
- npm run lint
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944e2123430832694d31d80d7f70ecd)