### PR TITLE
Standardize delete button styling

### DIFF
--- a/src/features/character-sheet/components/sections/SkillsSection.vue
+++ b/src/features/character-sheet/components/sections/SkillsSection.vue
@@ -13,7 +13,7 @@
               <div class="delete-button-wrapper" v-if="!uiStore.isViewingShared">
                 <button
                   type="button"
-                  class="button-base list-button list-button--delete"
+                  class="button-base button-base--delete list-button"
                   @click="characterStore.removeExpert(skill.id, expIndex)"
                   :disabled="skill.experts.length <= 1 && expert.value === ''"
                   :aria-label="sheetMessages.aria.removeExpert"

--- a/src/features/character-sheet/components/sections/SpecialSkillsSection.vue
+++ b/src/features/character-sheet/components/sections/SpecialSkillsSection.vue
@@ -23,7 +23,7 @@
           <div class="delete-button-wrapper flex-item-delete" v-if="!uiStore.isViewingShared">
             <button
               type="button"
-              class="button-base list-button list-button--delete"
+              class="button-base button-base--delete list-button"
               @click="characterStore.removeSpecialSkill(index)"
               :disabled="localSpecialSkills.length <= 1 && !hasSpecialSkillContent(specialSkill)"
               :aria-label="sheetMessages.aria.removeSpecialSkill"

--- a/src/features/character-sheet/components/ui/CharacterImageDisplay.vue
+++ b/src/features/character-sheet/components/ui/CharacterImageDisplay.vue
@@ -31,7 +31,7 @@
       <button
         :disabled="!currentImageSrc"
         @click="removeCurrentImage"
-        class="button-base imagefile-button imagefile-button--delete"
+        class="button-base button-base--delete imagefile-button"
         :aria-label="sheetMessages.images.deleteAria"
       >
         {{ sheetMessages.images.delete }}
@@ -264,29 +264,6 @@ const handleImageUpload = async (event) => {
 
 .imagefile-button--add:hover:not(:disabled) {
   border-color: var(--color-accent);
-}
-
-.imagefile-button--delete {
-  color: var(--color-delete-text);
-  border-color: var(--color-delete-border);
-}
-
-.imagefile-button--delete:hover:not(:disabled) {
-  border-color: var(--color-delete-text);
-  box-shadow:
-    inset 0 0 3px var(--color-delete-text),
-    0 0 6px var(--color-delete-text);
-  text-shadow: 0 0 2px var(--color-delete-text);
-  color: var(--color-delete-text-light);
-}
-
-.imagefile-button--delete:disabled {
-  cursor: default;
-  background-color: transparent;
-  color: var(--color-border-normal);
-  border-color: var(--color-border-normal);
-  box-shadow: none;
-  text-shadow: none;
 }
 
 @media (min-width: 769px) {

--- a/src/features/modals/components/contents/DriveLoadContent.vue
+++ b/src/features/modals/components/contents/DriveLoadContent.vue
@@ -296,7 +296,7 @@ onBeforeUnmount(() => {
                   </button>
                 </div>
                 <button
-                  class="button-base button-base--danger drive-row__delete"
+                  class="button-base button-base--delete drive-row__delete"
                   type="button"
                   :aria-label="messages.driveLoadPage.actions.deleteAria(getCharacterName(item))"
                   data-test="drive-row-delete"

--- a/src/shared/styles/_components.css
+++ b/src/shared/styles/_components.css
@@ -194,11 +194,13 @@
   border-color: var(--color-accent);
 }
 
+.button-base--delete,
 .list-button--delete {
   color: var(--color-delete-text);
   border-color: var(--color-delete-border);
 }
 
+.button-base--delete:hover:not(:disabled),
 .list-button--delete:hover:not(:disabled) {
   color: var(--color-delete-text);
   border-color: var(--color-delete-text);

--- a/src/shared/styles/_components.css
+++ b/src/shared/styles/_components.css
@@ -194,8 +194,7 @@
   border-color: var(--color-accent);
 }
 
-.button-base--delete,
-.list-button--delete {
+.button-base--delete {
   color: var(--color-delete-text);
   border-color: var(--color-delete-border);
 }

--- a/src/shared/ui/base/BaseListItem.vue
+++ b/src/shared/ui/base/BaseListItem.vue
@@ -3,7 +3,7 @@
     <div v-if="showDeleteButton" class="delete-button-wrapper">
       <button
         type="button"
-        class="button-base list-button list-button--delete"
+        class="button-base button-base--delete list-button"
         @click="emitDelete"
         :disabled="!canDelete"
         :aria-label="sheetMessages.aria.deleteItem"


### PR DESCRIPTION
## Summary
- add a shared delete button modifier and apply it across delete actions
- update character sheet sections, modals, and image controls to use the unified class
- remove redundant component-scoped delete button styles

## Testing
- npm run lint
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694664e516f883268d424d6ad6247f86)