### PR TITLE
Handle Drive item deletion in UI

### DIFF
--- a/src/features/cloud-sync/composables/useDriveLoadPageState.js
+++ b/src/features/cloud-sync/composables/useDriveLoadPageState.js
@@ -178,6 +178,12 @@ export function useDriveLoadPageState(options = {}) {
     updateItemsFromCacheMap();
   }
 
+  function removeItem(id) {
+    if (!id || !cacheMap.has(id)) return;
+    cacheMap.delete(id);
+    updateItemsFromCacheMap();
+  }
+
   function registerAborter(controller) {
     abortControllers.add(controller);
     return controller;
@@ -254,5 +260,6 @@ export function useDriveLoadPageState(options = {}) {
     cleanup,
     refresh: () => syncFromDrive(),
     selectCharacter,
+    removeItem,
   };
 }

--- a/src/features/modals/components/contents/DriveLoadContent.vue
+++ b/src/features/modals/components/contents/DriveLoadContent.vue
@@ -12,8 +12,18 @@ import { formatRelativeDateTime } from '@/shared/utils/utils.js';
 const sentinelRef = ref(null);
 const observer = ref(null);
 
-const { displayedItems, isLoadingCache, isSyncing, isFetchingMore, initialize, revealMore, refresh, cleanup, selectCharacter } =
-  useDriveLoadPageState();
+const {
+  displayedItems,
+  isLoadingCache,
+  isSyncing,
+  isFetchingMore,
+  initialize,
+  revealMore,
+  refresh,
+  cleanup,
+  selectCharacter,
+  removeItem,
+} = useDriveLoadPageState();
 
 const { showAsyncToast, logAndToastError } = useNotifications();
 const modalStore = useModalStore();
@@ -145,6 +155,7 @@ async function confirmDelete(item) {
   const manager = requireDriveManager();
   try {
     await showAsyncToast(manager.deleteCharacterFile(item.id), messages.driveLoadPage.toasts.delete, 'drive-delete');
+    removeItem(item.id);
     await refresh();
   } catch (error) {
     logAndToastError(error, messages.driveLoadPage.toasts.delete.error, 'drive-delete');

--- a/tests/unit/components/DriveLoadContent.test.js
+++ b/tests/unit/components/DriveLoadContent.test.js
@@ -67,6 +67,9 @@ const initialize = vi.fn();
 const refresh = vi.fn();
 const cleanup = vi.fn();
 const selectCharacter = vi.fn();
+const removeItem = vi.fn((id) => {
+  displayedItems.value = displayedItems.value.filter((item) => item.id !== id);
+});
 
 vi.mock('@/features/cloud-sync/composables/useDriveLoadPageState.js', () => {
   return {
@@ -82,6 +85,7 @@ vi.mock('@/features/cloud-sync/composables/useDriveLoadPageState.js', () => {
       refresh,
       cleanup,
       selectCharacter,
+      removeItem,
     }),
   };
 });
@@ -98,6 +102,7 @@ describe('DriveLoadContent', () => {
     enableShareMock.mockReset();
     disableShareMock.mockReset();
     copyTextMock.mockReset();
+    removeItem.mockClear();
     displayedItems.value = [];
   });
 
@@ -203,6 +208,26 @@ describe('DriveLoadContent', () => {
     await flushPromises();
 
     expect(managerMock.deleteCharacterFile).toHaveBeenCalledWith('file-5');
+  });
+
+  it('removes an item from the DOM after deletion', async () => {
+    managerMock.deleteCharacterFile.mockResolvedValue();
+    displayedItems.value = [
+      { id: 'file-7', fileName: 'ToRemove.zip', characterName: 'Remove', lastModifiedAtDrive: 1700, createdAt: 1600 },
+      { id: 'file-8', fileName: 'Keep.zip', characterName: 'Keep', lastModifiedAtDrive: 1500, createdAt: 1400 },
+    ];
+
+    const wrapper = mount(DriveLoadContent);
+
+    await wrapper.find('[data-test="drive-row-delete"]').trigger('click');
+    await flushPromises();
+    await wrapper.find('[data-test="drive-row-delete"]').trigger('click');
+    await flushPromises();
+
+    expect(removeItem).toHaveBeenCalledWith('file-7');
+    const items = wrapper.findAll('[data-test="drive-row"]');
+    expect(items).toHaveLength(1);
+    expect(items[0].text()).toContain('Keep');
   });
 
   it('unshares a file immediately and refreshes', async () => {

--- a/tests/unit/composables/useDriveLoadPageState.test.js
+++ b/tests/unit/composables/useDriveLoadPageState.test.js
@@ -112,4 +112,43 @@ describe('useDriveLoadPageState', () => {
 
     scope.stop();
   });
+
+  it('removes items from the cache and public list when removeItem is called', async () => {
+    const requestDrivePage = vi.fn().mockResolvedValue({
+      files: [
+        { id: 'remove-1', name: 'Keep.zip', mimeType: 'application/zip' },
+        { id: 'remove-2', name: 'Delete.zip', mimeType: 'application/zip' },
+      ],
+      nextPageToken: null,
+    });
+
+    const driveManager = {
+      findOrCreateConfiguredCharacterFolder: vi.fn().mockResolvedValue('folder'),
+      ensureAccessToken: vi.fn(),
+    };
+
+    const scope = effectScope();
+    let state;
+    scope.run(() => {
+      state = useDriveLoadPageState({ requestDrivePage, driveManager });
+    });
+
+    await state.initialize();
+    await nextTick();
+
+    expect(state.displayedItems.value).toHaveLength(2);
+
+    state.removeItem('remove-2');
+    await nextTick();
+
+    expect(state.displayedItems.value).toHaveLength(1);
+    expect(state.displayedItems.value[0].id).toBe('remove-1');
+
+    state.removeItem('missing');
+    await nextTick();
+
+    expect(state.displayedItems.value).toHaveLength(1);
+
+    scope.stop();
+  });
 });


### PR DESCRIPTION
## Summary
- add a removeItem helper to the Drive load state to prune cache entries
- remove deleted Drive items from the modal list immediately after a successful delete
- cover the new removal flow with composable and component tests

## Testing
- npm test
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69473d33eccc83268e9998a9fe0ab139)