### PR TITLE
Fix async toast handling and drive UI error cleanup

### DIFF
--- a/src/contents/ui_messages.csv
+++ b/src/contents/ui_messages.csv
@@ -105,10 +105,8 @@ driveLoadPage.title,保存済み冒険者,,Drive load page title
 driveLoadPage.placeholder,ここにGoogle Drive上のキャラクター一覧が表示されます,,Drive load page placeholder
 driveLoadPage.buttons.back,シートに戻る,,Drive load page back button
 driveLoadPage.buttons.refresh,同期,,Drive load page refresh button
-driveLoadPage.status.loadingCache,キャッシュを読み込み中…,,Drive load page cache status
-driveLoadPage.status.syncing,Google Driveと同期中…,,Drive load page syncing status
+driveLoadPage.status.loading,読み込み中…,,Drive load page loading status
 driveLoadPage.status.refreshed,最新の一覧を表示しています,,Drive load page refreshed status
-driveLoadPage.status.loadMore,さらに読み込み中…,,Drive load page load more status
 driveLoadPage.status.error,一覧の取得に失敗しました,,Drive load page error status
 driveLoadPage.status.retryHint,再試行してください。ネットワークや認証状態をご確認ください,,Drive load page retry hint
 driveLoadPage.labels.untitled,無題のファイル,,Drive load page untitled label

