### PR TITLE
Improve character sheet image layout resilience

### DIFF
--- a/src/features/character-sheet/components/sections/CharacterBasicInfo.vue
+++ b/src/features/character-sheet/components/sections/CharacterBasicInfo.vue
@@ -85,6 +85,7 @@ const handleSpeciesChange = () => {
   .character-info {
     display: flex;
     flex-direction: column;
+    min-height: 0;
   }
 
   .character-info .box-content {
@@ -92,6 +93,7 @@ const handleSpeciesChange = () => {
     flex-direction: column;
     flex: 1;
     height: 100%;
+    min-height: 0;
   }
 }
 </style>

--- a/src/features/character-sheet/components/ui/CharacterImageDisplay.vue
+++ b/src/features/character-sheet/components/ui/CharacterImageDisplay.vue
@@ -2,12 +2,7 @@
   <div class="character-image-container">
     <div class="image-display-area">
       <template v-if="imagesInternal.length > 0">
-        <img
-          v-if="currentImageSrc"
-          :src="currentImageSrc"
-          class="character-image-display"
-          :alt="sheetMessages.images.alt"
-        />
+        <img v-if="currentImageSrc" :src="currentImageSrc" class="character-image-display" :alt="sheetMessages.images.alt" />
         <button
           @click="previousImage"
           class="button-base button-imagenav button-imagenav--prev"
@@ -24,24 +19,16 @@
         >
           &gt;
         </button>
-        <div class="image-count-display">
-          {{ currentImageIndex + 1 }} / {{ imagesInternal.length }}
-        </div>
+        <div class="image-count-display">{{ currentImageIndex + 1 }} / {{ imagesInternal.length }}</div>
       </template>
-      
+
       <div class="character-image-placeholder" v-else>
         {{ sheetMessages.images.empty }}
       </div>
     </div>
 
     <div class="image-controls" v-if="!uiStore.isViewingShared">
-      <input
-        type="file"
-        id="character_image_upload"
-        @change="handleImageUpload"
-        accept="image/*"
-        style="display: none"
-      />
+      <input type="file" id="character_image_upload" @change="handleImageUpload" accept="image/*" style="display: none" />
       <label for="character_image_upload" class="button-base imagefile-button imagefile-button--upload">
         {{ sheetMessages.images.add }}
       </label>
@@ -110,11 +97,7 @@ watch(
 const currentImageIndex = ref(0);
 
 const currentImageSrc = computed(() => {
-  if (
-    imagesInternal.value.length > 0 &&
-    currentImageIndex.value >= 0 &&
-    currentImageIndex.value < imagesInternal.value.length
-  ) {
+  if (imagesInternal.value.length > 0 && currentImageIndex.value >= 0 && currentImageIndex.value < imagesInternal.value.length) {
     return imagesInternal.value[currentImageIndex.value];
   }
   return null;
@@ -128,8 +111,7 @@ const nextImage = () => {
 
 const previousImage = () => {
   if (imagesInternal.value.length > 0) {
-    currentImageIndex.value =
-      (currentImageIndex.value - 1 + imagesInternal.value.length) % imagesInternal.value.length;
+    currentImageIndex.value = (currentImageIndex.value - 1 + imagesInternal.value.length) % imagesInternal.value.length;
   }
 };
 
@@ -180,8 +162,8 @@ const handleImageUpload = async (event) => {
   justify-content: center;
   margin-bottom: 0;
   width: 100%;
-  flex: 1 1 0;
-  height: 0;
+  flex: none;
+  height: 350px;
   min-height: clamp(220px, 32vh, 360px);
   background-color: var(--color-background);
   border: 1px solid var(--color-border-normal);
@@ -305,9 +287,8 @@ const handleImageUpload = async (event) => {
 
 @media (min-width: 769px) {
   .character-image-container {
-    flex: 1;
-    height: 100%;
-    width: 100%;
+    height: 0;
+    flex: 1 1 0;
     min-height: 0;
   }
 }

--- a/src/features/character-sheet/components/ui/CharacterImageDisplay.vue
+++ b/src/features/character-sheet/components/ui/CharacterImageDisplay.vue
@@ -164,34 +164,35 @@ const handleImageUpload = async (event) => {
 .character-image-container {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   margin-bottom: 15px;
   padding: 0;
   border: 1px solid var(--color-border-normal);
   border-radius: 3px;
   background-color: var(--color-input-bg);
+  min-height: 0;
 }
 
 .image-display-area {
-  position: relative; 
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
   margin-bottom: 0;
   width: 100%;
-  min-height: 300px; 
-  flex: 1;
+  flex: 1 1 0;
+  height: 0;
+  min-height: clamp(220px, 32vh, 360px);
   background-color: var(--color-background);
   border: 1px solid var(--color-border-normal);
   border-radius: 2px;
-  overflow: hidden; 
+  overflow: hidden;
 }
 
 .character-image-display {
   display: block;
-  max-width: 100%;
-  max-height: 100%;
-  height: auto;
+  width: 100%;
+  height: 100%;
   object-fit: contain;
 }
 
@@ -201,6 +202,7 @@ const handleImageUpload = async (event) => {
   display: flex;
   align-items: center;
   justify-content: center;
+  min-height: clamp(220px, 32vh, 360px);
   color: var(--color-text-input-disabled);
 }
 
@@ -306,6 +308,7 @@ const handleImageUpload = async (event) => {
     flex: 1;
     height: 100%;
     width: 100%;
+    min-height: 0;
   }
 }
 </style>

--- a/src/shared/styles/_layout.css
+++ b/src/shared/styles/_layout.css
@@ -11,10 +11,17 @@
     'items items'
     'memo memo'
     'history history';
+  align-items: stretch;
+}
+
+.main-grid > * {
+  min-width: 0;
+  min-height: 0;
 }
 
 .character-info {
   grid-area: character-info;
+  min-height: 0;
 }
 
 .scar-weakness-wrapper {
@@ -22,6 +29,7 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+  min-height: 0;
 }
 
 .skills {


### PR DESCRIPTION
## Summary
- allow the character info container to stretch without inheriting min-content height
- constrain the character image viewport so extreme aspect ratios are contained without stretching the layout
- reset main grid child min-dimensions to keep desktop rows aligned with adjacent content

## Testing
- npm run lint
- npm test *(fails: tests/unit/functions/authApi.test.js cannot resolve `hono` import)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69464ab751b883268b33e1f87c1b7a30)