### PR TITLE
Update drive load UI notifications and layout

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -116,6 +116,7 @@ const { openLoadModal, openIoModal, openShareModal } = useAppModals({
   updateDriveFolderPath,
   canSignInToGoogle,
   isDriveReady,
+  loadCharacterFromDrive,
 });
 
 const maxExperiencePoints = computed(() => characterStore.maxExperiencePoints);

--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -115,7 +115,7 @@ export function useGoogleDrive(dataManager) {
     }
   }
 
-  async function loadCharacterFromDrive(fileId = uiStore.currentDriveFileId, initialData = null) {
+  async function loadCharacterFromDrive(fileId = uiStore.currentDriveFileId, initialData = null, displayName = null) {
     if (!isDriveReady.value) {
       showToast({ type: 'error', ...messages.googleDrive.initPending() });
       return null;
@@ -129,6 +129,7 @@ export function useGoogleDrive(dataManager) {
     }
 
     const providedData = initialData ?? uiStore.consumePrefetchedDriveData(targetId);
+    const targetName = displayName || targetId;
     const loadPromise = Promise.resolve(providedData ?? dataManager.loadDataFromDrive(targetId))
       .then((parsedData) => {
         const normalizedData = providedData ? dataManager.parseLoadedData(parsedData) : parsedData;
@@ -156,8 +157,8 @@ export function useGoogleDrive(dataManager) {
     showAsyncToast(
       loadPromise,
       {
-        loading: messages.googleDrive.load.loading(targetId),
-        success: messages.googleDrive.load.success(targetId),
+        loading: messages.googleDrive.load.loading(targetName),
+        success: messages.googleDrive.load.success(targetName),
         error: (loadErr) => messages.googleDrive.load.error(loadErr),
       },
       'loadCharacterFromDrive',

--- a/src/features/modals/components/BaseModal.vue
+++ b/src/features/modals/components/BaseModal.vue
@@ -8,6 +8,9 @@
             <div class="modal-icon" v-if="modal.type === 'critical'">!</div>
             <div class="modal-title">{{ modal.title }}</div>
           </div>
+          <div class="modal-header-actions" data-slot="header-actions">
+            <slot name="header-actions" />
+          </div>
         </div>
         <div class="modal-content box-content">
           <div class="modal-message" v-if="modal.message">
@@ -48,5 +51,20 @@ function resolve(value) {
 .box-content {
   border: none;
   padding: 14px;
+}
+
+.modal-header {
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding-right: 36px;
+}
+
+.modal-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: auto;
+  flex-wrap: wrap;
 }
 </style>

--- a/src/features/modals/components/BaseModal.vue
+++ b/src/features/modals/components/BaseModal.vue
@@ -64,7 +64,6 @@ function resolve(value) {
   display: flex;
   align-items: center;
   gap: 10px;
-  margin-left: auto;
   flex-wrap: wrap;
 }
 </style>

--- a/src/features/modals/components/contents/DriveLoadContent.vue
+++ b/src/features/modals/components/contents/DriveLoadContent.vue
@@ -130,7 +130,8 @@ async function handleLoad(item) {
   }
   const displayName = getCharacterName(item);
   if (typeof props.loadCharacterFromDrive === 'function') {
-    await props.loadCharacterFromDrive(item.id, prefetchedData, displayName);
+    const loaded = await props.loadCharacterFromDrive(item.id, prefetchedData, displayName);
+    if (!loaded) return;
   } else {
     selectCharacter(item.id, prefetchedData);
   }
@@ -414,13 +415,12 @@ onBeforeUnmount(() => {
   border-radius: 10px;
   padding: 14px;
   background-color: var(--color-panel-body);
-  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .drive-row:hover,
 .drive-row:focus-within {
   background-color: var(--color-panel-sub-header);
-  border-color: var(--color-border-normal);
   box-shadow: 0 4px 12px rgb(0 0 0 / 35%);
 }
 

--- a/src/features/modals/components/contents/DriveLoadContent.vue
+++ b/src/features/modals/components/contents/DriveLoadContent.vue
@@ -27,6 +27,12 @@ const {
 
 const { showAsyncToast, logAndToastError } = useNotifications();
 const modalStore = useModalStore();
+const props = defineProps({
+  loadCharacterFromDrive: {
+    type: Function,
+    default: null,
+  },
+});
 
 let driveManager = null;
 try {
@@ -122,7 +128,12 @@ async function handleLoad(item) {
     const result = await syncItemMetadata(item.id);
     prefetchedData = result?.payload || null;
   }
-  selectCharacter(item.id, prefetchedData);
+  const displayName = getCharacterName(item);
+  if (typeof props.loadCharacterFromDrive === 'function') {
+    await props.loadCharacterFromDrive(item.id, prefetchedData, displayName);
+  } else {
+    selectCharacter(item.id, prefetchedData);
+  }
   modalStore.hideModal();
 }
 
@@ -209,6 +220,11 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="drive-load" :aria-busy="isBusy">
+    <Teleport v-if="modalStore.isVisible" to="[data-slot='header-actions']">
+      <button class="button-base drive-load__refresh" type="button" :disabled="isBusy" @click="refresh">
+        {{ messages.driveLoadPage.buttons.refresh }}
+      </button>
+    </Teleport>
     <header class="drive-load__header">
       <div class="drive-load__title-group">
         <div
@@ -218,9 +234,6 @@ onBeforeUnmount(() => {
         />
         <h1 class="drive-load__title">{{ messages.driveLoadPage.title }}</h1>
       </div>
-      <button class="button-base drive-load__refresh" type="button" :disabled="isBusy" @click="refresh">
-        {{ messages.driveLoadPage.buttons.refresh }}
-      </button>
     </header>
     <p v-if="isEmpty" class="drive-load__placeholder">{{ messages.driveLoadPage.placeholder }}</p>
 
@@ -397,10 +410,18 @@ onBeforeUnmount(() => {
 }
 
 .drive-row {
-  border: 1px solid var(--color-border-muted, #3a3a4a);
+  border: 1px solid var(--color-border-normal);
   border-radius: 10px;
   padding: 14px;
-  background: linear-gradient(145deg, rgba(39, 39, 52, 0.9), rgba(26, 26, 36, 0.9));
+  background-color: var(--color-panel-body);
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.drive-row:hover,
+.drive-row:focus-within {
+  background-color: var(--color-panel-sub-header);
+  border-color: var(--color-border-normal);
+  box-shadow: 0 4px 12px rgb(0 0 0 / 35%);
 }
 
 .drive-row__layout {

--- a/src/features/modals/composables/useAppModals.js
+++ b/src/features/modals/composables/useAppModals.js
@@ -28,13 +28,14 @@ export function useAppModals(options) {
     updateDriveFolderPath,
     canSignInToGoogle,
     isDriveReady,
+    loadCharacterFromDrive,
   } = options;
 
   async function openDriveLoadModal() {
     await showModal({
       component: DriveLoadContent,
       title: messages.driveLoadPage.title,
-      props: {},
+      props: { loadCharacterFromDrive },
       buttons: [],
       size: 'wide',
     });


### PR DESCRIPTION
## Summary
- show drive load toasts using character display names provided by the loader
- add a header action slot to BaseModal and teleport the Drive Load sync button into it
- align Drive Load card styling with shared design variables

## Testing
- npm run lint
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69450c3a2ca8832683c0a2147a47be21)