--- a/src/features/cloud-sync/composables/useDriveLoadPageState.js
+++ b/src/features/cloud-sync/composables/useDriveLoadPageState.js
@@ -131,9 +131,11 @@ export function useDriveLoadPageState(options = {}) {
   const isFetchingMore = ref(false);
   const errorMessage = ref('');
   const visibleCount = ref(0);
+  const isLoading = computed(() => isLoadingCache.value || isSyncing.value);
+  const isBusy = computed(() => isLoading.value || isFetchingMore.value);
   const statusMessage = computed(() => {
     if (errorMessage.value) return errorMessage.value;
-    if (isSyncing.value) return messages.driveLoadPage.status.syncing;
+    if (isLoading.value) return messages.driveLoadPage.status.loading;
     return messages.driveLoadPage.status.refreshed;
   });
   const displayedItems = computed(() => items.value.slice(0, visibleCount.value));
@@ -252,6 +254,8 @@ export function useDriveLoadPageState(options = {}) {
     isLoadingCache,
     isSyncing,
     isFetchingMore,
+    isLoading,
+    isBusy,
     statusMessage,
     errorMessage,
     nextPageToken,

--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -132,29 +132,24 @@ export function useGoogleDrive(dataManager) {
 
     const providedData = initialData ?? uiStore.consumePrefetchedDriveData(targetId);
     const targetName = resolveDisplayName(displayName, providedData);
-    const loadPromise = Promise.resolve(providedData ?? dataManager.loadDataFromDrive(targetId))
-      .then((parsedData) => {
-        const normalizedData = providedData ? dataManager.parseLoadedData(parsedData) : parsedData;
-        if (!normalizedData) {
-          throw new Error(messages.googleDrive.load.missingData().message);
-        }
-        if (!parsedData) {
-          throw new Error(messages.googleDrive.load.missingData().message);
-        }
-        Object.assign(characterStore.character, normalizedData.character);
-        characterStore.skills.splice(0, characterStore.skills.length, ...normalizedData.skills);
-        characterStore.specialSkills.splice(0, characterStore.specialSkills.length, ...normalizedData.specialSkills);
-        Object.assign(characterStore.equipments, normalizedData.equipments);
-        characterStore.histories.splice(0, characterStore.histories.length, ...normalizedData.histories);
-        uiStore.setCurrentDriveFileId(targetId);
-        removeStoredCharacterDraft();
-        uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
-        return normalizedData;
-      })
-      .catch((err) => {
-        logAndToastError(err, (caught) => messages.googleDrive.load.error(caught), 'loadCharacterFromDrive');
-        return null;
-      });
+    const loadPromise = Promise.resolve(providedData ?? dataManager.loadDataFromDrive(targetId)).then((parsedData) => {
+      const normalizedData = providedData ? dataManager.parseLoadedData(parsedData) : parsedData;
+      if (!normalizedData) {
+        throw new Error(messages.googleDrive.load.missingData().message);
+      }
+      if (!parsedData) {
+        throw new Error(messages.googleDrive.load.missingData().message);
+      }
+      Object.assign(characterStore.character, normalizedData.character);
+      characterStore.skills.splice(0, characterStore.skills.length, ...normalizedData.skills);
+      characterStore.specialSkills.splice(0, characterStore.specialSkills.length, ...normalizedData.specialSkills);
+      Object.assign(characterStore.equipments, normalizedData.equipments);
+      characterStore.histories.splice(0, characterStore.histories.length, ...normalizedData.histories);
+      uiStore.setCurrentDriveFileId(targetId);
+      removeStoredCharacterDraft();
+      uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
+      return normalizedData;
+    });
 
     showAsyncToast(
       loadPromise,
@@ -166,7 +161,7 @@ export function useGoogleDrive(dataManager) {
       'loadCharacterFromDrive',
     );
 
-    return loadPromise;
+    return loadPromise.catch(() => null);
   }
 
   async function saveCharacterToDrive(option = false) {

--- a/src/features/modals/components/contents/DriveLoadContent.vue
+++ b/src/features/modals/components/contents/DriveLoadContent.vue
@@ -14,9 +14,8 @@ const observer = ref(null);
 
 const {
   displayedItems,
-  isLoadingCache,
-  isSyncing,
-  isFetchingMore,
+  isLoading,
+  isBusy,
   initialize,
   revealMore,
   refresh,
@@ -55,13 +54,13 @@ const filteredItems = computed(() =>
   displayedItems.value.filter((item) => typeof item?.fileName === 'string' && item.fileName.toLowerCase().endsWith('.zip')),
 );
 const hasItems = computed(() => filteredItems.value.length > 0);
-const isLoadingEmpty = computed(() => (isLoadingCache.value || isSyncing.value) && !hasItems.value);
+const isLoadingEmpty = computed(() => isLoading.value && !hasItems.value);
 const isEmpty = computed(() => !isLoadingEmpty.value && !hasItems.value);
-const isBusy = computed(() => isSyncing.value || isFetchingMore.value || isLoadingCache.value);
-const loadingLabel = computed(() => messages.driveLoadPage.status.loadingCache || '読み込み中……');
+const loadingLabel = computed(() => messages.driveLoadPage.status.loading || '読み込み中……');
 const emptyLabel = computed(
   () => messages.driveLoadPage.emptyMessage || messages.driveLoadPage.placeholder || '保存済みのキャラクターシートはありません',
 );
+const showSentinelMessage = computed(() => hasItems.value && isBusy.value);
 
 function formatTimestamp(seconds) {
   const formatted = formatRelativeDateTime(seconds);
@@ -157,8 +156,6 @@ async function confirmDelete(item) {
     await showAsyncToast(manager.deleteCharacterFile(item.id), messages.driveLoadPage.toasts.delete, 'drive-delete');
     removeItem(item.id);
     await refresh();
-  } catch (error) {
-    logAndToastError(error, messages.driveLoadPage.toasts.delete.error, 'drive-delete');
   } finally {
     cancelDelete();
   }
@@ -179,7 +176,7 @@ async function handleShare(item) {
   try {
     await showAsyncToast(task, messages.driveLoadPage.toasts.share, 'drive-share');
   } catch (error) {
-    logAndToastError(error, messages.driveLoadPage.toasts.share.error, 'drive-share');
+    return error;
   }
 }
 
@@ -191,8 +188,6 @@ async function handleUnshare(item) {
   try {
     await showAsyncToast(disableShare(item.id), messages.driveLoadPage.toasts.unshare, 'drive-unshare');
     await refresh();
-  } catch (error) {
-    logAndToastError(error, messages.driveLoadPage.toasts.unshare.error, 'drive-unshare');
   } finally {
     processingItemId.value = null;
   }
@@ -220,7 +215,7 @@ async function handleDownload(item) {
   try {
     await showAsyncToast(task, messages.driveLoadPage.toasts.download, 'drive-download');
   } catch (error) {
-    logAndToastError(error, messages.driveLoadPage.toasts.download.error, 'drive-download');
+    return error;
   }
 }
 
@@ -378,8 +373,7 @@ onBeforeUnmount(() => {
     </div>
 
     <div ref="sentinelRef" class="drive-load__sentinel" aria-hidden="true">
-      <span v-if="isSyncing">{{ messages.driveLoadPage.status.syncing }}</span>
-      <span v-else-if="isFetchingMore">{{ messages.driveLoadPage.status.loadMore }}</span>
+      <span v-if="showSentinelMessage">{{ loadingLabel }}</span>
     </div>
   </div>
 </template>

--- a/src/features/notifications/composables/useNotifications.js
+++ b/src/features/notifications/composables/useNotifications.js
@@ -55,29 +55,33 @@ export function useNotifications() {
   }
 
   function showAsyncToast(promise, messages, context = 'async-toast') {
+    const loadingOptions = resolveToastOptions(messages?.loading);
     const id = showToast({
       duration: 0,
       type: 'info',
-      ...(messages.loading || {}),
+      ...loadingOptions,
     });
 
     const finalize = (opts, type) => {
-      const duration = opts.duration === undefined ? 1000 : opts.duration;
-      store.updateToast(id, { duration, type, ...opts });
+      const normalized = opts || {};
+      const duration = normalized.duration === undefined ? 1000 : normalized.duration;
+      store.updateToast(id, { duration, type, ...normalized });
     };
 
-    promise
+    const managedPromise = promise
       .then((res) => {
-        finalize(messages.success || {}, 'success');
+        const successOptions = resolveToastOptions(messages?.success, res);
+        finalize(successOptions, 'success');
         return res;
       })
       .catch((err) => {
         const normalized = logError(err, context);
-        const errorOpts = resolveToastOptions(messages.error, normalized);
+        const errorOpts = resolveToastOptions(messages?.error, normalized);
         finalize(errorOpts, 'error');
+        throw normalized;
       });
 
-    return promise;
+    return managedPromise;
   }
 
   return { showToast, showAsyncToast, logAndToastError };

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -249,10 +249,8 @@ export const messages = {
       refresh: t('driveLoadPage.buttons.refresh'),
     },
     status: {
-      loadingCache: t('driveLoadPage.status.loadingCache'),
-      syncing: t('driveLoadPage.status.syncing'),
+      loading: t('driveLoadPage.status.loading'),
       refreshed: t('driveLoadPage.status.refreshed'),
-      loadMore: t('driveLoadPage.status.loadMore'),
       error: t('driveLoadPage.status.error'),
       retryHint: t('driveLoadPage.status.retryHint'),
     },

--- a/tests/unit/components/DriveLoadContent.test.js
+++ b/tests/unit/components/DriveLoadContent.test.js
@@ -78,6 +78,8 @@ vi.mock('@/features/cloud-sync/composables/useDriveLoadPageState.js', () => {
       isLoadingCache: ref(false),
       isSyncing: ref(false),
       isFetchingMore: ref(false),
+      isLoading: computed(() => false),
+      isBusy: computed(() => false),
       statusMessage: computed(() => 'status'),
       errorMessage: ref(''),
       initialize,

--- a/tests/unit/composables/useNotifications.test.js
+++ b/tests/unit/composables/useNotifications.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { useNotifications } from '@/features/notifications/composables/useNotifications.js';
+
+const addToast = vi.fn();
+const updateToast = vi.fn();
+
+vi.mock('@/features/notifications/stores/notificationStore.js', () => ({
+  useNotificationStore: () => ({
+    addToast,
+    updateToast,
+  }),
+}));
+
+vi.mock('@/i18n/index.js', () => ({
+  messages: {
+    errors: { unexpected: 'Unexpected error' },
+  },
+}));
+
+describe('useNotifications', () => {
+  beforeEach(() => {
+    let counter = 0;
+    addToast.mockClear();
+    addToast.mockImplementation(() => `toast-${++counter}`);
+    updateToast.mockReset();
+  });
+
+  it('resolves function-based toast messages for loading and success states', async () => {
+    const { showAsyncToast } = useNotifications();
+    const asyncTask = Promise.resolve('done');
+
+    await showAsyncToast(asyncTask, {
+      loading: () => ({ title: 'Loading', message: 'Working…' }),
+      success: (res) => ({ title: 'Success', message: `Result: ${res}` }),
+    });
+
+    expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'info', message: 'Working…' }));
+    expect(updateToast).toHaveBeenCalledWith(
+      'toast-1',
+      expect.objectContaining({ type: 'success', message: 'Result: done', duration: 1000 }),
+    );
+  });
+
+  it('logs and updates error toasts when the task fails', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { showAsyncToast } = useNotifications();
+    const failingTask = Promise.reject(new Error('toast boom'));
+
+    await expect(
+      showAsyncToast(failingTask, { error: (err) => ({ title: 'Failed', message: err.message }) }, 'toast-context'),
+    ).rejects.toThrow('toast boom');
+
+    expect(consoleSpy).toHaveBeenCalledWith('[toast-context]', expect.any(Error));
+    expect(updateToast).toHaveBeenCalledWith('toast-1', expect.objectContaining({ type: 'error', message: 'toast boom', duration: 1000 }));
+
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure async toast options are resolved for function-based messages and propagate normalized errors
- align Drive load interactions with centralized toast handling to avoid duplicate error logs
- add unit coverage for useNotifications to confirm message resolution and error logging

## Testing
- npm test *(fails: missing test dependencies hono and vue-router in authApi.test.js and router/index.test.js)*
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947709d03848326935a81344c46ad3a)