### PR TITLE
Internationalize folder name and fix modal dismissal on file upload

### DIFF
--- a/src/features/character-sheet/composables/useDataExport.js
+++ b/src/features/character-sheet/composables/useDataExport.js
@@ -28,7 +28,7 @@ export function useDataExport() {
   }
 
   function handleFileUpload(event) {
-    dataManager.handleFileUpload(
+    return dataManager.handleFileUpload(
       event,
       (parsedData) => {
         characterStore.hydrateFromData(parsedData);

--- a/src/features/character-sheet/composables/useDataExport.js
+++ b/src/features/character-sheet/composables/useDataExport.js
@@ -33,6 +33,7 @@ export function useDataExport() {
       (parsedData) => {
         characterStore.hydrateFromData(parsedData);
         uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
+        uiStore.clearCurrentDriveFileId();
       },
       (errorMessage) =>
         showToast({

--- a/src/features/character-sheet/services/dataManager.js
+++ b/src/features/character-sheet/services/dataManager.js
@@ -67,39 +67,45 @@ export class DataManager {
    */
   handleFileUpload(event, onSuccess, onError) {
     const file = event.target.files[0];
-    if (!file) return;
+    if (!file) return Promise.resolve();
 
     const fileName = file.name;
-    const reader = new FileReader();
 
-    if (fileName.endsWith('.zip')) {
-      reader.onload = async (e) => {
-        try {
-          const rawJsonData = await deserializeCharacterPayload(e.target.result);
-          const parsedData = this.parseLoadedData(rawJsonData);
-          onSuccess(parsedData);
-        } catch (error) {
-          console.error('Failed to parse ZIP file:', error);
-          onError(messages.file.loadError + ' (ZIP: ' + error.message + ')');
-        }
-      };
-      reader.readAsArrayBuffer(file); // Read ZIP as ArrayBuffer
-    } else {
-      // Assume JSON or other text file
-      reader.onload = async (e) => {
-        const fileContent = e.target.result;
-        try {
-          const rawJsonData = await deserializeCharacterPayload(fileContent);
-          const parsedData = this.parseLoadedData(rawJsonData);
-          onSuccess(parsedData);
-        } catch (error) {
-          console.error('Failed to parse JSON file:', error);
-          onError((error && error.message) || messages.file.loadError);
-        }
-      };
-      reader.readAsText(file);
-    }
+    const promise = new Promise((resolve) => {
+      const reader = new FileReader();
+
+      if (fileName.endsWith('.zip')) {
+        reader.onload = async (e) => {
+          try {
+            const rawJsonData = await deserializeCharacterPayload(e.target.result);
+            const parsedData = this.parseLoadedData(rawJsonData);
+            onSuccess(parsedData);
+          } catch (error) {
+            console.error('Failed to parse ZIP file:', error);
+            onError(messages.file.loadError + ' (ZIP: ' + error.message + ')');
+          }
+          resolve();
+        };
+        reader.readAsArrayBuffer(file);
+      } else {
+        reader.onload = async (e) => {
+          const fileContent = e.target.result;
+          try {
+            const rawJsonData = await deserializeCharacterPayload(fileContent);
+            const parsedData = this.parseLoadedData(rawJsonData);
+            onSuccess(parsedData);
+          } catch (error) {
+            console.error('Failed to parse JSON file:', error);
+            onError((error && error.message) || messages.file.loadError);
+          }
+          resolve();
+        };
+        reader.readAsText(file);
+      }
+    });
+
     event.target.value = null;
+    return promise;
   }
 
   async _buildDriveSaveContext(character, skills, specialSkills, equipments, histories) {

--- a/src/features/modals/composables/useAppModals.js
+++ b/src/features/modals/composables/useAppModals.js
@@ -58,7 +58,10 @@ export function useAppModals(options) {
       props: initialProps,
       buttons: [],
       on: {
-        'load-local': handleFileUpload,
+        'load-local': (event) => {
+          handleFileUpload(event);
+          modalStore.hideModal();
+        },
         'sign-in': handleSignInClick,
         'open-history': () => openHistoryRecoveryModal(),
       },

--- a/src/features/modals/composables/useAppModals.js
+++ b/src/features/modals/composables/useAppModals.js
@@ -58,9 +58,12 @@ export function useAppModals(options) {
       props: initialProps,
       buttons: [],
       on: {
-        'load-local': (event) => {
-          handleFileUpload(event);
-          modalStore.hideModal();
+        'load-local': async (event) => {
+          try {
+            await handleFileUpload(event);
+          } finally {
+            modalStore.hideModal();
+          }
         },
         'sign-in': handleSignInClick,
         'open-history': () => openHistoryRecoveryModal(),

--- a/src/infrastructure/google-drive/googleDriveManager.js
+++ b/src/infrastructure/google-drive/googleDriveManager.js
@@ -82,7 +82,7 @@ export class GoogleDriveManager {
   }
 
   static get DEFAULT_FOLDER_NAME() {
-    return '慈悲なきアイオニア';
+    return 'Aionia TRPG Character Sheet';
   }
 
   getDefaultConfig() {

--- a/src/infrastructure/google-drive/mockGoogleDriveManager.js
+++ b/src/infrastructure/google-drive/mockGoogleDriveManager.js
@@ -44,7 +44,7 @@ export class MockGoogleDriveManager {
   }
 
   static get DEFAULT_FOLDER_NAME() {
-    return '慈悲なきアイオニア';
+    return 'Aionia TRPG Character Sheet';
   }
 
   _getDefaultState() {

--- a/tests/unit/composables/useAppModals.test.js
+++ b/tests/unit/composables/useAppModals.test.js
@@ -33,7 +33,7 @@ describe('useAppModals', () => {
       dataManager: {},
       handleSignInClick: vi.fn(),
       saveData: vi.fn(),
-      handleFileUpload: vi.fn(),
+      handleFileUpload: vi.fn().mockResolvedValue(),
       outputToCocofolia: vi.fn(),
       getChatPaletteText: vi.fn().mockResolvedValue('モックされたチャットパレット'),
       printCharacterSheet: vi.fn(),
@@ -73,7 +73,7 @@ describe('useAppModals', () => {
     expect(args.on['sign-in']).toBe(handleSignInClick);
     expect(typeof args.on['load-local']).toBe('function');
     const mockEvent = { target: { files: [] } };
-    args.on['load-local'](mockEvent);
+    await args.on['load-local'](mockEvent);
     expect(opts.handleFileUpload).toHaveBeenCalledWith(mockEvent);
   });
 

--- a/tests/unit/composables/useAppModals.test.js
+++ b/tests/unit/composables/useAppModals.test.js
@@ -71,7 +71,10 @@ describe('useAppModals', () => {
     await openLoadModal();
     const args = showModalMock.mock.calls[0][0];
     expect(args.on['sign-in']).toBe(handleSignInClick);
-    expect(args.on['load-local']).toBe(opts.handleFileUpload);
+    expect(typeof args.on['load-local']).toBe('function');
+    const mockEvent = { target: { files: [] } };
+    args.on['load-local'](mockEvent);
+    expect(opts.handleFileUpload).toHaveBeenCalledWith(mockEvent);
   });
 
   test('desktop uses direct print', async () => {

--- a/tests/unit/googleDriveManager.test.js
+++ b/tests/unit/googleDriveManager.test.js
@@ -87,14 +87,14 @@ describe('GoogleDriveManager configuration and folder handling', () => {
   test('findOrCreateConfiguredCharacterFolder creates new folder when stored ID is invalid', async () => {
     gapi.client.drive.files.list.mockResolvedValue({ result: { files: [] } });
     gapi.client.request.mockResolvedValue({ result: { id: 'cfg-new', name: 'aioniacs.cfg' } });
-    gapi.client.drive.files.create.mockResolvedValue({ result: { id: 'new-folder', name: '慈悲なきアイオニア' } });
+    gapi.client.drive.files.create.mockResolvedValue({ result: { id: 'new-folder', name: 'Aionia TRPG Character Sheet' } });
 
     const folderId = await gdm.findOrCreateConfiguredCharacterFolder();
 
     expect(folderId).toBe('new-folder');
     expect(gapi.client.drive.files.create).toHaveBeenCalledWith({
       resource: {
-        name: '慈悲なきアイオニア',
+        name: 'Aionia TRPG Character Sheet',
         mimeType: 'application/vnd.google-apps.folder',
         parents: ['root'],
       },
@@ -107,7 +107,7 @@ describe('GoogleDriveManager configuration and folder handling', () => {
     gapi.client.drive.files.list.mockResolvedValue({ result: { files: [] } });
     gapi.client.request.mockResolvedValue({ result: { id: 'cfg-5', name: 'aioniacs.cfg' } });
     // createFolder for character folder
-    gapi.client.drive.files.create.mockResolvedValue({ result: { id: 'folder', name: '慈悲なきアイオニア' } });
+    gapi.client.drive.files.create.mockResolvedValue({ result: { id: 'folder', name: 'Aionia TRPG Character Sheet' } });
 
     const res = await gdm.createCharacterFile({ content: new Uint8Array([0x01, 0x02]), mimeType: 'application/zip', name: 'Hero' });
 
@@ -122,7 +122,7 @@ describe('GoogleDriveManager configuration and folder handling', () => {
   test('saveFile injects url-safe thumbnail content hints when provided', async () => {
     gapi.client.drive.files.list.mockResolvedValue({ result: { files: [] } });
     gapi.client.request.mockResolvedValue({ result: { id: 'cfg-thumb', name: 'aioniacs.cfg' } });
-    gapi.client.drive.files.create.mockResolvedValue({ result: { id: 'folder-thumb', name: '慈悲なきアイオニア' } });
+    gapi.client.drive.files.create.mockResolvedValue({ result: { id: 'folder-thumb', name: 'Aionia TRPG Character Sheet' } });
 
     await gdm.createCharacterFile({
       content: '{}',
@@ -141,7 +141,7 @@ describe('GoogleDriveManager configuration and folder handling', () => {
   test('updateCharacterFile patches existing file', async () => {
     gapi.client.drive.files.list.mockResolvedValue({ result: { files: [] } });
     gapi.client.request.mockResolvedValue({ result: { id: 'cfg-6', name: 'aioniacs.cfg' } });
-    gapi.client.drive.files.create.mockResolvedValue({ result: { id: 'folder', name: '慈悲なきアイオニア' } });
+    gapi.client.drive.files.create.mockResolvedValue({ result: { id: 'folder', name: 'Aionia TRPG Character Sheet' } });
 
     await gdm.updateCharacterFile('file-1', { content: new Uint8Array([0x03, 0x04]), mimeType: 'application/zip', name: 'Hero' });
 
@@ -171,7 +171,7 @@ describe('GoogleDriveManager configuration and folder handling', () => {
       result: { files: [{ id: 'found', name: 'Hero.zip' }] },
     });
     gapi.client.request.mockResolvedValue({ result: { id: 'cfg-7', name: 'aioniacs.cfg' } });
-    gapi.client.drive.files.create.mockResolvedValue({ result: { id: 'folder', name: '慈悲なきアイオニア' } });
+    gapi.client.drive.files.create.mockResolvedValue({ result: { id: 'folder', name: 'Aionia TRPG Character Sheet' } });
 
     const file = await gdm.findFileByName('Hero.zip');
 
@@ -186,7 +186,7 @@ describe('GoogleDriveManager configuration and folder handling', () => {
   test('isFileInConfiguredFolder detects mismatched parent', async () => {
     gapi.client.drive.files.list.mockResolvedValue({ result: { files: [] } });
     gapi.client.request.mockResolvedValue({ result: { id: 'cfg-8', name: 'aioniacs.cfg' } });
-    gapi.client.drive.files.create.mockResolvedValue({ result: { id: 'folder-x', name: '慈悲なきアイオニア' } });
+    gapi.client.drive.files.create.mockResolvedValue({ result: { id: 'folder-x', name: 'Aionia TRPG Character Sheet' } });
     gapi.client.drive.files.get.mockResolvedValue({ result: { parents: ['other-folder'] } });
 
     const result = await gdm.isFileInConfiguredFolder('file-xyz');


### PR DESCRIPTION
## Summary
This PR makes two key improvements: internationalizing the Google Drive folder name from Japanese to English, and fixing a UI issue where the file upload modal wasn't being dismissed after a successful upload.

## Key Changes
- **Internationalization**: Changed the default Google Drive folder name from '慈悲なきアイオニア' (Japanese) to 'Aionia TRPG Character Sheet' (English) across:
  - `googleDriveManager.js` - Updated `DEFAULT_FOLDER_NAME` constant
  - `mockGoogleDriveManager.js` - Updated mock implementation to match
  - All related unit tests - Updated mock return values and assertions

- **Modal Dismissal Fix**: Fixed the file upload modal not closing after successful upload by:
  - Wrapping the `handleFileUpload` callback to explicitly call `modalStore.hideModal()` after file processing completes
  - This ensures the modal is dismissed regardless of the upload outcome

- **Data Export Cleanup**: Added `uiStore.clearCurrentDriveFileId()` call after successful data import to properly reset the current file state

## Implementation Details
The modal fix uses a closure pattern to maintain the original `handleFileUpload` functionality while adding the modal dismissal as a side effect. This approach preserves existing behavior while ensuring proper UI state management.

https://claude.ai/code/session_01LypLuTuGjhU4HGcQeYQegA