### PR TITLE
Add error handling for dynamic module imports

### DIFF
--- a/src/app/main.js
+++ b/src/app/main.js
@@ -7,6 +7,10 @@ import '@/shared/styles/style.css';
 
 window.addEventListener('vite:preloadError', (event) => {
   event.preventDefault();
+  const lastReload = sessionStorage.getItem('vite-preload-reload');
+  const now = Date.now();
+  if (lastReload && now - Number(lastReload) < 10000) return;
+  sessionStorage.setItem('vite-preload-reload', now.toString());
   window.location.reload();
 });
 

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -5,6 +5,11 @@ import { router } from './router/index.js';
 import { initializeDriveManager } from '@/infrastructure/google-drive/index.js';
 import '@/shared/styles/style.css';
 
+window.addEventListener('vite:preloadError', (event) => {
+  event.preventDefault();
+  window.location.reload();
+});
+
 initializeDriveManager(import.meta.env.VITE_GOOGLE_API_KEY, import.meta.env.VITE_GOOGLE_CLIENT_ID);
 
 const app = createApp(RootApp);

--- a/src/features/modals/composables/useAppModals.js
+++ b/src/features/modals/composables/useAppModals.js
@@ -2,10 +2,23 @@ import { defineAsyncComponent, watch } from 'vue';
 import { useModal } from './useModal.js';
 import { useModalStore } from '@/features/modals/stores/modalStore.js';
 import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
-const LoadModal = defineAsyncComponent(() => import('@/features/modals/components/contents/LoadModal.vue'));
-const HistoryRecoveryModal = defineAsyncComponent(() => import('@/features/modals/components/contents/HistoryRecoveryModal.vue'));
-const IoModal = defineAsyncComponent(() => import('@/features/modals/components/contents/IoModal.vue'));
-const ShareResultModal = defineAsyncComponent(() => import('@/features/modals/components/contents/ShareResultModal.vue'));
+function lazyModal(loader) {
+  return defineAsyncComponent({
+    loader,
+    onError(error, retry, fail) {
+      if (error.message.includes('dynamically imported module') || error.message.includes('Failed to fetch')) {
+        window.location.reload();
+      } else {
+        fail();
+      }
+    },
+  });
+}
+
+const LoadModal = lazyModal(() => import('@/features/modals/components/contents/LoadModal.vue'));
+const HistoryRecoveryModal = lazyModal(() => import('@/features/modals/components/contents/HistoryRecoveryModal.vue'));
+const IoModal = lazyModal(() => import('@/features/modals/components/contents/IoModal.vue'));
+const ShareResultModal = lazyModal(() => import('@/features/modals/components/contents/ShareResultModal.vue'));
 import { isDesktopDevice } from '@/shared/utils/device.js';
 import { messages } from '@/i18n/index.js';
 import { useShare } from '@/features/cloud-sync/composables/useShare.js';

--- a/src/features/modals/composables/useAppModals.js
+++ b/src/features/modals/composables/useAppModals.js
@@ -7,6 +7,13 @@ function lazyModal(loader) {
     loader,
     onError(error, retry, fail) {
       if (error.message.includes('dynamically imported module') || error.message.includes('Failed to fetch')) {
+        const lastReload = sessionStorage.getItem('vite-preload-reload');
+        const now = Date.now();
+        if (lastReload && now - Number(lastReload) < 10000) {
+          fail();
+          return;
+        }
+        sessionStorage.setItem('vite-preload-reload', now.toString());
         window.location.reload();
       } else {
         fail();


### PR DESCRIPTION
## Summary
This PR improves the application's resilience when dynamic module imports fail by adding comprehensive error handling for async component loading and Vite preload errors.

## Key Changes
- **Created `lazyModal()` helper function** in `useAppModals.js` that wraps `defineAsyncComponent()` with custom error handling
  - Detects module import failures and network errors
  - Automatically reloads the page when recoverable errors occur (dynamically imported module errors, fetch failures)
  - Properly fails for other error types
  - Applied to all modal component imports (LoadModal, HistoryRecoveryModal, IoModal, ShareResultModal)

- **Added global Vite preload error handler** in `main.js`
  - Listens for `vite:preloadError` events
  - Prevents default error behavior and triggers page reload
  - Ensures graceful recovery from preload failures during application startup

## Implementation Details
The error handling strategy distinguishes between recoverable errors (network/module loading issues) that warrant a full page reload versus other errors that should fail gracefully. This approach helps users recover from transient network issues or stale module caches without manual intervention.

https://claude.ai/code/session_01WCTzbydGcG4FaWB2Ujnmhj