### PR TITLE
Remove unused drive out-of-sync handling

### DIFF
--- a/src/contents/ui_messages.csv
+++ b/src/contents/ui_messages.csv
@@ -120,8 +120,6 @@ driveLoadPage.labels.driveHash,Drive上のハッシュ,,Drive load page drive ha
 driveLoadPage.labels.cachedHash,キャッシュのハッシュ,,Drive load page cached hash label
 driveLoadPage.labels.notAvailable,なし,,Drive load page not available label
 driveLoadPage.labels.unknownDate,日時不明,,Drive load page unknown date label
-driveLoadPage.labels.outOfSync,要同期,,Drive load page out-of-sync badge
-driveLoadPage.labels.hashWarning,ハッシュが一致しません。外部で編集された可能性があります,,Drive load page hash mismatch warning
 driveLoadPage.labels.shared,共有中,,Drive load page shared badge
 driveLoadPage.labels.sharedAria,このファイルは共有されています,,Drive load page shared aria label
 driveLoadPage.labels.selectAction,このキャラクターを開く,,Drive load page select card aria label

--- a/src/features/cloud-sync/composables/useDriveLoadPageState.js
+++ b/src/features/cloud-sync/composables/useDriveLoadPageState.js
@@ -3,7 +3,6 @@ import { getDriveManagerInstance } from '@/infrastructure/google-drive/index.js'
 import { useNotifications } from '@/features/notifications/composables/useNotifications.js';
 import { messages } from '@/i18n/index.js';
 import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
-import { deserializeCharacterPayload } from '@/shared/utils/characterSerialization.js';
 
 const DISPLAY_BATCH = 10;
 const PREFETCH_BUFFER = 10;
@@ -63,7 +62,6 @@ export function normalizeMetadataItem(raw) {
     shared,
     hasThumbnail: hasThumbnail == null ? null : Boolean(hasThumbnail),
     thumbnailLink,
-    outOfSync: false,
   };
 }
 
@@ -174,7 +172,6 @@ export function useDriveLoadPageState(options = {}) {
         shared: normalized.shared ?? existing.shared ?? false,
         hasThumbnail: normalized.hasThumbnail ?? existing.hasThumbnail ?? false,
         thumbnailLink: normalized.thumbnailLink ?? existing.thumbnailLink ?? null,
-        outOfSync: false,
       };
       cacheMap.set(normalized.id, merged);
     }
@@ -190,19 +187,6 @@ export function useDriveLoadPageState(options = {}) {
     disposed = true;
     abortControllers.forEach((controller) => controller.abort());
     abortControllers.clear();
-  }
-
-  async function syncItemMetadata(id) {
-    if (!id || !driveManager?.loadFileContent) return null;
-    try {
-      const content = await driveManager.loadFileContent(id);
-      const payload = await deserializeCharacterPayload(content);
-      uiStore.setPrefetchedDriveData(id, payload);
-      return { payload };
-    } catch (error) {
-      handleError(error, 'syncItemMetadata');
-      return null;
-    }
   }
 
   async function syncFromDrive(pageToken = null) {
@@ -270,6 +254,5 @@ export function useDriveLoadPageState(options = {}) {
     cleanup,
     refresh: () => syncFromDrive(),
     selectCharacter,
-    syncItemMetadata,
   };
 }

--- a/src/features/modals/components/contents/DriveLoadContent.vue
+++ b/src/features/modals/components/contents/DriveLoadContent.vue
@@ -22,7 +22,6 @@ const {
   refresh,
   cleanup,
   selectCharacter,
-  syncItemMetadata,
 } = useDriveLoadPageState();
 
 const { showAsyncToast, logAndToastError } = useNotifications();
