### PR TITLE
Implement joined styling for load controls and buttons

### DIFF
--- a/src/features/modals/components/contents/DriveLoadContent.vue
+++ b/src/features/modals/components/contents/DriveLoadContent.vue
@@ -276,9 +276,10 @@ onBeforeUnmount(() => {
                   </span>
                 </div>
               </div>
-              <div class="drive-row__actions">
+            <div class="drive-row__actions">
+              <div class="drive-row__action-group">
                 <button
-                  class="button-base button-base--primary"
+                  class="button-base button-base--primary is-joined-right"
                   type="button"
                   :aria-label="messages.driveLoadPage.actions.loadAria(getCharacterName(item))"
                   data-test="drive-row-load"
@@ -287,16 +288,7 @@ onBeforeUnmount(() => {
                   {{ messages.driveLoadPage.actions.load }}
                 </button>
                 <button
-                  class="button-base button-base--danger"
-                  type="button"
-                  :aria-label="messages.driveLoadPage.actions.deleteAria(getCharacterName(item))"
-                  data-test="drive-row-delete"
-                  @click="handleDelete(item)"
-                >
-                  {{ messages.driveLoadPage.actions.delete }}
-                </button>
-                <button
-                  class="button-base button-base--ghost"
+                  class="button-base button-base--ghost is-joined-left is-joined-right"
                   type="button"
                   :aria-label="messages.driveLoadPage.actions.shareAria(getCharacterName(item))"
                   data-test="drive-row-share"
@@ -305,7 +297,7 @@ onBeforeUnmount(() => {
                   {{ messages.driveLoadPage.actions.share }}
                 </button>
                 <button
-                  class="button-base button-base--ghost drive-row__unshare"
+                  class="button-base button-base--ghost drive-row__unshare is-joined-left is-joined-right"
                   type="button"
                   :disabled="!item.shared"
                   :aria-label="messages.driveLoadPage.actions.unshareAria(getCharacterName(item))"
@@ -315,7 +307,7 @@ onBeforeUnmount(() => {
                   {{ item.shared ? messages.driveLoadPage.actions.unshare : messages.driveLoadPage.actions.unshareDisabled }}
                 </button>
                 <button
-                  class="button-base button-base--ghost"
+                  class="button-base button-base--ghost is-joined-left"
                   type="button"
                   :aria-label="messages.driveLoadPage.actions.downloadAria(getDownloadName(item))"
                   data-test="drive-row-download"
@@ -324,6 +316,16 @@ onBeforeUnmount(() => {
                   {{ messages.driveLoadPage.actions.download }}
                 </button>
               </div>
+              <button
+                class="button-base button-base--danger drive-row__delete"
+                type="button"
+                :aria-label="messages.driveLoadPage.actions.deleteAria(getCharacterName(item))"
+                data-test="drive-row-delete"
+                @click="handleDelete(item)"
+              >
+                {{ messages.driveLoadPage.actions.delete }}
+              </button>
+            </div>
             </div>
             <div class="drive-row__footer">
               <div class="drive-row__dates">
@@ -516,8 +518,27 @@ onBeforeUnmount(() => {
 .drive-row__actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  column-gap: 12px;
+  row-gap: 8px;
   justify-content: flex-start;
+  align-items: stretch;
+}
+
+.drive-row__action-group {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 0;
+  row-gap: 8px;
+}
+
+.drive-row__action-group > .button-base,
+.drive-row__delete {
+  height: 48px;
+}
+
+.drive-row__delete {
+  margin-left: auto;
+  flex-shrink: 0;
 }
 
 .drive-row__unshare:disabled {

--- a/src/features/modals/components/contents/LoadModal.vue
+++ b/src/features/modals/components/contents/LoadModal.vue
@@ -13,16 +13,26 @@
       <div class="load-modal__config">
         <label class="load-modal__label" :for="folderInputId">{{ driveFolderLabel }}</label>
         <div class="load-modal__input-group">
-          <input
+          <BaseInput
             :id="folderInputId"
             class="load-modal__input"
             type="text"
             v-model="folderPathInput"
             :placeholder="driveFolderPlaceholder"
             :disabled="isDriveControlsDisabled"
+            :joined="'right'"
             @blur="commitFolderPath"
             @keyup.enter.prevent="commitFolderPath"
           />
+          <button
+            class="button-base button-base--primary load-modal__apply is-joined-left"
+            type="button"
+            :disabled="isDriveControlsDisabled"
+            data-test="load-modal-apply-folder"
+            @click="commitFolderPath"
+          >
+            {{ driveFolderChangeLabel }}
+          </button>
         </div>
       </div>
     </section>
@@ -37,6 +47,7 @@
 
 <script setup>
 import { ref, watch, computed } from 'vue';
+import BaseInput from '@/shared/ui/base/BaseInput.vue';
 
 const props = defineProps({
   isSignedIn: Boolean,
@@ -44,6 +55,7 @@ const props = defineProps({
   isDriveReady: Boolean,
   driveFolderPath: String,
   driveFolderLabel: String,
+  driveFolderChangeLabel: { type: String, default: 'Apply' },
   driveFolderPlaceholder: String,
   loadLocalLabel: String,
   selectCharacterLabel: String,
@@ -118,6 +130,14 @@ function handleLocalChange(event) {
   gap: 8px;
 }
 
+.load-modal__input-group {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 0;
+  row-gap: 8px;
+  align-items: stretch;
+}
+
 .load-modal__button--secondary {
   background-color: var(--color-panel);
   color: var(--color-text-primary, #fff);
@@ -130,17 +150,24 @@ function handleLocalChange(event) {
 }
 
 .load-modal__input {
-  flex: 1;
+  flex: 1 1 0;
   padding: 8px 10px;
-  border-radius: 4px 0 0 4px;
+  border-radius: 4px;
   border: 1px solid var(--color-border-normal);
   background-color: var(--color-panel-body);
   color: var(--color-text-primary, #fff);
+  box-sizing: border-box;
 }
 
 .load-modal__input:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.load-modal__apply {
+  flex: 0 0 auto;
+  height: 48px;
+  padding-inline: 16px;
 }
 
 .load-modal__section--local {

--- a/src/features/modals/composables/useAppModals.js
+++ b/src/features/modals/composables/useAppModals.js
@@ -48,6 +48,7 @@ export function useAppModals(options) {
       isDriveReady: isDriveReady?.value ?? false,
       driveFolderPath: uiStore.driveFolderPath,
       driveFolderLabel: messages.characterHub.driveFolder.label,
+      driveFolderChangeLabel: messages.characterHub.driveFolder.changeButton,
       driveFolderPlaceholder: messages.characterHub.driveFolder.placeholder,
       loadLocalLabel: messages.ui.modal.load.buttons.loadLocal,
       selectCharacterLabel: messages.ui.modal.load.buttons.selectCharacter,

--- a/src/shared/styles/_components.css
+++ b/src/shared/styles/_components.css
@@ -169,6 +169,27 @@
   color: var(--color-accent);
 }
 
+.is-joined-right {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  margin-right: -1px;
+}
+
+.is-joined-left {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.is-joined-left:hover,
+.is-joined-right:hover,
+.is-joined-left:focus,
+.is-joined-right:focus,
+.is-joined-left:focus-visible,
+.is-joined-right:focus-visible {
+  position: relative;
+  z-index: 1;
+}
+
 .list-button--add:hover:not(:disabled) {
   border-color: var(--color-accent);
 }

--- a/src/shared/ui/base/AnimatedButton.vue
+++ b/src/shared/ui/base/AnimatedButton.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     class="button-base animated-button"
-    :class="[stateClass, { 'is-animating': isAnimating }]"
+    :class="[stateClass, joinedClasses, { 'is-animating': isAnimating }]"
     :disabled="isAnimating"
     @click="$emit('click')"
   >
@@ -10,13 +10,14 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 const props = defineProps({
   defaultLabel: { type: String, default: '' },
   animatingLabel: { type: String, default: '' },
   successLabel: { type: String, default: '' },
   trigger: { type: Number, default: 0 },
+  joined: { type: String, default: 'none' },
   timings: {
     type: Object,
     default: () => ({
@@ -34,6 +35,10 @@ const emit = defineEmits(['finished', 'click']);
 const currentLabel = ref(props.defaultLabel);
 const stateClass = ref('');
 const isAnimating = ref(false);
+const joinedClasses = computed(() => ({
+  'is-joined-left': props.joined === 'left' || props.joined === 'both',
+  'is-joined-right': props.joined === 'right' || props.joined === 'both',
+}));
 
 watch(
   () => props.trigger,

--- a/src/shared/ui/base/BaseInput.vue
+++ b/src/shared/ui/base/BaseInput.vue
@@ -1,15 +1,30 @@
 <template>
-  <input v-bind="$attrs" :type="type" :placeholder="placeholder" :disabled="disabled" :value="modelValue" @input="onInput" />
+  <input
+    v-bind="$attrs"
+    :type="type"
+    :placeholder="placeholder"
+    :disabled="disabled"
+    :value="modelValue"
+    :class="joinedClasses"
+    @input="onInput"
+  />
 </template>
 
 <script setup>
-defineProps({
+import { computed } from 'vue';
+
+const props = defineProps({
   modelValue: [String, Number],
   type: { type: String, default: 'text' },
   placeholder: { type: String, default: '' },
   disabled: Boolean,
+  joined: { type: String, default: 'none' },
 });
 const emit = defineEmits(['update:modelValue']);
+const joinedClasses = computed(() => ({
+  'is-joined-left': props.joined === 'left' || props.joined === 'both',
+  'is-joined-right': props.joined === 'right' || props.joined === 'both',
+}));
 function onInput(e) {
   emit('update:modelValue', e.target.value);
 }

--- a/tests/unit/components/LoadModal.test.js
+++ b/tests/unit/components/LoadModal.test.js
@@ -10,6 +10,7 @@ function baseProps(overrides = {}) {
     isDriveReady: true,
     driveFolderPath: 'path',
     driveFolderLabel: 'label',
+    driveFolderChangeLabel: 'change',
     driveFolderPlaceholder: 'placeholder',
     loadLocalLabel: 'local',
     selectCharacterLabel: 'Driveから読み込む',
@@ -38,6 +39,7 @@ describe('LoadModal', () => {
   test('disables drive controls when signed out', async () => {
     const wrapper = mount(LoadModal, { props: baseProps({ isSignedIn: false }) });
     expect(wrapper.find('.load-modal__input').attributes('disabled')).toBeDefined();
+    expect(wrapper.find('[data-test="load-modal-apply-folder"]').attributes('disabled')).toBeDefined();
     expect(wrapper.find('[data-test="load-modal-select-character"]').exists()).toBe(false);
   });
 
@@ -48,5 +50,12 @@ describe('LoadModal', () => {
     expect(button.text()).toBe('Driveから読み込む');
     await button.trigger('click');
     expect(wrapper.emitted('select-character')).toHaveLength(1);
+  });
+
+  test('emits update-drive-folder-path when apply is clicked while signed in', async () => {
+    const wrapper = mount(LoadModal, { props: baseProps({ isSignedIn: true }) });
+    const applyButton = wrapper.find('[data-test="load-modal-apply-folder"]');
+    await applyButton.trigger('click');
+    expect(wrapper.emitted('update-drive-folder-path')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- add shared joined utility classes and expose a `joined` prop on AnimatedButton and BaseInput
- connect the drive folder input and apply button in the load modal with joined styling and updated tests
- group drive action buttons with joined edges while keeping the delete action isolated

## Testing
- npm run lint
- npm test *(fails: missing dependencies hono/vue-router in tests/unit/functions/authApi.test.js and tests/unit/router/index.test.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694639014e7c8326a1f5f048afd1e3c9)