### PR TITLE
Prevent negative scroll position in header visibility hook

### DIFF
--- a/src/shared/composables/useHeaderVisibility.js
+++ b/src/shared/composables/useHeaderVisibility.js
@@ -7,7 +7,7 @@ export function useHeaderVisibility(targetRef) {
 
   function handleScroll() {
     requestAnimationFrame(() => {
-      const y = window.scrollY;
+      const y = Math.max(0, window.scrollY);
       const delta = y - lastScrollY;
       currentTranslateY -= delta;
       if (currentTranslateY > 0) currentTranslateY = 0;


### PR DESCRIPTION
## Summary
Fixed a potential issue in the header visibility composable where negative scroll values could cause incorrect header positioning behavior.

## Key Changes
- Added `Math.max(0, window.scrollY)` to ensure the scroll position is never negative when calculating header translation

## Implementation Details
The `window.scrollY` value should theoretically never be negative in normal browser behavior, but this defensive check prevents edge cases or browser inconsistencies from causing the header to translate incorrectly. By ensuring `y` is always non-negative, we maintain the expected behavior of the header visibility toggle mechanism.

https://claude.ai/code/session_01UuNxSivf4XdiUQkB1T7tCj