### PR TITLE
Fix Google API init race handling

### DIFF
--- a/src/app/providers/useAppInitialization.js
+++ b/src/app/providers/useAppInitialization.js
@@ -1,11 +1,41 @@
 import { initializeDriveManager, isUsingMockDrive } from '@/infrastructure/google-drive/index.js';
 import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
 
+function waitForGoogleScript() {
+  if (typeof window === 'undefined') {
+    return Promise.resolve();
+  }
+  if (window.gapi && window.gapi.load) {
+    return Promise.resolve();
+  }
+  if (typeof document === 'undefined') {
+    return Promise.resolve();
+  }
+  const script = document.querySelector('script[src*="apis.google.com/js/api.js"]');
+  if (!script) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    const finalize = () => {
+      script.removeEventListener('load', finalize);
+      script.removeEventListener('error', finalize);
+      resolve();
+    };
+    script.addEventListener('load', finalize);
+    script.addEventListener('error', finalize);
+  });
+}
+
 export function useAppInitialization() {
   const uiStore = useUiStore();
 
   async function initialize() {
     const driveManager = initializeDriveManager(import.meta.env.VITE_GOOGLE_API_KEY, import.meta.env.VITE_GOOGLE_CLIENT_ID);
+    const usingMock = isUsingMockDrive();
+
+    if (!usingMock) {
+      await waitForGoogleScript();
+    }
 
     if (driveManager && typeof driveManager.onGapiLoad === 'function') {
       try {
@@ -21,12 +51,12 @@ export function useAppInitialization() {
         }
       } catch (error) {
         console.error('Failed to initialize Drive manager:', error);
-        if (isUsingMockDrive()) {
+        if (usingMock) {
           uiStore.isGapiInitialized = true;
           uiStore.isSignedIn = true;
         }
       }
-    } else if (isUsingMockDrive()) {
+    } else if (usingMock) {
       uiStore.isGapiInitialized = true;
       uiStore.isSignedIn = true;
     }

--- a/src/app/providers/useAppInitialization.js
+++ b/src/app/providers/useAppInitialization.js
@@ -15,14 +15,30 @@ function waitForGoogleScript() {
   if (!script) {
     return Promise.resolve();
   }
-  return new Promise((resolve) => {
-    const finalize = () => {
-      script.removeEventListener('load', finalize);
-      script.removeEventListener('error', finalize);
+  return new Promise((resolve, reject) => {
+    let timerId;
+    const cleanup = () => {
+      if (timerId) {
+        clearTimeout(timerId);
+        timerId = null;
+      }
+      script.removeEventListener('load', onLoad);
+      script.removeEventListener('error', onError);
+    };
+    const onLoad = () => {
+      cleanup();
       resolve();
     };
-    script.addEventListener('load', finalize);
-    script.addEventListener('error', finalize);
+    const onError = () => {
+      cleanup();
+      reject(new Error('Google API script failed to load.'));
+    };
+    timerId = setTimeout(() => {
+      cleanup();
+      reject(new Error('Google API script load timed out.'));
+    }, 8000);
+    script.addEventListener('load', onLoad);
+    script.addEventListener('error', onError);
   });
 }
 
@@ -33,12 +49,11 @@ export function useAppInitialization() {
     const driveManager = initializeDriveManager(import.meta.env.VITE_GOOGLE_API_KEY, import.meta.env.VITE_GOOGLE_CLIENT_ID);
     const usingMock = isUsingMockDrive();
 
-    if (!usingMock) {
-      await waitForGoogleScript();
-    }
-
     if (driveManager && typeof driveManager.onGapiLoad === 'function') {
       try {
+        if (!usingMock) {
+          await waitForGoogleScript();
+        }
         await driveManager.onGapiLoad();
         uiStore.isGapiInitialized = true;
         const restored = await driveManager.restoreSession();

--- a/src/infrastructure/google-drive/googleDriveManager.js
+++ b/src/infrastructure/google-drive/googleDriveManager.js
@@ -248,18 +248,23 @@ export class GoogleDriveManager {
       return this.gapiLoadPromise;
     }
 
+    if (typeof gapi === 'undefined' || !gapi.load) {
+      const err = new Error('GAPI core script not available for gapi.load.');
+      console.error('GDM: ' + err.message);
+      return Promise.reject(err);
+    }
+
     this.gapiLoadPromise = new Promise((resolve, reject) => {
-      if (typeof gapi === 'undefined' || !gapi.load) {
-        const err = new Error('GAPI core script not available for gapi.load.');
-        console.error('GDM: ' + err.message);
-        return reject(err);
-      }
+      const resetAndReject = (error) => {
+        this.gapiLoadPromise = null;
+        reject(error);
+      };
       // Picker API removed; initialize only the Drive client for in-app loaders.
       gapi.load('client', () => {
         if (typeof gapi.client === 'undefined' || !gapi.client.init) {
           const err = new Error('GAPI client script not available for gapi.client.init.');
           console.error('GDM: ' + err.message);
-          return reject(err);
+          return resetAndReject(err);
         }
         gapi.client
           .init({
@@ -273,7 +278,7 @@ export class GoogleDriveManager {
           })
           .catch((error) => {
             console.error('GDM: Error initializing GAPI client:', error);
-            reject(error);
+            resetAndReject(error);
           });
       });
     });


### PR DESCRIPTION
### Motivation
- Prevent a race where the app initializes before the Google API core script is available, which caused unrecoverable failures and a cached rejected Promise.
- Allow the Drive initialization to be retried after transient load/initialization errors instead of permanently caching a failed Promise.

### Description
- Update `onGapiLoad` in `src/infrastructure/google-drive/googleDriveManager.js` to early-reject when `gapi`/`gapi.load` is missing and to reset the cached `gapiLoadPromise` on initialization errors so retries are possible.
- Add a `resetAndReject` helper to clear `this.gapiLoadPromise` on failures and use it for both client script and init errors.
- Add `waitForGoogleScript` in `src/app/providers/useAppInitialization.js` to await the `<script src=".../api.js">` tag `load`/`error` events (skipped when `isUsingMockDrive()`), and reuse a `usingMock` flag during initialization.
- Keep existing mock-drive behavior and avoid polling or altering `index.html` script attributes.

### Testing
- Ran `npm run lint` and the lint checks completed successfully.
- Ran `npm test` and all automated tests passed (`35` test files, `165` tests) with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69639dc9be888326a78c82b927368ee6)