### PR TITLE
Refine SubMemoItem styling and delete button appearance

### DIFF
--- a/src/features/character-sheet/components/sections/SubMemoItem.vue
+++ b/src/features/character-sheet/components/sections/SubMemoItem.vue
@@ -129,22 +129,14 @@ const showGuard = computed(() => props.readonly && props.subMemo.isSpoiler && !p
 }
 
 .submemo-body {
-  padding: 0;
+  padding: 18px;
+  background-color: var(--color-panel-body);
 }
 
 .submemo-textarea {
   width: 100%;
   min-height: 120px;
   resize: vertical;
-  border: none;
-  border-radius: 0;
-  display: block;
-}
-
-.submemo-textarea:focus {
-  border: none;
-  box-shadow: inset 0 0 0 0.2rem rgb(192 154 105 / 25%);
-  outline: none;
 }
 
 .submemo-guard {

--- a/src/features/character-sheet/components/sections/SubMemoItem.vue
+++ b/src/features/character-sheet/components/sections/SubMemoItem.vue
@@ -143,7 +143,7 @@ const showGuard = computed(() => props.readonly && props.subMemo.isSpoiler && !p
 
 .submemo-textarea:focus {
   border: none;
-  box-shadow: none;
+  box-shadow: inset 0 0 0 0.2rem rgb(192 154 105 / 25%);
   outline: none;
 }
 

--- a/src/features/character-sheet/components/sections/SubMemoItem.vue
+++ b/src/features/character-sheet/components/sections/SubMemoItem.vue
@@ -135,6 +135,9 @@ const showGuard = computed(() => props.readonly && props.subMemo.isSpoiler && !p
   width: 100%;
   min-height: 120px;
   resize: vertical;
+  border: none;
+  border-radius: 0;
+  display: block;
 }
 
 .submemo-guard {

--- a/src/features/character-sheet/components/sections/SubMemoItem.vue
+++ b/src/features/character-sheet/components/sections/SubMemoItem.vue
@@ -23,7 +23,7 @@
         <span>{{ messages.spoilerLabel }}</span>
       </label>
       <button
-        class="button-base list-button list-button--delete"
+        class="button-base list-button list-button--delete button-base--delete"
         type="button"
         :disabled="readonly"
         :aria-label="messages.deleteLabel"
@@ -113,7 +113,7 @@ const showGuard = computed(() => props.readonly && props.subMemo.isSpoiler && !p
   padding: 6px 8px;
   border-radius: 4px;
   border: 1px solid var(--color-border-normal);
-  background: transparent;
+  background: var(--color-panel-body);
   color: inherit;
 }
 
@@ -128,7 +128,7 @@ const showGuard = computed(() => props.readonly && props.subMemo.isSpoiler && !p
 }
 
 .submemo-body {
-  padding: 12px;
+  padding: 0;
 }
 
 .submemo-textarea {

--- a/src/features/character-sheet/components/sections/SubMemoItem.vue
+++ b/src/features/character-sheet/components/sections/SubMemoItem.vue
@@ -92,6 +92,7 @@ const showGuard = computed(() => props.readonly && props.subMemo.isSpoiler && !p
   align-items: center;
   gap: 8px;
   padding: 8px 12px;
+  margin-bottom: 0;
 }
 
 .submemo-toggle {
@@ -138,6 +139,12 @@ const showGuard = computed(() => props.readonly && props.subMemo.isSpoiler && !p
   border: none;
   border-radius: 0;
   display: block;
+}
+
+.submemo-textarea:focus {
+  border: none;
+  box-shadow: none;
+  outline: none;
 }
 
 .submemo-guard {


### PR DESCRIPTION
## Summary
Updated the SubMemoItem component styling to improve visual consistency and adjust spacing. These changes refine the button appearance and container padding.

## Key Changes
- Added `button-base--delete` class to the delete button for consistent delete button styling
- Changed `.button-base` background from `transparent` to `var(--color-panel-body)` for better visual hierarchy
- Removed padding from `.submemo-body` container (changed from `12px` to `0`) to allow more flexible content spacing

## Implementation Details
These styling adjustments appear to be part of a design refinement to ensure the delete button has consistent styling with other delete buttons in the application, while also adjusting the container padding to provide more control over internal spacing of the submemo content.

https://claude.ai/code/session_01JQLXjNuD8LdPh46VugdXUT