### PR TITLE
Add drive.metadata.readonly scope to Google OAuth permissions

### DIFF
--- a/functions/api/[[route]].js
+++ b/functions/api/[[route]].js
@@ -4,8 +4,13 @@ import { handle } from 'hono/cloudflare-pages';
 
 const SESSION_COOKIE_NAME = 'aioniacs_session';
 const STATE_COOKIE_NAME = 'aioniacs_oauth_state';
-const AUTH_SCOPE = 'https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive.file openid email profile';
-const REQUIRED_SCOPES = ['https://www.googleapis.com/auth/drive.appdata', 'https://www.googleapis.com/auth/drive.file'];
+const AUTH_SCOPE =
+  'https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.metadata.readonly openid email profile';
+const REQUIRED_SCOPES = [
+  'https://www.googleapis.com/auth/drive.appdata',
+  'https://www.googleapis.com/auth/drive.file',
+  'https://www.googleapis.com/auth/drive.metadata.readonly',
+];
 const SESSION_TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days
 const STATE_TTL_SECONDS = 10 * 60; // 10 minutes
 

--- a/tests/unit/functions/authApi.test.js
+++ b/tests/unit/functions/authApi.test.js
@@ -108,7 +108,8 @@ describe('Cloudflare auth functions', () => {
           access_token: 'access',
           refresh_token: 'refresh',
           expires_in: 3600,
-          scope: 'https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive.file',
+          scope:
+            'https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.metadata.readonly',
         }),
       })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 'user-1', email: 'user@example.com' }) });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,4 @@
+name = "aioniacs"
 pages_build_output_dir = "dist"
 
 [[d1_databases]]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,5 @@
+pages_build_output_dir = "dist"
+
 [[d1_databases]]
 binding = "DB" # Honoからこの名前でアクセスします
 database_name = "aionia-auth-db"


### PR DESCRIPTION
## Summary
This PR adds the `drive.metadata.readonly` scope to the Google OAuth authentication configuration, enabling read-only access to Google Drive file metadata.

## Key Changes
- **OAuth Scope Configuration**: Added `https://www.googleapis.com/auth/drive.metadata.readonly` to both `AUTH_SCOPE` and `REQUIRED_SCOPES` constants in the API handler
- **Code Formatting**: Reformatted scope constants for improved readability by splitting long lines
- **Test Updates**: Updated the mock OAuth token response in tests to reflect the new scope requirement
- **Build Configuration**: Added `pages_build_output_dir = "dist"` to `wrangler.toml` to specify the Cloudflare Pages build output directory

## Implementation Details
The new scope is added alongside existing scopes for app data storage (`drive.appdata`) and file access (`drive.file`), allowing the application to read metadata about files in Google Drive while maintaining the principle of least privilege with read-only access.

https://claude.ai/code/session_01Ej3598ymUcKQN7MA1nth3K