### PR TITLE
権利文言の削除

### DIFF
--- a/src/layouts/CharacterSheetLayout.vue
+++ b/src/layouts/CharacterSheetLayout.vue
@@ -39,14 +39,6 @@ async function openPrivacyPolicy() {
     <AdventureLogSection />
   </div>
   <div class="copyright-footer">
-    <p>
-      本サイトは<a href="https://www.aioniatrpg.com/" target="_blank" rel="noopener noreferrer"
-        >「イチ（フシギ製作所）」様が権利を有する「慈悲なきアイオニア」</a
-      >の二次創作物です(Ver 1.2対応)。<br />
-      本サイトは<a href="https://bright-trpg.github.io/aionia_character_maker/" target="_blank" rel="noopener noreferrer"
-        >bright-trpg様作成の「慈悲なきアイオニア　キャラクター作成用ツール」</a
-      >をもとに、あろすてりっくが作成しました。
-    </p>
     <button class="button-link" @click="openPrivacyPolicy">プライバシーポリシー</button>
     <div class="build-info" v-if="buildInfo">{{ buildInfo }}</div>
   </div>


### PR DESCRIPTION
42~49行目(div classの下の行)から以下の文言を削除。

----------------
    <p>
      本サイトは<a href="https://www.aioniatrpg.com/" target="_blank" rel="noopener noreferrer"
        >「イチ（フシギ製作所）」様が権利を有する「慈悲なきアイオニア」</a
      >の二次創作物です(Ver 1.2対応)。<br />
      本サイトは<a href="https://bright-trpg.github.io/aionia_character_maker/" target="_blank" rel="noopener noreferrer"
        >bright-trpg様作成の「慈悲なきアイオニア　キャラクター作成用ツール」</a
      >をもとに、あろすてりっくが作成しました。
    </p>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed copyright and version information from the footer display, retaining only the privacy policy button and build information block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->