### PR TITLE
Add runtime mock-Drive fallback and improve Load modal UX

### DIFF
--- a/src/app/providers/useAppInitialization.js
+++ b/src/app/providers/useAppInitialization.js
@@ -1,4 +1,4 @@
-import { initializeDriveManager, isUsingMockDrive } from '@/infrastructure/google-drive/index.js';
+import { fallbackToMockDriveManager, initializeDriveManager, isUsingMockDrive } from '@/infrastructure/google-drive/index.js';
 import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
 
 function waitForGoogleScript() {
@@ -66,7 +66,12 @@ export function useAppInitialization() {
         }
       } catch (error) {
         console.error('Failed to initialize Drive manager:', error);
-        if (usingMock) {
+        if (!usingMock) {
+          const mockManager = fallbackToMockDriveManager(import.meta.env.VITE_GOOGLE_API_KEY, import.meta.env.VITE_GOOGLE_CLIENT_ID);
+          await mockManager.onGapiLoad();
+          uiStore.isGapiInitialized = true;
+          uiStore.isSignedIn = await mockManager.restoreSession();
+        } else {
           uiStore.isGapiInitialized = true;
           uiStore.isSignedIn = true;
         }

--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -1,5 +1,10 @@
 import { ref, computed, onMounted } from 'vue';
-import { getDriveManagerInstance, initializeDriveManager, isUsingMockDrive } from '@/infrastructure/google-drive/index.js';
+import {
+  fallbackToMockDriveManager,
+  getDriveManagerInstance,
+  initializeDriveManager,
+  isUsingMockDrive,
+} from '@/infrastructure/google-drive/index.js';
 import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
 import { useCharacterStore } from '@/features/character-sheet/stores/characterStore.js';
 import { removeStoredCharacterDraft } from '@/features/character-sheet/composables/useLocalCharacterPersistence.js';
@@ -262,6 +267,14 @@ export function useGoogleDrive(dataManager) {
           refreshDriveFolderPath();
         }
       } catch (error) {
+        if (!isUsingMockDrive()) {
+          googleDriveManager.value = fallbackToMockDriveManager();
+          if (googleDriveManager.value && typeof dataManager.setGoogleDriveManager === 'function') {
+            dataManager.setGoogleDriveManager(googleDriveManager.value);
+          }
+          await handleDriveReady();
+          return;
+        }
         uiStore.isGapiInitialized = false;
         uiStore.isSignedIn = false;
         logAndToastError(error, messages.googleDrive.apiInitError, 'initializeGoogleDrive');
@@ -291,7 +304,17 @@ export function useGoogleDrive(dataManager) {
 
     waitForScript('script[src="https://apis.google.com/js/api.js"]', () => window.gapi && window.gapi.load)
       .then(handleDriveReady)
-      .catch((error) => logAndToastError(error, messages.googleDrive.apiInitError, 'initializeGoogleDrive'));
+      .catch(async (error) => {
+        if (!isUsingMockDrive()) {
+          googleDriveManager.value = fallbackToMockDriveManager();
+          if (googleDriveManager.value && typeof dataManager.setGoogleDriveManager === 'function') {
+            dataManager.setGoogleDriveManager(googleDriveManager.value);
+          }
+          await handleDriveReady();
+          return;
+        }
+        logAndToastError(error, messages.googleDrive.apiInitError, 'initializeGoogleDrive');
+      });
   }
 
   syncGoogleDriveManager();

--- a/src/features/modals/components/contents/LoadModal.vue
+++ b/src/features/modals/components/contents/LoadModal.vue
@@ -4,7 +4,7 @@
       <div class="load-modal__sub-actions">
         <div v-if="isSignedIn" class="load-modal__folder-controls">
           <button
-            class="button-base button-base--ghost load-modal__sub-button load-modal__sub-button--compact"
+            class="button-base button-base--ghost load-modal__sub-button load-modal__sub-button--compact load-modal__folder-toggle"
             type="button"
             data-test="load-modal-folder-toggle"
             @click="toggleFolderEditor"
@@ -309,6 +309,10 @@ function handleLocalChange(event) {
   max-height: 72vh;
 }
 
+.load-modal * {
+  min-width: 0;
+}
+
 .load-modal__header {
   display: flex;
   align-items: center;
@@ -370,8 +374,13 @@ function handleLocalChange(event) {
 }
 
 .load-modal__local-actions > .load-modal__sub-button {
-  width: 100%;
+  width: auto;
+  max-width: 220px;
   justify-content: center;
+}
+
+.load-modal__folder-toggle {
+  min-width: 8.5rem;
 }
 
 .load-modal__folder-editor {
@@ -426,8 +435,8 @@ function handleLocalChange(event) {
 .load-modal__drive-scroll {
   flex: 1 1 auto;
   min-height: 0;
-  overflow-y: auto;
-  padding-right: 4px;
+  overflow: visible;
+  padding-right: 0;
 }
 
 .load-modal__drive-hint {

--- a/src/infrastructure/google-drive/index.js
+++ b/src/infrastructure/google-drive/index.js
@@ -7,6 +7,7 @@ import {
 
 const env = typeof import.meta !== 'undefined' ? import.meta.env : process.env;
 const useMockDrive = env?.VITE_USE_MOCK_DRIVE === 'true';
+const isDevEnvironment = env?.DEV === true || env?.NODE_ENV === 'development';
 
 let sharedInstance = null;
 let currentInitializer = null;
@@ -14,7 +15,7 @@ let currentGetter = null;
 let runtimeUseMockDrive = useMockDrive;
 
 function exposeDevGlobal(instance) {
-  if (runtimeUseMockDrive && typeof window !== 'undefined') {
+  if (runtimeUseMockDrive && isDevEnvironment && typeof window !== 'undefined') {
     window.__DRIVE_DEV__ = instance;
   }
 }

--- a/src/infrastructure/google-drive/index.js
+++ b/src/infrastructure/google-drive/index.js
@@ -11,23 +11,24 @@ const useMockDrive = env?.VITE_USE_MOCK_DRIVE === 'true';
 let sharedInstance = null;
 let currentInitializer = null;
 let currentGetter = null;
+let runtimeUseMockDrive = useMockDrive;
 
 function exposeDevGlobal(instance) {
-  if (useMockDrive && typeof window !== 'undefined') {
+  if (runtimeUseMockDrive && typeof window !== 'undefined') {
     window.__DRIVE_DEV__ = instance;
   }
 }
 
 function resolveInitializer() {
   if (!currentInitializer) {
-    currentInitializer = useMockDrive ? initializeMockGoogleDriveManager : initializeGoogleDriveManager;
+    currentInitializer = runtimeUseMockDrive ? initializeMockGoogleDriveManager : initializeGoogleDriveManager;
   }
   return currentInitializer;
 }
 
 function resolveGetter() {
   if (!currentGetter) {
-    currentGetter = useMockDrive ? getMockGoogleDriveManagerInstance : getGoogleDriveManagerInstance;
+    currentGetter = runtimeUseMockDrive ? getMockGoogleDriveManagerInstance : getGoogleDriveManagerInstance;
   }
   return currentGetter;
 }
@@ -60,13 +61,25 @@ export function resetDriveManagerForTests() {
   sharedInstance = null;
   currentInitializer = null;
   currentGetter = null;
-  if (useMockDrive) {
+  runtimeUseMockDrive = useMockDrive;
+  if (runtimeUseMockDrive) {
     resetMockGoogleDriveManagerForTests();
   } else {
     resetGoogleDriveManagerForTests();
   }
 }
 
+export function fallbackToMockDriveManager(apiKey = env?.VITE_GOOGLE_API_KEY, clientId = env?.VITE_GOOGLE_CLIENT_ID) {
+  if (runtimeUseMockDrive && sharedInstance) {
+    return sharedInstance;
+  }
+  runtimeUseMockDrive = true;
+  sharedInstance = null;
+  currentInitializer = initializeMockGoogleDriveManager;
+  currentGetter = getMockGoogleDriveManagerInstance;
+  return initializeDriveManager(apiKey, clientId);
+}
+
 export function isUsingMockDrive() {
-  return useMockDrive;
+  return runtimeUseMockDrive;
 }

--- a/src/shared/styles/_notifications.css
+++ b/src/shared/styles/_notifications.css
@@ -268,6 +268,25 @@
 .modal .modal-content {
   overflow-y: auto;
   flex-grow: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgb(255 255 255 / 0.2) transparent;
+}
+
+.modal .modal-content::-webkit-scrollbar {
+  width: 8px;
+}
+
+.modal .modal-content::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.modal .modal-content::-webkit-scrollbar-thumb {
+  background-color: rgb(255 255 255 / 0.2);
+  border-radius: 999px;
+}
+
+.modal .modal-content::-webkit-scrollbar-thumb:hover {
+  background-color: rgb(255 255 255 / 0.3);
 }
 .modal-message {
   margin-bottom: 25px;


### PR DESCRIPTION
### Motivation
- Ensure the app continues to work when the Google API/script or `onGapiLoad` fails by falling back to a local mock Drive implementation at runtime. 
- Fix UI issues in the Load modal where the local-file button was too wide and the Drive-folder button changed size when toggled. 
- Remove nested scrolling inside the Load modal so a single modal-level scrollbar is used and make that scrollbar visually subtle.

### Description
- Added runtime mock selection and `fallbackToMockDriveManager()` in `src/infrastructure/google-drive/index.js` and made `isUsingMockDrive()` reflect runtime state. 
- Updated initialization flows to retry with the mock manager when Google API script load or `onGapiLoad` fail by changing `src/app/providers/useAppInitialization.js` and `src/features/cloud-sync/composables/useGoogleDrive.js` to call `fallbackToMockDriveManager()` and wire the mock into the `dataManager`. 
- Adjusted Load modal layout/styles in `src/features/modals/components/contents/LoadModal.vue` to limit the local-file button width, stabilize the Drive-folder button width, and remove the inner list scroll so the modal uses a single scroll area. 
- Tuned modal scrollbar appearance to `thin` and semi-transparent in `src/shared/styles/_notifications.css` so scrollbars are less visually prominent.

### Testing
- Ran `npm run lint` and style checks with no lint errors. (passed)
- Ran unit tests with `npm test` and all tests passed (`36` files, `181` tests). (passed)
- Started the dev server and captured a screenshot of the updated Load modal to visually verify layout changes (`vite` dev server used for screenshot). (manual visual check)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7ad68e64883219c177423581b10bc)