### PR TITLE
Add unsaved changes check before loading files

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -76,6 +76,20 @@ async function confirmDiscardingUnsavedChanges() {
   return result?.value === 'confirm';
 }
 
+async function checkUnsavedBeforeLoad() {
+  if (!hasUnsavedChanges()) return true;
+  const result = await showModal(messages.ui.confirmations.loadFile);
+  const choice = result?.value;
+  if (choice === 'save') {
+    const saved = await saveCharacterToDrive();
+    return !!saved;
+  }
+  if (choice === 'discard') {
+    return true;
+  }
+  return false;
+}
+
 const handleCreateNewCharacter = async () => {
   if (hasUnsavedChanges()) {
     const result = await showModal(messages.ui.confirmations.unsavedChanges);
@@ -110,6 +124,7 @@ const { openLoadModal, openIoModal, openShareModal } = useAppModals({
   printCharacterSheet,
   openPreviewPage,
   loadCharacterFromDrive,
+  checkUnsavedBeforeLoad,
   copyEditCallback: () => {
     uiStore.isViewingShared = false;
   },
@@ -136,7 +151,15 @@ watch(
   { immediate: true },
 );
 
-document.title = messages.ui.header.defaultTitle;
+const defaultDocumentTitle = messages.ui.header.defaultTitle;
+document.title = defaultDocumentTitle;
+
+watch(
+  () => characterStore.character.name,
+  (name) => {
+    document.title = name ? `${name} | ${defaultDocumentTitle}` : defaultDocumentTitle;
+  },
+);
 
 watch(
   () => modalStore.isVisible,

--- a/src/contents/ui_messages.csv
+++ b/src/contents/ui_messages.csv
@@ -155,6 +155,7 @@ ui.confirmations.unsavedChanges.message,現在の内容はまだ保存されて�
 ui.confirmations.unsavedChanges.buttons.save,保存して続行,,Unsaved changes dialog save button
 ui.confirmations.unsavedChanges.buttons.discard,保存せず続行,,Unsaved changes dialog discard button
 ui.confirmations.unsavedChanges.buttons.cancel,キャンセル,,Unsaved changes dialog cancel button
+ui.confirmations.loadFile.message,現在の内容はまだ保存されていません。ファイルを読み込むと変更は失われます。続行しますか？,,Load file unsaved changes message
 ui.modal.load.title,読込,,Load modal title
 ui.modal.load.buttons.loadLocal,ローカルファイル読込,,Load modal local button
 ui.modal.load.buttons.loadDrive,Driveから読み込む,,Load modal drive button

--- a/src/features/character-sheet/composables/useDataExport.js
+++ b/src/features/character-sheet/composables/useDataExport.js
@@ -31,6 +31,7 @@ export function useDataExport() {
     return dataManager.handleFileUpload(
       event,
       (parsedData) => {
+        characterStore.initializeAll();
         characterStore.hydrateFromData(parsedData);
         uiStore.setLastSavedSnapshot(buildSnapshotFromStore(characterStore));
         uiStore.clearCurrentDriveFileId();

--- a/src/features/modals/composables/useAppModals.js
+++ b/src/features/modals/composables/useAppModals.js
@@ -27,6 +27,7 @@ export function useAppModals(options) {
     openPreviewPage,
     copyEditCallback,
     loadCharacterFromDrive,
+    checkUnsavedBeforeLoad,
     canSignInToGoogle,
     isDriveReady,
     getLocalHistoryList,
@@ -59,11 +60,18 @@ export function useAppModals(options) {
       buttons: [],
       on: {
         'load-local': async (event) => {
-          try {
-            await handleFileUpload(event);
-          } finally {
-            modalStore.hideModal();
+          // Capture file before modal changes may remove the input element
+          const file = event.target.files?.[0];
+          if (!file) return;
+
+          modalStore.hideModal();
+
+          if (typeof checkUnsavedBeforeLoad === 'function') {
+            const confirmed = await checkUnsavedBeforeLoad();
+            if (!confirmed) return;
           }
+
+          await handleFileUpload({ target: { files: [file], value: '' } });
         },
         'sign-in': handleSignInClick,
         'open-history': () => openHistoryRecoveryModal(),

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -226,6 +226,15 @@ export const messages = {
           { label: t('ui.confirmations.unsavedChanges.buttons.cancel'), value: 'cancel', variant: 'secondary' },
         ],
       },
+      loadFile: {
+        title: t('ui.confirmations.unsavedChanges.title'),
+        message: t('ui.confirmations.loadFile.message'),
+        buttons: [
+          { label: t('ui.confirmations.unsavedChanges.buttons.save'), value: 'save', variant: 'primary' },
+          { label: t('ui.confirmations.unsavedChanges.buttons.discard'), value: 'discard', variant: 'secondary' },
+          { label: t('ui.confirmations.unsavedChanges.buttons.cancel'), value: 'cancel', variant: 'secondary' },
+        ],
+      },
     },
     modal: {
       load: {

--- a/tests/unit/composables/useAppModals.test.js
+++ b/tests/unit/composables/useAppModals.test.js
@@ -72,9 +72,10 @@ describe('useAppModals', () => {
     const args = showModalMock.mock.calls[0][0];
     expect(args.on['sign-in']).toBe(handleSignInClick);
     expect(typeof args.on['load-local']).toBe('function');
-    const mockEvent = { target: { files: [] } };
+    const mockFile = new File(['{}'], 'test.zip', { type: 'application/zip' });
+    const mockEvent = { target: { files: [mockFile] } };
     await args.on['load-local'](mockEvent);
-    expect(opts.handleFileUpload).toHaveBeenCalledWith(mockEvent);
+    expect(opts.handleFileUpload).toHaveBeenCalledWith({ target: { files: [mockFile], value: '' } });
   });
 
   test('desktop uses direct print', async () => {


### PR DESCRIPTION
## Summary
This PR adds a confirmation dialog when attempting to load a file while there are unsaved changes, allowing users to save, discard, or cancel the operation. It also improves the document title to display the current character name.

## Key Changes
- **New `checkUnsavedBeforeLoad()` function**: Added to App.vue to prompt users before loading a file if there are unsaved changes. Users can choose to save changes first, discard them, or cancel the load operation.
- **Updated file load modal handler**: Modified the 'load-local' event handler in useAppModals to call the new unsaved changes check before processing the file upload.
- **Dynamic document title**: The browser tab title now displays the current character name (e.g., "Character Name | Default Title") and updates reactively when the character name changes.
- **File input handling improvement**: Captured the file reference before modal state changes to ensure the file is properly passed to the upload handler.
- **Character initialization on load**: Added `characterStore.initializeAll()` call in useDataExport to ensure clean state before hydrating with loaded data.
- **Localization**: Added new confirmation message for the load file dialog in the UI messages CSV.

## Implementation Details
- The `checkUnsavedBeforeLoad()` function reuses the existing modal confirmation pattern and integrates with the character save functionality
- The file upload handler now explicitly clears the input value after processing to allow re-selecting the same file
- Document title updates are handled via a watcher on the character name property
- Tests were updated to reflect the new file handling behavior

https://claude.ai/code/session_01FA4qz1DK23UPWh3kWiHRXr