### PR TITLE
Suppress expected auth errors during session restore

### DIFF
--- a/src/infrastructure/google-drive/googleDriveManager.js
+++ b/src/infrastructure/google-drive/googleDriveManager.js
@@ -327,7 +327,12 @@ export class GoogleDriveManager {
       await this.ensureAccessToken();
       return true;
     } catch (error) {
-      console.error('Failed to restore session:', error);
+      const message = error?.message;
+      if (message === 'Authentication required.') {
+        console.info('GDM: No active session found. Starting as guest.');
+      } else {
+        console.error('Failed to restore session:', error);
+      }
       if (gapi.client && typeof gapi.client.setToken === 'function') {
         gapi.client.setToken('');
       }


### PR DESCRIPTION
### Motivation
- Reduce noisy error logging when an unauthenticated user starts the app (expected `401 Unauthorized`).
- Treat the authentication-absent flow as normal (guest start) instead of a failure in developer tools.

### Description
- Updated `restoreSession` in `src/infrastructure/google-drive/googleDriveManager.js` to inspect `error.message` and detect the expected `'Authentication required.'` case.
- For the expected authentication error the code now logs an informational message with `console.info` (`GDM: No active session found. Starting as guest.`).
- Unexpected errors still use `console.error` and the routine continues to clear `gapi.client` token and `this.currentTokenInfo` as before.

### Testing
- Ran `npm run lint` and the lint step completed successfully.
- Ran the test suite with `npm test` and all automated tests passed (`35` test files, `165` tests).
- Pre-commit hooks and formatters ran during commit and passed.
- No additional failures were observed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696445934ed88326b225de8cb50cd441)