### PR TITLE
Adjust Drive folder editor placement and Load modal button layout

### DIFF
--- a/src/features/modals/components/contents/DriveLoadContent.vue
+++ b/src/features/modals/components/contents/DriveLoadContent.vue
@@ -280,7 +280,7 @@ onBeforeUnmount(() => {
                     :aria-label="messages.driveLoadPage.labels.selectAction"
                   >
                     <button
-                      class="button-base button-base--primary"
+                      class="button-base button-base--primary is-joined-right"
                       type="button"
                       :aria-label="messages.driveLoadPage.actions.loadAria(getCharacterName(item))"
                       data-test="drive-row-load"
@@ -289,7 +289,7 @@ onBeforeUnmount(() => {
                       {{ messages.driveLoadPage.actions.load }}
                     </button>
                     <button
-                      class="button-base button-base--ghost"
+                      class="button-base button-base--ghost is-joined-left"
                       type="button"
                       :aria-label="messages.driveLoadPage.actions.shareAria(getCharacterName(item))"
                       data-test="drive-row-share"

--- a/src/features/modals/components/contents/LoadModal.vue
+++ b/src/features/modals/components/contents/LoadModal.vue
@@ -2,15 +2,68 @@
   <div class="load-modal">
     <div class="load-modal__header">
       <div class="load-modal__sub-actions">
-        <button
-          v-if="isSignedIn"
-          class="button-base button-base--ghost load-modal__sub-button load-modal__sub-button--compact"
-          type="button"
-          data-test="load-modal-folder-toggle"
-          @click="toggleFolderEditor"
-        >
-          {{ driveFolderLabel }}
-        </button>
+        <div v-if="isSignedIn" class="load-modal__folder-controls">
+          <button
+            class="button-base button-base--ghost load-modal__sub-button load-modal__sub-button--compact"
+            type="button"
+            data-test="load-modal-folder-toggle"
+            @click="toggleFolderEditor"
+          >
+            {{ driveFolderLabel }}
+          </button>
+
+          <div v-if="isFolderEditorOpen" class="load-modal__folder-editor">
+            <div class="load-modal__input-group">
+              <BaseInput
+                :id="folderInputId"
+                class="load-modal__input"
+                type="text"
+                v-model="folderPathInput"
+                :placeholder="driveFolderPlaceholder"
+                :disabled="isDriveControlsDisabled || isAwaitingFolderCreationChoice"
+                :joined="'right'"
+                @keyup.enter.prevent="commitFolderPath"
+              />
+              <button
+                class="button-base button-base--primary load-modal__apply is-joined-left"
+                type="button"
+                :disabled="isDriveControlsDisabled || isAwaitingFolderCreationChoice"
+                data-test="load-modal-apply-folder"
+                @click="commitFolderPath"
+              >
+                {{ driveFolderChangeLabel }}
+              </button>
+            </div>
+            <div
+              v-if="isAwaitingFolderCreationChoice"
+              class="load-modal__folder-confirm"
+              role="status"
+              aria-live="polite"
+            >
+              <p class="load-modal__folder-confirm-text">{{ driveFolderCreateConfirmMessage }}</p>
+              <div class="load-modal__folder-confirm-actions">
+                <button
+                  class="button-base button-base--primary is-joined-right"
+                  type="button"
+                  :disabled="isDriveControlsDisabled"
+                  data-test="load-modal-folder-create-yes"
+                  @click="createAndApplyFolder"
+                >
+                  {{ driveFolderCreateYesLabel }}
+                </button>
+                <button
+                  class="button-base button-base--ghost is-joined-left"
+                  type="button"
+                  :disabled="isDriveControlsDisabled"
+                  data-test="load-modal-folder-create-no"
+                  @click="cancelFolderCreatePrompt"
+                >
+                  {{ driveFolderCreateNoLabel }}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
         <button
           class="button-base button-base--ghost load-modal__sub-button load-modal__sub-button--compact"
           :disabled="!hasHistory"
@@ -27,53 +80,6 @@
         {{ loadLocalLabel }}
         <input type="file" class="hidden" accept=".json,.txt,.zip" @change="handleLocalChange" />
       </label>
-    </div>
-
-    <div v-if="isSignedIn && isFolderEditorOpen" class="load-modal__folder-editor">
-        <div class="load-modal__input-group">
-          <BaseInput
-            :id="folderInputId"
-            class="load-modal__input"
-            type="text"
-            v-model="folderPathInput"
-            :placeholder="driveFolderPlaceholder"
-            :disabled="isDriveControlsDisabled || isAwaitingFolderCreationChoice"
-            :joined="'right'"
-            @keyup.enter.prevent="commitFolderPath"
-          />
-          <button
-            class="button-base button-base--primary load-modal__apply is-joined-left"
-            type="button"
-            :disabled="isDriveControlsDisabled || isAwaitingFolderCreationChoice"
-            data-test="load-modal-apply-folder"
-            @click="commitFolderPath"
-          >
-            {{ driveFolderChangeLabel }}
-          </button>
-        </div>
-        <div v-if="isAwaitingFolderCreationChoice" class="load-modal__folder-confirm" role="status" aria-live="polite">
-          <p class="load-modal__folder-confirm-text">{{ driveFolderCreateConfirmMessage }}</p>
-          <div class="load-modal__folder-confirm-actions">
-            <button
-              class="button-base button-base--primary is-joined-right"
-              type="button"
-              :disabled="isDriveControlsDisabled"
-              data-test="load-modal-folder-create-yes"
-              @click="createAndApplyFolder"
-            >
-              {{ driveFolderCreateYesLabel }}
-            </button>
-            <button
-              class="button-base button-base--ghost is-joined-left"
-              type="button"
-              :disabled="isDriveControlsDisabled"
-              data-test="load-modal-folder-create-no"
-              @click="cancelFolderCreatePrompt"
-            >
-              {{ driveFolderCreateNoLabel }}
-            </button>
-          </div>
-        </div>
     </div>
 
     <div class="load-modal__drive-scroll">
@@ -235,6 +241,7 @@ async function validateAndApplyFolderPath() {
   if (!normalized) {
     cancelFolderCreatePrompt();
     emit('update-drive-folder-path', normalized);
+    isFolderEditorOpen.value = false;
     return;
   }
 
@@ -243,6 +250,7 @@ async function validateAndApplyFolderPath() {
     if (exists) {
       cancelFolderCreatePrompt();
       emit('update-drive-folder-path', normalized);
+      isFolderEditorOpen.value = false;
       return;
     }
   } catch {
@@ -281,6 +289,7 @@ async function createAndApplyFolder() {
     }
     cancelFolderCreatePrompt();
     emit('update-drive-folder-path', targetPath);
+    isFolderEditorOpen.value = false;
   } finally {
     isApplyingFolder.value = false;
   }
@@ -333,8 +342,14 @@ function handleLocalChange(event) {
 .load-modal__sub-actions {
   display: flex;
   gap: 6px;
-  align-items: center;
+  align-items: flex-start;
   margin-left: auto;
+}
+
+.load-modal__folder-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .load-modal__sub-button {
@@ -354,6 +369,11 @@ function handleLocalChange(event) {
   display: flex;
 }
 
+.load-modal__local-actions > .load-modal__sub-button {
+  width: 100%;
+  justify-content: center;
+}
+
 .load-modal__folder-editor {
   display: flex;
   flex-direction: column;
@@ -368,6 +388,7 @@ function handleLocalChange(event) {
 .load-modal__input {
   flex: 1 1 0;
   min-width: 0;
+  height: 48px;
   padding: 8px 10px;
   border-radius: 4px;
   border: 1px solid var(--color-border-normal);


### PR DESCRIPTION
### Motivation

- Improve the Drive folder editing UX by placing the input directly under the `Drive保存先` toggle so it is not visually below the local file controls. 
- Close the folder editor after a successful apply (existing path) or after creating missing folders to reduce extra clicks. 
- Make local file action and folder input visuals consistent by matching heights and giving the local button a wider appearance. 
- Visually join the Drive item `読込` and `共有` buttons to match other joined/connected button groups.

### Description

- Move the Drive folder input/editor block into the header next to the `Drive保存先` toggle and consolidate the confirm prompt inside that block. (edited `src/features/modals/components/contents/LoadModal.vue`).
- Automatically close the folder editor when `commitFolderPath` succeeds for existing paths and when `createAndApplyFolder` finishes creating missing folders by setting `isFolderEditorOpen` to `false`. (edited `LoadModal.vue`).
- Add small CSS adjustments: `.load-modal__folder-controls` container, make the local file sub-button stretch (`width: 100%`) and center its content, and align the folder input height to `48px` to match the confirm button. (edited `LoadModal.vue`).
- Add joined button classes to Drive list item actions so `読込` and `共有` display as visually connected using `is-joined-right` and `is-joined-left`. (edited `src/features/modals/components/contents/DriveLoadContent.vue`).

### Testing

- Ran `npm run lint` and it completed with no lint errors. 
- Ran `npm test` (Vitest) and all unit tests passed: `36` test files and `181` tests passed. 
- Attempted an automated Playwright screenshot to validate the modal layout, but the run timed out because the `Drive保存先` toggle is only available when signed-in, so the automated UI capture failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a671f6b0608321aed50cc78282f309)