### PR TITLE
Integrate drive loader into load modal (Version 1)

### DIFF
--- a/src/features/cloud-sync/composables/useDriveLoadPageState.js
+++ b/src/features/cloud-sync/composables/useDriveLoadPageState.js
@@ -239,6 +239,9 @@ export function useDriveLoadPageState(options = {}) {
     items.value = [];
     isLoadingCache.value = false;
     await syncFromDrive();
+    if (shouldPrefetch()) {
+      await syncFromDrive(nextPageToken.value);
+    }
   }
 
   function selectCharacter(id, initialData) {

--- a/src/features/modals/components/contents/DriveLoadContent.vue
+++ b/src/features/modals/components/contents/DriveLoadContent.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { messages } from '@/i18n/index.js';
 import { useDriveLoadPageState } from '@/features/cloud-sync/composables/useDriveLoadPageState.js';
 import { copyText } from '@/shared/utils/clipboard.js';
@@ -11,6 +11,21 @@ import { formatRelativeDateTime } from '@/shared/utils/utils.js';
 
 const sentinelRef = ref(null);
 const observer = ref(null);
+
+const props = defineProps({
+  loadCharacterFromDrive: {
+    type: Function,
+    default: null,
+  },
+  isSignedIn: {
+    type: Boolean,
+    default: false,
+  },
+  isDriveReady: {
+    type: Boolean,
+    default: false,
+  },
+});
 
 const {
   displayedItems,
@@ -26,13 +41,6 @@ const {
 
 const { showAsyncToast, logAndToastError } = useNotifications();
 const modalStore = useModalStore();
-const props = defineProps({
-  loadCharacterFromDrive: {
-    type: Function,
-    default: null,
-  },
-});
-
 let driveManager = null;
 try {
   driveManager = getDriveManagerInstance();
@@ -61,6 +69,8 @@ const emptyLabel = computed(
   () => messages.driveLoadPage.emptyMessage || messages.driveLoadPage.placeholder || '保存済みのキャラクターシートはありません',
 );
 const showSentinelMessage = computed(() => hasItems.value && isBusy.value);
+const canInitialize = computed(() => props.isSignedIn && props.isDriveReady);
+const hasInitialized = ref(false);
 
 function formatTimestamp(seconds) {
   const formatted = formatRelativeDateTime(seconds);
@@ -220,9 +230,18 @@ async function handleDownload(item) {
 }
 
 onMounted(() => {
-  initialize();
   setupObserver();
 });
+
+watch(
+  canInitialize,
+  async (ready) => {
+    if (!ready || hasInitialized.value) return;
+    hasInitialized.value = true;
+    await initialize();
+  },
+  { immediate: true },
+);
 
 onBeforeUnmount(() => {
   if (observer.value) {

--- a/src/features/modals/components/contents/LoadModal.vue
+++ b/src/features/modals/components/contents/LoadModal.vue
@@ -1,15 +1,16 @@
 <template>
   <div class="load-modal">
-    <section v-if="!isSignedIn" class="load-modal__section">
-      <p class="load-modal__signin-message">{{ signInMessage }}</p>
-      <button class="button-base load-modal__button" :disabled="!canSignIn" data-test="load-modal-signin" @click="$emit('sign-in')">
-        {{ signInLabel }}
-      </button>
-    </section>
-    <section class="load-modal__section load-modal__section--drive">
-      <button v-if="isSignedIn" class="button-base load-modal__button" type="button" :disabled="!canUseDrive" data-test="load-modal-select-character" @click="$emit('select-character')">
-        {{ selectCharacterLabel }}
-      </button>
+    <section class="load-modal__section load-modal__section--controls">
+      <div v-if="!isSignedIn" class="load-modal__signin">
+        <p class="load-modal__signin-message">{{ signInMessage }}</p>
+        <button class="button-base load-modal__button" :disabled="!canSignIn" data-test="load-modal-signin" @click="$emit('sign-in')">
+          {{ signInLabel }}
+        </button>
+      </div>
+      <label class="button-base load-modal__button">
+        {{ loadLocalLabel }}
+        <input type="file" class="hidden" accept=".json,.txt,.zip" @change="handleLocalChange" />
+      </label>
       <div class="load-modal__config">
         <label class="load-modal__label" :for="folderInputId">{{ driveFolderLabel }}</label>
         <div class="load-modal__input-group">
@@ -36,11 +37,17 @@
         </div>
       </div>
     </section>
-    <section class="load-modal__section load-modal__section--local">
-      <label class="button-base load-modal__button">
-        {{ loadLocalLabel }}
-        <input type="file" class="hidden" accept=".json,.txt,.zip" @change="handleLocalChange" />
-      </label>
+    <div class="load-modal__divider" />
+    <section class="load-modal__section load-modal__section--drive">
+      <div class="load-modal__drive-scroll">
+        <DriveLoadContent
+          v-if="isSignedIn"
+          :is-signed-in="isSignedIn"
+          :is-drive-ready="isDriveReady"
+          :load-character-from-drive="loadCharacterFromDrive"
+        />
+        <p v-else class="load-modal__drive-hint">{{ signInMessage }}</p>
+      </div>
     </section>
   </div>
 </template>
@@ -48,6 +55,7 @@
 <script setup>
 import { ref, watch, computed } from 'vue';
 import BaseInput from '@/shared/ui/base/BaseInput.vue';
+import DriveLoadContent from '@/features/modals/components/contents/DriveLoadContent.vue';
 
 const props = defineProps({
   isSignedIn: Boolean,
@@ -58,7 +66,10 @@ const props = defineProps({
   driveFolderChangeLabel: { type: String, default: 'Apply' },
   driveFolderPlaceholder: String,
   loadLocalLabel: String,
-  selectCharacterLabel: String,
+  loadCharacterFromDrive: {
+    type: Function,
+    default: null,
+  },
   signInLabel: String,
   signInMessage: String,
 });
@@ -67,7 +78,6 @@ const emit = defineEmits([
   'load-local',
   'sign-in',
   'update-drive-folder-path',
-  'select-character',
 ]);
 
 const folderInputId = 'load_modal_drive_folder';
@@ -89,7 +99,6 @@ watch(
   },
 );
 
-const canUseDrive = computed(() => props.isSignedIn && props.isDriveReady);
 const isDriveControlsDisabled = computed(() => !props.isSignedIn);
 
 function commitFolderPath() {
@@ -111,6 +120,7 @@ function handleLocalChange(event) {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  max-height: 70vh;
 }
 
 .load-modal__section {
@@ -119,9 +129,41 @@ function handleLocalChange(event) {
   gap: 12px;
 }
 
+.load-modal__section--controls,
+.load-modal__section--drive {
+  min-height: 0;
+}
+
+.load-modal__section--drive {
+  flex: 1 1 auto;
+}
+
+.load-modal__signin {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .load-modal__button {
   width: 100%;
   justify-content: center;
+}
+
+.load-modal__divider {
+  border-top: 1px solid var(--color-border-normal);
+}
+
+.load-modal__drive-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.load-modal__drive-hint {
+  margin: 0;
+  color: var(--color-text-muted);
+  text-align: center;
 }
 
 .load-modal__config {
@@ -168,11 +210,6 @@ function handleLocalChange(event) {
   flex: 0 0 auto;
   height: 48px;
   padding-inline: 16px;
-}
-
-.load-modal__section--local {
-  border-top: 1px solid var(--color-border-normal);
-  padding-top: 12px;
 }
 
 .load-modal__signin-message {

--- a/src/features/modals/composables/useAppModals.js
+++ b/src/features/modals/composables/useAppModals.js
@@ -4,7 +4,6 @@ import { useModalStore } from '@/features/modals/stores/modalStore.js';
 import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
 const LoadModal = defineAsyncComponent(() => import('@/features/modals/components/contents/LoadModal.vue'));
 const IoModal = defineAsyncComponent(() => import('@/features/modals/components/contents/IoModal.vue'));
-const DriveLoadContent = defineAsyncComponent(() => import('@/features/modals/components/contents/DriveLoadContent.vue'));
 import { isDesktopDevice } from '@/shared/utils/device.js';
 import { messages } from '@/i18n/index.js';
 import { useShare } from '@/features/cloud-sync/composables/useShare.js';
@@ -31,16 +30,6 @@ export function useAppModals(options) {
     loadCharacterFromDrive,
   } = options;
 
-  async function openDriveLoadModal() {
-    await showModal({
-      component: DriveLoadContent,
-      title: messages.driveLoadPage.title,
-      props: { loadCharacterFromDrive },
-      buttons: [],
-      size: 'wide',
-    });
-  }
-
   async function openLoadModal() {
     const initialProps = {
       isSignedIn: uiStore.isSignedIn,
@@ -51,7 +40,7 @@ export function useAppModals(options) {
       driveFolderChangeLabel: messages.characterHub.driveFolder.changeButton,
       driveFolderPlaceholder: messages.characterHub.driveFolder.placeholder,
       loadLocalLabel: messages.ui.modal.load.buttons.loadLocal,
-      selectCharacterLabel: messages.ui.modal.load.buttons.selectCharacter,
+      loadCharacterFromDrive,
       signInLabel: messages.characterHub.buttons.signIn,
       signInMessage: messages.ui.modal.load.signInMessage,
     };
@@ -65,10 +54,6 @@ export function useAppModals(options) {
         'load-local': handleFileUpload,
         'sign-in': handleSignInClick,
         'update-drive-folder-path': updateDriveFolderPath,
-        'select-character': async () => {
-          modalStore.resolveModal({ value: 'drive-load' });
-          await openDriveLoadModal();
-        },
       },
     });
 

--- a/tests/unit/components/DriveLoadContent.test.js
+++ b/tests/unit/components/DriveLoadContent.test.js
@@ -93,6 +93,16 @@ vi.mock('@/features/cloud-sync/composables/useDriveLoadPageState.js', () => {
 });
 
 describe('DriveLoadContent', () => {
+  function mountWithProps(props = {}) {
+    return mount(DriveLoadContent, {
+      props: {
+        isSignedIn: true,
+        isDriveReady: true,
+        ...props,
+      },
+    });
+  }
+
   beforeEach(() => {
     revealMore.mockClear();
     initialize.mockClear();
@@ -109,9 +119,18 @@ describe('DriveLoadContent', () => {
   });
 
   it('triggers revealMore when the sentinel enters view', async () => {
-    mount(DriveLoadContent);
+    mountWithProps();
     observerCallback?.([{ isIntersecting: true }]);
     expect(revealMore).toHaveBeenCalled();
+    expect(initialize).toHaveBeenCalled();
+  });
+
+  it('waits for drive readiness before initializing', async () => {
+    const wrapper = mountWithProps({ isDriveReady: false });
+    await flushPromises();
+    expect(initialize).not.toHaveBeenCalled();
+    await wrapper.setProps({ isDriveReady: true });
+    await flushPromises();
     expect(initialize).toHaveBeenCalled();
   });
 
@@ -125,7 +144,7 @@ describe('DriveLoadContent', () => {
         createdAt: 1600,
       },
     ];
-    const wrapper = mount(DriveLoadContent);
+    const wrapper = mountWithProps();
     await wrapper.find('[data-test="drive-row-load"]').trigger('click');
     await flushPromises();
     expect(selectCharacter).toHaveBeenCalledWith('file-1', null);
@@ -144,7 +163,7 @@ describe('DriveLoadContent', () => {
       },
     ];
 
-    const wrapper = mount(DriveLoadContent);
+    const wrapper = mountWithProps();
     expect(wrapper.find('[data-test="drive-row-title"]').text()).toBe('Shared Hero');
     const fields = wrapper.findAll('[data-test="drive-row-field"]');
     expect(fields[0].text()).toContain(messages.driveLoadPage.labels.created);
@@ -157,7 +176,7 @@ describe('DriveLoadContent', () => {
       { id: 'legacy', fileName: 'legacy.json', characterName: 'Legacy', lastModifiedAtDrive: 1300, createdAt: 900 },
     ];
 
-    const wrapper = mount(DriveLoadContent);
+    const wrapper = mountWithProps();
     const cards = wrapper.findAll('[data-test="drive-row"]');
     expect(cards).toHaveLength(1);
     expect(cards[0].text()).toContain('Playable');
@@ -169,7 +188,7 @@ describe('DriveLoadContent', () => {
       { id: 'file-3', fileName: 'Shareable.zip', characterName: 'Shareable', lastModifiedAtDrive: 1500, createdAt: 1400 },
     ];
 
-    const wrapper = mount(DriveLoadContent);
+    const wrapper = mountWithProps();
     await wrapper.find('[data-test="drive-row-share"]').trigger('click');
     await flushPromises();
 
@@ -185,7 +204,7 @@ describe('DriveLoadContent', () => {
       { id: 'file-4', fileName: 'Archive.zip', characterName: 'Archive', lastModifiedAtDrive: 1600, createdAt: 1500 },
     ];
 
-    const wrapper = mount(DriveLoadContent);
+    const wrapper = mountWithProps();
     await wrapper.find('[data-test="drive-row-download"]').trigger('click');
     await flushPromises();
 
@@ -199,7 +218,7 @@ describe('DriveLoadContent', () => {
       { id: 'file-5', fileName: 'ToRemove.zip', characterName: 'Remove', lastModifiedAtDrive: 1700, createdAt: 1600 },
     ];
 
-    const wrapper = mount(DriveLoadContent);
+    const wrapper = mountWithProps();
     const deleteButton = wrapper.find('[data-test="drive-row-delete"]');
     await deleteButton.trigger('click');
     await flushPromises();
@@ -219,7 +238,7 @@ describe('DriveLoadContent', () => {
       { id: 'file-8', fileName: 'Keep.zip', characterName: 'Keep', lastModifiedAtDrive: 1500, createdAt: 1400 },
     ];
 
-    const wrapper = mount(DriveLoadContent);
+    const wrapper = mountWithProps();
 
     await wrapper.find('[data-test="drive-row-delete"]').trigger('click');
     await flushPromises();
@@ -238,7 +257,7 @@ describe('DriveLoadContent', () => {
       { id: 'file-6', fileName: 'Shared.zip', characterName: 'Shared', shared: true, lastModifiedAtDrive: 1800, createdAt: 1750 },
     ];
 
-    const wrapper = mount(DriveLoadContent);
+    const wrapper = mountWithProps();
     await wrapper.find('[data-test="drive-row-unshare"]').trigger('click');
     await flushPromises();
 
@@ -257,7 +276,7 @@ describe('DriveLoadContent', () => {
       { id: 'file-7', fileName: 'BusyShared.zip', characterName: 'BusyShared', shared: true, lastModifiedAtDrive: 1900, createdAt: 1850 },
     ];
 
-    const wrapper = mount(DriveLoadContent);
+    const wrapper = mountWithProps();
     const button = wrapper.find('[data-test="drive-row-unshare"]');
     await button.trigger('click');
 

--- a/tests/unit/components/LoadModal.test.js
+++ b/tests/unit/components/LoadModal.test.js
@@ -1,6 +1,7 @@
 import * as Vue from 'vue';
 global.Vue = Vue;
 import { mount } from '@vue/test-utils';
+import { vi } from 'vitest';
 import LoadModal from '@/features/modals/components/contents/LoadModal.vue';
 
 function baseProps(overrides = {}) {
@@ -13,23 +14,34 @@ function baseProps(overrides = {}) {
     driveFolderChangeLabel: 'change',
     driveFolderPlaceholder: 'placeholder',
     loadLocalLabel: 'local',
-    selectCharacterLabel: 'Driveから読み込む',
     signInLabel: 'signin',
     signInMessage: 'message',
+    loadCharacterFromDrive: vi.fn(),
     ...overrides,
   };
 }
 
+function mountWithStubs(props) {
+  return mount(LoadModal, {
+    props,
+    global: {
+      stubs: {
+        DriveLoadContent: { template: '<div data-test="drive-load-content-stub" />' },
+      },
+    },
+  });
+}
+
 describe('LoadModal', () => {
   test('emits load-local on file change', async () => {
-    const wrapper = mount(LoadModal, { props: baseProps() });
+    const wrapper = mountWithStubs(baseProps());
     const input = wrapper.find('input[type="file"]');
     await input.trigger('change');
     expect(wrapper.emitted('load-local')).toBeTruthy();
   });
 
   test('shows sign-in button when signed out', async () => {
-    const wrapper = mount(LoadModal, { props: baseProps({ isSignedIn: false }) });
+    const wrapper = mountWithStubs(baseProps({ isSignedIn: false }));
     const button = wrapper.find('[data-test="load-modal-signin"]');
     expect(button.exists()).toBe(true);
     await button.trigger('click');
@@ -37,23 +49,19 @@ describe('LoadModal', () => {
   });
 
   test('disables drive controls when signed out', async () => {
-    const wrapper = mount(LoadModal, { props: baseProps({ isSignedIn: false }) });
+    const wrapper = mountWithStubs(baseProps({ isSignedIn: false }));
     expect(wrapper.find('.load-modal__input').attributes('disabled')).toBeDefined();
     expect(wrapper.find('[data-test="load-modal-apply-folder"]').attributes('disabled')).toBeDefined();
-    expect(wrapper.find('[data-test="load-modal-select-character"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="drive-load-content-stub"]').exists()).toBe(false);
   });
 
-  test('shows drive load label and emits select-character when signed in', async () => {
-    const wrapper = mount(LoadModal, { props: baseProps({ isSignedIn: true }) });
-    const button = wrapper.find('[data-test="load-modal-select-character"]');
-    expect(button.exists()).toBe(true);
-    expect(button.text()).toBe('Driveから読み込む');
-    await button.trigger('click');
-    expect(wrapper.emitted('select-character')).toHaveLength(1);
+  test('shows drive content when signed in', async () => {
+    const wrapper = mountWithStubs(baseProps({ isSignedIn: true }));
+    expect(wrapper.find('[data-test="drive-load-content-stub"]').exists()).toBe(true);
   });
 
   test('emits update-drive-folder-path when apply is clicked while signed in', async () => {
-    const wrapper = mount(LoadModal, { props: baseProps({ isSignedIn: true }) });
+    const wrapper = mountWithStubs(baseProps({ isSignedIn: true }));
     const applyButton = wrapper.find('[data-test="load-modal-apply-folder"]');
     await applyButton.trigger('click');
     expect(wrapper.emitted('update-drive-folder-path')).toHaveLength(1);

--- a/tests/unit/composables/useAppModals.test.js
+++ b/tests/unit/composables/useAppModals.test.js
@@ -6,7 +6,6 @@ import { isDesktopDevice } from '@/shared/utils/device.js';
 import { useNotifications } from '@/features/notifications/composables/useNotifications.js';
 import { useShare } from '@/features/cloud-sync/composables/useShare.js';
 import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
-import { useModalStore } from '@/features/modals/stores/modalStore.js';
 
 vi.mock('@/features/modals/composables/useModal.js', () => ({
   useModal: vi.fn(),
@@ -136,15 +135,11 @@ describe('useAppModals', () => {
     expect(showAsyncToastMock).not.toHaveBeenCalled();
   });
 
-  test('openLoadModal select-character opens drive modal', async () => {
-    const { openLoadModal } = useAppModals(createOptions());
-    const modalStore = useModalStore();
+  test('openLoadModal passes drive loader to modal props', async () => {
+    const loadCharacterFromDrive = vi.fn();
+    const { openLoadModal } = useAppModals(createOptions({ loadCharacterFromDrive }));
     await openLoadModal();
     const args = showModalMock.mock.calls[0][0];
-    modalStore.showModal({});
-    await args.on['select-character']();
-    expect(modalStore.isVisible).toBe(false);
-    expect(showModalMock).toHaveBeenCalledTimes(2);
-    expect(showModalMock.mock.calls[1][0].size).toBe('wide');
+    expect(args.props.loadCharacterFromDrive).toBe(loadCharacterFromDrive);
   });
 });

--- a/tests/unit/composables/useDriveLoadPageState.test.js
+++ b/tests/unit/composables/useDriveLoadPageState.test.js
@@ -47,6 +47,7 @@ describe('useDriveLoadPageState', () => {
     expect(state.displayedItems.value[0].characterName).toBe('Drive');
     expect(state.displayedItems.value[0].thumbnailLink).toBe('https://example.com/thumb');
     expect(requestDrivePage).toHaveBeenCalledWith({ pageSize: 20, pageToken: null, abortSignal: expect.any(AbortSignal) });
+    expect(requestDrivePage).toHaveBeenCalledWith({ pageSize: 10, pageToken: 'next', abortSignal: expect.any(AbortSignal) });
 
     scope.stop();
   });


### PR DESCRIPTION
### Motivation
- Simplify the user flow by embedding the Drive character list directly into the Load modal so users can load characters with fewer clicks.
- Ensure Drive list initialization only runs when the user is signed-in and Drive is ready to avoid unnecessary API calls and to maintain user-activation context for actions (downloads/clipboard).
- Improve perceived performance by prefetching the next Drive page when appropriate to minimize wait during scrolling.

### Description
- Reworked `LoadModal.vue` to combine local file controls, folder-path input, and an embedded `DriveLoadContent` list with a scrollable region and sign-in hinting. (`src/features/modals/components/contents/LoadModal.vue`).
- Updated `useAppModals.js` to pass the drive loader callback into the unified modal props and removed the separate two-step drive modal flow. (`src/features/modals/composables/useAppModals.js`).
- Added readiness gating to `DriveLoadContent.vue` so `initialize()` only runs after `isSignedIn && isDriveReady`, and kept an IntersectionObserver for incremental reveal. (`src/features/modals/components/contents/DriveLoadContent.vue`).
- Enhanced `useDriveLoadPageState.js` to perform an immediate prefetch of the next page when initialization indicates more pages are available. (`src/features/cloud-sync/composables/useDriveLoadPageState.js`).
- Updated unit tests and test stubs to reflect the integrated modal and readiness behavior. (`tests/unit/components/LoadModal.test.js`, `tests/unit/components/DriveLoadContent.test.js`, `tests/unit/composables/useAppModals.test.js`, `tests/unit/composables/useDriveLoadPageState.test.js`).

### Testing
- Ran `npm run lint` with no errors (JS/CSS/HTML lint checks completed successfully). — success.
- Ran unit tests with `npm test` (Vitest); all tests passed: `166 passed` (full test suite run). — success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69676a9d16008326a685c3eb3e70fdaf)