### PR TITLE
Improve Drive load UX and date formatting

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -153,18 +153,6 @@ watch(
   },
 );
 
-const lastLoadedDriveId = ref(uiStore.currentDriveFileId);
-watch(
-  () => uiStore.currentDriveFileId,
-  async (id) => {
-    if (!id || id === lastLoadedDriveId.value) {
-      return;
-    }
-    lastLoadedDriveId.value = id;
-    await loadCharacterFromDrive(id);
-  },
-);
-
 const { initialize } = useAppInitialization(dataManager);
 const pendingSharedId = ref(null);
 

--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -107,6 +107,16 @@ export function useGoogleDrive(dataManager) {
     }
   }
 
+  function resolveDisplayName(displayName, providedData) {
+    const candidates = [
+      typeof displayName === 'string' ? displayName.trim() : '',
+      typeof providedData?.character?.name === 'string' ? providedData.character.name.trim() : '',
+      typeof characterStore.character.name === 'string' ? characterStore.character.name.trim() : '',
+    ].filter(Boolean);
+
+    return candidates[0] || messages.driveLoadPage.labels.unknownCharacter;
+  }
+
   async function loadCharacterFromDrive(fileId = uiStore.currentDriveFileId, initialData = null, displayName = null) {
     if (!isDriveReady.value) {
       showToast({ type: 'error', ...messages.googleDrive.initPending() });
@@ -121,7 +131,7 @@ export function useGoogleDrive(dataManager) {
     }
 
     const providedData = initialData ?? uiStore.consumePrefetchedDriveData(targetId);
-    const targetName = displayName || targetId;
+    const targetName = resolveDisplayName(displayName, providedData);
     const loadPromise = Promise.resolve(providedData ?? dataManager.loadDataFromDrive(targetId))
       .then((parsedData) => {
         const normalizedData = providedData ? dataManager.parseLoadedData(parsedData) : parsedData;

--- a/src/features/modals/components/contents/DriveLoadContent.vue
+++ b/src/features/modals/components/contents/DriveLoadContent.vue
@@ -7,6 +7,7 @@ import { useNotifications } from '@/features/notifications/composables/useNotifi
 import { getDriveManagerInstance } from '@/infrastructure/google-drive/index.js';
 import { useModalStore } from '@/features/modals/stores/modalStore.js';
 import { useShare } from '@/features/cloud-sync/composables/useShare.js';
+import { formatRelativeDateTime } from '@/shared/utils/utils.js';
 
 const sentinelRef = ref(null);
 const observer = ref(null);
@@ -16,7 +17,6 @@ const {
   isLoadingCache,
   isSyncing,
   isFetchingMore,
-  errorMessage,
   initialize,
   revealMore,
   refresh,
@@ -46,22 +46,21 @@ const { enableShare, disableShare } = useShare({ googleDriveManager: driveManage
 const filteredItems = computed(() =>
   displayedItems.value.filter((item) => typeof item?.fileName === 'string' && item.fileName.toLowerCase().endsWith('.zip')),
 );
-const isEmpty = computed(() => !isLoadingCache.value && filteredItems.value.length === 0);
-const isBusy = computed(() => isSyncing.value || isFetchingMore.value);
+const hasItems = computed(() => filteredItems.value.length > 0);
+const isLoadingEmpty = computed(() => (isLoadingCache.value || isSyncing.value) && !hasItems.value);
+const isEmpty = computed(() => !isLoadingEmpty.value && !hasItems.value);
+const isBusy = computed(() => isSyncing.value || isFetchingMore.value || isLoadingCache.value);
+const loadingLabel = computed(() => messages.driveLoadPage.status.loadingCache || '読み込み中……');
+const emptyLabel = computed(
+  () => messages.driveLoadPage.emptyMessage || messages.driveLoadPage.placeholder || '保存済みのキャラクターシートはありません',
+);
 
 function formatTimestamp(seconds) {
-  if (!seconds) return messages.driveLoadPage.labels.unknownDate;
-  const date = new Date(seconds * 1000);
-  if (Number.isNaN(date.getTime())) {
+  const formatted = formatRelativeDateTime(seconds);
+  if (!formatted) {
     return messages.driveLoadPage.labels.unknownDate;
   }
-  return new Intl.DateTimeFormat('ja-JP', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  }).format(date);
+  return formatted;
 }
 
 function setupObserver() {
@@ -227,12 +226,15 @@ onBeforeUnmount(() => {
       </button>
     </Teleport>
     <header class="drive-load__header">
-      <div class="drive-load__title-group">
-        <div class="drive-load__status-indicator" :data-state="errorMessage ? 'error' : isSyncing ? 'sync' : 'idle'" aria-hidden="true" />
-        <h1 class="drive-load__title">{{ messages.driveLoadPage.title }}</h1>
-      </div>
+      <h1 class="drive-load__title">{{ messages.driveLoadPage.title }}</h1>
     </header>
-    <p v-if="isEmpty" class="drive-load__placeholder">{{ messages.driveLoadPage.placeholder }}</p>
+
+    <div v-if="isLoadingEmpty" class="drive-load__state drive-load__state--loading">
+      <p class="drive-load__state-text">{{ loadingLabel }}</p>
+    </div>
+    <div v-else-if="isEmpty" class="drive-load__state drive-load__state--empty">
+      <p class="drive-load__state-text">{{ emptyLabel }}</p>
+    </div>
 
     <div v-else class="drive-load__list" role="list">
       <article
@@ -251,9 +253,17 @@ onBeforeUnmount(() => {
 
           <div class="drive-row__content">
             <div class="drive-row__main">
-              <div class="drive-row__heading">
+              <div class="drive-row__title-row">
                 <h2 class="drive-row__title" data-test="drive-row-title">{{ getCharacterName(item) }}</h2>
                 <div class="drive-row__badges">
+                  <span
+                    v-if="item.shared"
+                    class="drive-row__badge drive-row__badge--muted"
+                    role="status"
+                    :aria-label="messages.driveLoadPage.labels.sharedAria"
+                  >
+                    {{ messages.driveLoadPage.labels.shared }}
+                  </span>
                   <span
                     v-if="item.outOfSync"
                     class="drive-row__indicator drive-row__indicator--warning"
@@ -264,23 +274,8 @@ onBeforeUnmount(() => {
                   >
                     ▲
                   </span>
-                  <span v-if="item.shared" class="drive-row__badge drive-row__badge--muted" role="status">
-                    {{ messages.driveLoadPage.labels.shared }}
-                  </span>
                 </div>
               </div>
-            </div>
-            <div class="drive-row__meta">
-              <dl class="drive-row__meta-grid">
-                <div class="drive-row__meta-item" data-test="drive-row-field">
-                  <dt>{{ messages.driveLoadPage.labels.created }}</dt>
-                  <dd>{{ formatTimestamp(item.createdAt) }}</dd>
-                </div>
-                <div class="drive-row__meta-item" data-test="drive-row-field">
-                  <dt>{{ messages.driveLoadPage.labels.modified }}</dt>
-                  <dd>{{ formatTimestamp(item.lastModifiedAtDrive) }}</dd>
-                </div>
-              </dl>
               <div class="drive-row__actions">
                 <button
                   class="button-base button-base--primary"
@@ -330,6 +325,16 @@ onBeforeUnmount(() => {
                 </button>
               </div>
             </div>
+            <div class="drive-row__footer">
+              <div class="drive-row__dates">
+                <span data-test="drive-row-field">
+                  {{ messages.driveLoadPage.labels.created }}: {{ formatTimestamp(item.createdAt) }}
+                </span>
+                <span data-test="drive-row-field">
+                  {{ messages.driveLoadPage.labels.modified }}: {{ formatTimestamp(item.lastModifiedAtDrive) }}
+                </span>
+              </div>
+            </div>
           </div>
         </div>
       </article>
@@ -356,14 +361,6 @@ onBeforeUnmount(() => {
   justify-content: space-between;
   gap: 12px;
   padding: 4px 4px 0;
-  flex-wrap: wrap;
-}
-
-.drive-load__title-group {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  min-width: 0;
 }
 
 .drive-load__title {
@@ -373,30 +370,25 @@ onBeforeUnmount(() => {
   color: var(--color-text-primary);
 }
 
-.drive-load__status-indicator {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: var(--color-border-muted, #3a3a4a);
-}
-
-.drive-load__status-indicator[data-state='sync'] {
-  background: #4da3ff;
-  box-shadow: 0 0 0 6px rgba(77, 163, 255, 0.15);
-}
-
-.drive-load__status-indicator[data-state='error'] {
-  background: #ff6b6b;
-  box-shadow: 0 0 0 6px rgba(255, 107, 107, 0.15);
-}
-
 .drive-load__refresh {
   align-self: flex-start;
 }
 
-.drive-load__placeholder {
+.drive-load__state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+  border: 1px dashed var(--color-border-muted, #3a3a4a);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.drive-load__state-text {
   margin: 0;
-  color: var(--color-text-muted);
+  font-size: 1.1rem;
+  color: var(--color-text-primary);
+  text-align: center;
 }
 
 .drive-load__list {
@@ -415,19 +407,25 @@ onBeforeUnmount(() => {
     box-shadow 0.2s ease;
 }
 
+.drive-row__layout {
+  display: flex;
+  gap: 12px;
+  align-items: stretch;
+}
+
 .drive-row__thumb {
-  width: 128px;
-  height: 128px;
+  width: 120px;
+  height: 120px;
   border-radius: 8px;
   overflow: hidden;
   border: 1px solid var(--color-border-muted, #3a3a4a);
   background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.05), rgba(0, 0, 0, 0.35));
-  justify-self: start;
+  flex-shrink: 0;
 }
 
 .drive-row__thumb img {
-  width: 128px;
-  height: 128px;
+  width: 100%;
+  height: 100%;
   object-fit: contain;
   display: block;
 }
@@ -445,21 +443,23 @@ onBeforeUnmount(() => {
 
 .drive-row__content {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   gap: 12px;
+  flex: 1;
+  min-width: 0;
 }
 
 .drive-row__main {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 
-.drive-row__heading {
+.drive-row__title-row {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
 .drive-row__title {
@@ -467,12 +467,15 @@ onBeforeUnmount(() => {
   font-weight: 800;
   font-size: 1.1rem;
   letter-spacing: 0.3px;
+  flex: 1;
+  min-width: 0;
 }
 
 .drive-row__badges {
-  display: flex;
+  display: inline-flex;
   gap: 6px;
   align-items: center;
+  flex-shrink: 0;
 }
 
 .drive-row__indicator {
@@ -510,48 +513,31 @@ onBeforeUnmount(() => {
   border-color: var(--color-border-muted, #3a3a4a);
 }
 
-.drive-row__meta {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  align-items: flex-end;
-}
-
-.drive-row__meta-grid {
-  margin: 0;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(140px, 1fr));
-  gap: 8px 12px;
-}
-
-.drive-row__meta-item {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.drive-row__meta-item dt {
-  color: var(--color-text-muted);
-  font-size: 0.7rem;
-}
-
-.drive-row__meta-item dd {
-  margin: 0;
-  text-align: right;
-  color: var(--color-text-primary);
-  font-weight: 700;
-  font-size: 0.8rem;
-}
-
 .drive-row__actions {
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-end;
   gap: 8px;
+  justify-content: flex-start;
 }
 
 .drive-row__unshare:disabled {
   opacity: 0.5;
+}
+
+.drive-row__footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.drive-row__dates {
+  display: flex;
+  gap: 14px;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  width: 100%;
 }
 
 .drive-load__sentinel {
@@ -559,5 +545,24 @@ onBeforeUnmount(() => {
   color: var(--color-text-muted);
   text-align: center;
   padding: 4px;
+}
+
+@media (max-width: 720px) {
+  .drive-row__layout {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .drive-row__content {
+    width: 100%;
+  }
+
+  .drive-row__actions {
+    justify-content: center;
+  }
+
+  .drive-row__footer {
+    justify-content: center;
+  }
 }
 </style>

--- a/src/shared/utils/utils.js
+++ b/src/shared/utils/utils.js
@@ -22,7 +22,7 @@ export function formatRelativeDateTime(timestampSeconds, { locale = 'ja-JP', tim
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
-    hour12: false,
+    hourCycle: 'h23',
   });
 
   function toZoned(dateTime) {

--- a/src/shared/utils/utils.js
+++ b/src/shared/utils/utils.js
@@ -7,3 +7,57 @@ export function createWeaknessArray(max) {
     .fill(null)
     .map(() => ({ text: '', acquired: '--' }));
 }
+
+export function formatRelativeDateTime(timestampSeconds, { locale = 'ja-JP', timeZone = 'Asia/Tokyo' } = {}) {
+  if (timestampSeconds == null) return null;
+  const milliseconds = Number(timestampSeconds) * 1000;
+  const date = new Date(milliseconds);
+  if (Number.isNaN(date.getTime())) return null;
+
+  const zonedDateFormatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+
+  function toZoned(dateTime) {
+    const parts = zonedDateFormatter.formatToParts(dateTime).reduce((acc, part) => {
+      if (part.type !== 'literal') {
+        acc[part.type] = part.value;
+      }
+      return acc;
+    }, {});
+
+    if (!parts.year || !parts.month || !parts.day || !parts.hour || !parts.minute || !parts.second) {
+      return null;
+    }
+
+    const isoString = `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}Z`;
+    return { parts, zonedDate: new Date(isoString) };
+  }
+
+  const now = new Date();
+  const zonedNow = toZoned(now);
+  const zonedTarget = toZoned(date);
+
+  if (!zonedNow || !zonedTarget) return null;
+
+  const startOfToday = new Date(`${zonedNow.parts.year}-${zonedNow.parts.month}-${zonedNow.parts.day}T00:00:00Z`);
+  const startOfYesterday = new Date(startOfToday);
+  startOfYesterday.setUTCDate(startOfToday.getUTCDate() - 1);
+
+  const timeFormatter = new Intl.DateTimeFormat(locale, { timeZone, hour: '2-digit', minute: '2-digit' });
+  if (zonedTarget.zonedDate >= startOfToday) {
+    return `本日 ${timeFormatter.format(date)}`;
+  }
+  if (zonedTarget.zonedDate >= startOfYesterday) {
+    return `昨日 ${timeFormatter.format(date)}`;
+  }
+
+  return new Intl.DateTimeFormat(locale, { timeZone, year: 'numeric', month: '2-digit', day: '2-digit' }).format(date);
+}

--- a/tests/unit/composables/useGoogleDrive.test.js
+++ b/tests/unit/composables/useGoogleDrive.test.js
@@ -80,6 +80,59 @@ describe('useGoogleDrive', () => {
     expect(uiStore.lastSavedSnapshot).toBe(buildSnapshotFromStore(charStore));
   });
 
+  test('loadCharacterFromDrive uses provided display name in toast messages', async () => {
+    const loadData = {
+      character: { name: 'Explorer' },
+      skills: [],
+      specialSkills: [],
+      equipments: {},
+      histories: [],
+    };
+    const dataManager = {
+      saveCharacterToDrive: vi.fn(),
+      loadDataFromDrive: vi.fn().mockResolvedValue(loadData),
+      parseLoadedData: vi.fn(),
+      googleDriveManager: {},
+      getDriveFileName: vi.fn().mockReturnValue('Explorer.json'),
+    };
+    const { loadCharacterFromDrive } = useGoogleDrive(dataManager);
+    const uiStore = useUiStore();
+    uiStore.isGapiInitialized = true;
+    uiStore.isSignedIn = true;
+
+    await loadCharacterFromDrive('file-display', null, 'Display Name');
+
+    const toastOptions = showAsyncToastMock.mock.calls[showAsyncToastMock.mock.calls.length - 1][1];
+    expect(toastOptions.loading).toEqual(messages.googleDrive.load.loading('Display Name'));
+    expect(toastOptions.success).toEqual(messages.googleDrive.load.success('Display Name'));
+  });
+
+  test('loadCharacterFromDrive falls back to character name when display name is missing', async () => {
+    const initialData = {
+      character: { name: 'Fallback Name' },
+      skills: [],
+      specialSkills: [],
+      equipments: {},
+      histories: [],
+    };
+    const dataManager = {
+      saveCharacterToDrive: vi.fn(),
+      loadDataFromDrive: vi.fn(),
+      parseLoadedData: vi.fn().mockReturnValue(initialData),
+      googleDriveManager: {},
+      getDriveFileName: vi.fn().mockReturnValue('Fallback.json'),
+    };
+    const { loadCharacterFromDrive } = useGoogleDrive(dataManager);
+    const uiStore = useUiStore();
+    uiStore.isGapiInitialized = true;
+    uiStore.isSignedIn = true;
+
+    await loadCharacterFromDrive('file-fallback', initialData);
+
+    const toastOptions = showAsyncToastMock.mock.calls[showAsyncToastMock.mock.calls.length - 1][1];
+    expect(toastOptions.loading).toEqual(messages.googleDrive.load.loading('Fallback Name'));
+  });
+
   test('loadCharacterFromDrive uses initial data without downloading', async () => {
     const initialData = {
       character: { name: 'Prefetched' },

--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -1,5 +1,5 @@
 // tests/unit/utils.test.js
-import { deepClone, createWeaknessArray } from '@/shared/utils/utils.js';
+import { deepClone, createWeaknessArray, formatRelativeDateTime } from '@/shared/utils/utils.js';
 
 describe('deepClone', () => {
   test('returns a deep copy of objects', () => {
@@ -18,5 +18,41 @@ describe('createWeaknessArray', () => {
     arr.forEach((item) => {
       expect(item).toEqual({ text: '', acquired: '--' });
     });
+  });
+});
+
+describe('formatRelativeDateTime', () => {
+  const fixedNow = new Date('2024-05-10T12:00:00+09:00');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(fixedNow);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('returns formatted time for today', () => {
+    const timestampSeconds = Math.floor(new Date('2024-05-10T09:30:00+09:00').getTime() / 1000);
+    const result = formatRelativeDateTime(timestampSeconds);
+    expect(result).toBe('本日 09:30');
+  });
+
+  test('returns formatted time for yesterday', () => {
+    const timestampSeconds = Math.floor(new Date('2024-05-09T23:00:00+09:00').getTime() / 1000);
+    const result = formatRelativeDateTime(timestampSeconds);
+    expect(result).toBe('昨日 23:00');
+  });
+
+  test('returns date for older timestamps', () => {
+    const timestampSeconds = Math.floor(new Date('2024-04-30T12:00:00+09:00').getTime() / 1000);
+    const result = formatRelativeDateTime(timestampSeconds);
+    expect(result).toBe('2024/04/30');
+  });
+
+  test('returns null for invalid values', () => {
+    expect(formatRelativeDateTime(null)).toBeNull();
+    expect(formatRelativeDateTime('invalid')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- remove implicit Drive reloads to avoid duplicate load toasts and ensure Drive load toasts use character names
- simplify Drive load modal states, refresh the row layout, and display creation/modification timestamps with relative formatting
- add a shared relative date utility with accompanying tests and coverage for Drive load notifications

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946335c5fe083269ece7dc6e5e29275)