@@ -122,17 +121,12 @@ function requireDriveManager() {
 
 async function handleLoad(item) {
   if (!item?.id) return;
-  let prefetchedData = null;
-  if (item.outOfSync) {
-    const result = await syncItemMetadata(item.id);
-    prefetchedData = result?.payload || null;
-  }
   const displayName = getCharacterName(item);
   if (typeof props.loadCharacterFromDrive === 'function') {
-    const loaded = await props.loadCharacterFromDrive(item.id, prefetchedData, displayName);
+    const loaded = await props.loadCharacterFromDrive(item.id, null, displayName);
     if (!loaded) return;
   } else {
-    selectCharacter(item.id, prefetchedData);
+    selectCharacter(item.id, null);
   }
   modalStore.hideModal();
 }
@@ -263,16 +257,6 @@ onBeforeUnmount(() => {
                     :aria-label="messages.driveLoadPage.labels.sharedAria"
                   >
                     {{ messages.driveLoadPage.labels.shared }}
-                  </span>
-                  <span
-                    v-if="item.outOfSync"
-                    class="drive-row__indicator drive-row__indicator--warning"
-                    role="img"
-                    :title="messages.driveLoadPage.labels.hashWarning"
-                    :aria-label="messages.driveLoadPage.labels.hashWarning"
-                    data-test="drive-row-warning"
-                  >
-                    ▲
                   </span>
                   <div class="drive-row__dates">
                     <span data-test="drive-row-field">
@@ -476,25 +460,6 @@ onBeforeUnmount(() => {
   gap: 6px;
   align-items: center;
   flex-shrink: 0;
-}
-
-.drive-row__indicator {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 8px;
-  border: 1px solid rgba(255, 200, 70, 0.55);
-  background: radial-gradient(circle at 30% 30%, rgba(255, 220, 120, 0.18), rgba(40, 30, 10, 0.85));
-  color: #f6d76b;
-  font-weight: 800;
-  font-size: 0.85rem;
-  box-shadow: 0 0 12px rgba(255, 200, 70, 0.15);
-}
-
-.drive-row__indicator--warning {
-  background: radial-gradient(circle at 30% 30%, rgba(255, 220, 120, 0.2), rgba(60, 45, 20, 0.9));
 }
 
 .drive-row__badge {

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -266,8 +266,6 @@ export const messages = {
       cachedHash: t('driveLoadPage.labels.cachedHash'),
       notAvailable: t('driveLoadPage.labels.notAvailable'),
       unknownDate: t('driveLoadPage.labels.unknownDate'),
-      outOfSync: t('driveLoadPage.labels.outOfSync'),
-      hashWarning: t('driveLoadPage.labels.hashWarning'),
       shared: t('driveLoadPage.labels.shared'),
       sharedAria: t('driveLoadPage.labels.sharedAria'),
       selectAction: t('driveLoadPage.labels.selectAction'),

--- a/tests/unit/components/DriveLoadContent.test.js
+++ b/tests/unit/components/DriveLoadContent.test.js
@@ -67,7 +67,6 @@ const initialize = vi.fn();
 const refresh = vi.fn();
 const cleanup = vi.fn();
 const selectCharacter = vi.fn();
-const syncItemMetadata = vi.fn().mockResolvedValue({ payload: null, syncItems: [] });
 
 vi.mock('@/features/cloud-sync/composables/useDriveLoadPageState.js', () => {
   return {
@@ -83,7 +82,6 @@ vi.mock('@/features/cloud-sync/composables/useDriveLoadPageState.js', () => {
       refresh,
       cleanup,
       selectCharacter,
-      syncItemMetadata,
     }),
   };
 });
@@ -93,8 +91,6 @@ describe('DriveLoadContent', () => {
     revealMore.mockClear();
     initialize.mockClear();
     selectCharacter.mockClear();
-    syncItemMetadata.mockClear();
-    syncItemMetadata.mockResolvedValue();
     hideModalMock.mockClear();
     managerMock.deleteCharacterFile.mockReset();
     managerMock.ensureFilePublic.mockReset();
@@ -129,37 +125,7 @@ describe('DriveLoadContent', () => {
     expect(hideModalMock).toHaveBeenCalled();
   });
 
-  it('syncs metadata for out-of-sync items without blocking load', async () => {
-    displayedItems.value = [
-      {
-        id: 'file-sync',
-        fileName: 'Hero.zip',
-        characterName: 'ロードテスト',
-        lastModifiedAtDrive: 1700,
-        createdAt: 1600,
-        outOfSync: true,
-      },
-    ];
-    syncItemMetadata.mockResolvedValue({
-      payload: { character: { name: 'Synced' }, skills: [], specialSkills: [], equipments: {}, histories: [] },
-    });
-
-    const wrapper = mount(DriveLoadContent);
-    await wrapper.find('[data-test="drive-row-load"]').trigger('click');
-    await flushPromises();
-
-    expect(syncItemMetadata).toHaveBeenCalledWith('file-sync');
-    expect(selectCharacter).toHaveBeenCalledWith('file-sync', {
-      character: { name: 'Synced' },
-      skills: [],
-      specialSkills: [],
-      equipments: {},
-      histories: [],
-    });
-    expect(hideModalMock).toHaveBeenCalled();
-  });
-
-  it('renders character info with timestamps and warnings', () => {
+  it('renders character info with timestamps', () => {
     displayedItems.value = [
       {
         id: 'file-2',
@@ -168,7 +134,6 @@ describe('DriveLoadContent', () => {
         lastModifiedAtDrive: 2000,
         createdAt: 1900,
         shared: true,
-        outOfSync: true,
       },
     ];
 
@@ -177,9 +142,6 @@ describe('DriveLoadContent', () => {
     const fields = wrapper.findAll('[data-test="drive-row-field"]');
     expect(fields[0].text()).toContain(messages.driveLoadPage.labels.created);
     expect(fields[1].text()).toContain(messages.driveLoadPage.labels.modified);
-    const warning = wrapper.find('[data-test="drive-row-warning"]');
-    expect(warning.text()).toBe('▲');
-    expect(warning.attributes('title')).toBe(messages.driveLoadPage.labels.hashWarning);
   });
 
   it('omits non-zip entries from the rendered list', () => {

--- a/tests/unit/composables/useDriveLoadPageState.test.js
+++ b/tests/unit/composables/useDriveLoadPageState.test.js
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { effectScope, nextTick } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
-import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
 import { useDriveLoadPageState } from '@/features/cloud-sync/composables/useDriveLoadPageState.js';
 
 vi.mock('@/features/notifications/composables/useNotifications.js', () => ({
@@ -110,39 +109,6 @@ describe('useDriveLoadPageState', () => {
 
     expect(state.displayedItems.value).toHaveLength(1);
     expect(state.displayedItems.value[0].fileName).toBe('Valid.zip');
-
-    scope.stop();
-  });
-
-  it('prefetches metadata for a specific entry when requested', async () => {
-    const payload = {
-      character: { playerName: 'GM', name: 'Hero' },
-      skills: [],
-      specialSkills: [],
-      equipments: {},
-      histories: [],
-    };
-
-    const requestDrivePage = vi.fn().mockResolvedValue({ files: [], nextPageToken: null });
-
-    const driveManager = {
-      findOrCreateConfiguredCharacterFolder: vi.fn().mockResolvedValue('folder'),
-      ensureAccessToken: vi.fn(),
-      loadFileContent: vi.fn().mockResolvedValue(JSON.stringify(payload)),
-    };
-
-    const scope = effectScope();
-    let state;
-    scope.run(() => {
-      state = useDriveLoadPageState({ requestDrivePage, driveManager });
-    });
-
-    await state.initialize();
-    const result = await state.syncItemMetadata('file-1');
-
-    const uiStore = useUiStore();
-    expect(result?.payload?.character?.name).toBe('Hero');
-    expect(uiStore.consumePrefetchedDriveData('file-1')).toBeTruthy();
 
     scope.stop();
   });


### PR DESCRIPTION
## Summary
- remove the unused out-of-sync metadata flag and related prefetch logic
- simplify the Drive Load UI by dropping the warning indicator and translations
- update tests to match the streamlined metadata handling

## Testing
- npm test
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69464e6921348326ac6c3c3de77e5295)