### PR TITLE
fix: Drive保存の偽成功・フォルダ未作成とヘルプ画面のスクロール不可を修正

### DIFF
--- a/src/app/providers/useAppInitialization.js
+++ b/src/app/providers/useAppInitialization.js
@@ -1,4 +1,4 @@
-import { fallbackToMockDriveManager, initializeDriveManager, isUsingMockDrive } from '@/infrastructure/google-drive/index.js';
+import { initializeDriveManager, isUsingMockDrive } from '@/infrastructure/google-drive/index.js';
 import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
 
 function waitForGoogleScript() {
@@ -66,14 +66,14 @@ export function useAppInitialization() {
         }
       } catch (error) {
         console.error('Failed to initialize Drive manager:', error);
-        if (!usingMock) {
-          const mockManager = fallbackToMockDriveManager(import.meta.env.VITE_GOOGLE_API_KEY, import.meta.env.VITE_GOOGLE_CLIENT_ID);
-          await mockManager.onGapiLoad();
-          uiStore.isGapiInitialized = true;
-          uiStore.isSignedIn = await mockManager.restoreSession();
-        } else {
+        if (usingMock) {
           uiStore.isGapiInitialized = true;
           uiStore.isSignedIn = true;
+        } else {
+          // モックDriveへの無言フォールバックは廃止。実際には保存されないのに
+          // 「保存成功」と表示される事故を防ぐため、未接続のままにする。
+          uiStore.isGapiInitialized = false;
+          uiStore.isSignedIn = false;
         }
       }
     } else if (usingMock) {

--- a/src/features/character-sheet/components/ui/HelpPanel.vue
+++ b/src/features/character-sheet/components/ui/HelpPanel.vue
@@ -87,6 +87,12 @@ defineExpose({ panelEl });
   z-index: 200;
   max-width: 90%;
   width: 400px;
+
+  /* fixed配置のためページスクロールが効かない。内容が画面より長い場合に
+     備えてパネル自体をスクロール可能にする（112px = top 92px + 下余白20px） */
+  max-height: calc(100vh - 112px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
   font-size: 0.9em;
   color: var(--color-text-normal);
 }

--- a/src/features/cloud-sync/composables/useGoogleDrive.js
+++ b/src/features/cloud-sync/composables/useGoogleDrive.js
@@ -1,10 +1,5 @@
 import { ref, computed, onMounted } from 'vue';
-import {
-  fallbackToMockDriveManager,
-  getDriveManagerInstance,
-  initializeDriveManager,
-  isUsingMockDrive,
-} from '@/infrastructure/google-drive/index.js';
+import { getDriveManagerInstance, initializeDriveManager, isUsingMockDrive } from '@/infrastructure/google-drive/index.js';
 import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
 import { useCharacterStore } from '@/features/character-sheet/stores/characterStore.js';
 import { removeStoredCharacterDraft } from '@/features/character-sheet/composables/useLocalCharacterPersistence.js';
@@ -148,12 +143,14 @@ export function useGoogleDrive(dataManager) {
         targetFileId,
       )
       .then(async (result) => {
-        if (result) {
-          uiStore.setCurrentDriveFileId(result.id);
-          uiStore.setLastSavedSnapshot(snapshotToSave);
-          return renameDriveFileIfNeeded(result);
+        if (!result) {
+          // GoogleDriveManagerはAPIエラー時にnullを返すため、ここで失敗として
+          // 扱わないと保存されていないのに成功トーストが表示されてしまう
+          throw new Error(messages.googleDrive.save.error().message);
         }
-        return result;
+        uiStore.setCurrentDriveFileId(result.id);
+        uiStore.setLastSavedSnapshot(snapshotToSave);
+        return renameDriveFileIfNeeded(result);
       });
 
     showAsyncToast(
@@ -166,7 +163,7 @@ export function useGoogleDrive(dataManager) {
       'saveCharacterToDrive',
     );
 
-    return savePromise;
+    return savePromise.catch(() => null);
   }
 
   async function renameDriveFileIfNeeded(result) {
@@ -198,13 +195,6 @@ export function useGoogleDrive(dataManager) {
 
     scriptsWatched = true;
 
-    function applyFallbackMockDrive() {
-      googleDriveManager.value = fallbackToMockDriveManager();
-      if (googleDriveManager.value && typeof dataManager.setGoogleDriveManager === 'function') {
-        dataManager.setGoogleDriveManager(googleDriveManager.value);
-      }
-    }
-
     const handleDriveReady = async () => {
       if (uiStore.isGapiInitialized || !googleDriveManager.value) return;
       console.info('Google API Loading...');
@@ -215,11 +205,9 @@ export function useGoogleDrive(dataManager) {
         const restored = await googleDriveManager.value.restoreSession();
         uiStore.isSignedIn = restored;
       } catch (error) {
-        if (!isUsingMockDrive()) {
-          applyFallbackMockDrive();
-          await handleDriveReady();
-          return;
-        }
+        // 以前はここでモックDriveに無言で切り替えていたが、その場合
+        // 保存が「成功」してもGoogleドライブには何も書き込まれない。
+        // 偽の成功よりエラーを明示する方が安全なので、未接続として扱う。
         uiStore.isGapiInitialized = false;
         uiStore.isSignedIn = false;
         logAndToastError(error, messages.googleDrive.apiInitError, 'initializeGoogleDrive');
@@ -249,12 +237,9 @@ export function useGoogleDrive(dataManager) {
 
     waitForScript('script[src="https://apis.google.com/js/api.js"]', () => window.gapi && window.gapi.load)
       .then(handleDriveReady)
-      .catch(async (error) => {
-        if (!isUsingMockDrive()) {
-          applyFallbackMockDrive();
-          await handleDriveReady();
-          return;
-        }
+      .catch((error) => {
+        uiStore.isGapiInitialized = false;
+        uiStore.isSignedIn = false;
         logAndToastError(error, messages.googleDrive.apiInitError, 'initializeGoogleDrive');
       });
   }

--- a/src/infrastructure/google-drive/googleDriveManager.js
+++ b/src/infrastructure/google-drive/googleDriveManager.js
@@ -65,6 +65,7 @@ export class GoogleDriveManager {
     this.scope = 'https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive.file';
     this.gapiLoadedCallback = null;
     this.aioniaFolderId = null;
+    this.folderLookupPromise = null;
     this.gapiLoadPromise = null;
     this.currentTokenInfo = null;
     this.authStatusEndpoint = '/api/auth/status';
@@ -103,12 +104,14 @@ export class GoogleDriveManager {
 
     const escapedName = this.configFileName.replace(/'/g, "\\'");
 
+    let listSucceeded = false;
     try {
       const response = await gapi.client.drive.files.list({
         q: `name='${escapedName}'`,
         fields: 'files(id, name)',
         spaces: 'appDataFolder',
       });
+      listSucceeded = true;
       const file = response.result.files?.[0];
       if (file) {
         this.configFileId = file.id;
@@ -131,7 +134,12 @@ export class GoogleDriveManager {
     }
 
     this.config = this.getDefaultConfig();
-    await this.saveConfig();
+    // 一覧取得自体が失敗した時に保存すると、既存の設定ファイルと重複した
+    // aioniacs.cfgを作ってしまう（次回どちらが読まれるかは不定になる）ため、
+    // 「確実に存在しない」と分かった場合だけ既定値を永続化する
+    if (listSucceeded) {
+      await this.saveConfig();
+    }
     return this.config;
   }
 
@@ -577,13 +585,20 @@ export class GoogleDriveManager {
   /**
    * Ensures the character folder exists in Drive and returns its ID.
    * Uses the stored folder ID if available; otherwise creates a new folder.
+   * Concurrent calls share the same lookup to avoid creating duplicate folders.
    * @returns {Promise<string|null>} The ID of the folder, or null if not available.
    */
   async findOrCreateConfiguredCharacterFolder() {
-    if (this.aioniaFolderId) {
-      return this.aioniaFolderId;
+    if (this.folderLookupPromise) {
+      return this.folderLookupPromise;
     }
+    this.folderLookupPromise = this._findOrCreateConfiguredCharacterFolder().finally(() => {
+      this.folderLookupPromise = null;
+    });
+    return this.folderLookupPromise;
+  }
 
+  async _findOrCreateConfiguredCharacterFolder() {
     if (!gapi.client || !gapi.client.drive) {
       console.error('GAPI client or Drive API not loaded for findOrCreateConfiguredCharacterFolder.');
       return null;
@@ -591,21 +606,26 @@ export class GoogleDriveManager {
 
     const config = await this.loadConfig();
 
-    // Try to access the stored folder ID
-    if (config?.characterFolderId) {
+    // メモリキャッシュも信用せず毎回存在確認する。セッション中にユーザーが
+    // Drive上でフォルダを削除した場合、ゴミ箱内のフォルダを親にした保存が
+    // 成功してしまい、シートがゴミ箱に消える事故を防ぐため。
+    const candidateId = this.aioniaFolderId || config?.characterFolderId;
+    if (candidateId) {
       try {
         await this.ensureAccessToken();
         const response = await gapi.client.drive.files.get({
-          fileId: config.characterFolderId,
+          fileId: candidateId,
           fields: 'id, trashed',
         });
         if (response.result?.id && !response.result.trashed) {
           this.aioniaFolderId = response.result.id;
           return this.aioniaFolderId;
         }
+        console.log('Configured folder is trashed, creating new folder.');
       } catch (error) {
         console.log('Stored folder ID no longer accessible, creating new folder.', error);
       }
+      this.aioniaFolderId = null;
     }
 
     // Create a new folder with the fixed name

--- a/src/infrastructure/google-drive/googleDriveManager.js
+++ b/src/infrastructure/google-drive/googleDriveManager.js
@@ -96,8 +96,8 @@ export class GoogleDriveManager {
     }
     if (!gapi.client || !gapi.client.drive) {
       console.error('GAPI client or Drive API not loaded for loadConfig.');
-      this.config = this.getDefaultConfig();
-      return this.config;
+      // キャッシュすると以降ずっと空の設定が返り続けるため、キャッシュせず返す
+      return this.getDefaultConfig();
     }
 
     await this.ensureAccessToken();
@@ -133,14 +133,16 @@ export class GoogleDriveManager {
       console.error('Error loading config file:', error);
     }
 
-    this.config = this.getDefaultConfig();
-    // 一覧取得自体が失敗した時に保存すると、既存の設定ファイルと重複した
-    // aioniacs.cfgを作ってしまう（次回どちらが読まれるかは不定になる）ため、
-    // 「確実に存在しない」と分かった場合だけ既定値を永続化する
+    // 一覧取得自体が失敗した場合はキャッシュも永続化もしない。
+    // キャッシュすると通信回復後も空の設定が返り続け、永続化すると既存の
+    // 設定ファイルと重複したaioniacs.cfgを作ってしまうため、
+    // 「確実に存在しない」と分かった場合だけ既定値を確定させる
     if (listSucceeded) {
+      this.config = this.getDefaultConfig();
       await this.saveConfig();
+      return this.config;
     }
-    return this.config;
+    return this.getDefaultConfig();
   }
 
   async saveConfig() {

--- a/src/infrastructure/google-drive/index.js
+++ b/src/infrastructure/google-drive/index.js
@@ -70,17 +70,6 @@ export function resetDriveManagerForTests() {
   }
 }
 
-export function fallbackToMockDriveManager(apiKey = env?.VITE_GOOGLE_API_KEY, clientId = env?.VITE_GOOGLE_CLIENT_ID) {
-  if (runtimeUseMockDrive && sharedInstance) {
-    return sharedInstance;
-  }
-  runtimeUseMockDrive = true;
-  sharedInstance = null;
-  currentInitializer = initializeMockGoogleDriveManager;
-  currentGetter = getMockGoogleDriveManagerInstance;
-  return initializeDriveManager(apiKey, clientId);
-}
-
 export function isUsingMockDrive() {
   return runtimeUseMockDrive;
 }

--- a/tests/unit/composables/useAppInitialization.test.js
+++ b/tests/unit/composables/useAppInitialization.test.js
@@ -1,17 +1,61 @@
 import { setActivePinia, createPinia } from 'pinia';
-import { useAppInitialization } from '@/app/providers/useAppInitialization.js';
 import { useUiStore } from '@/features/cloud-sync/stores/uiStore.js';
+
+const initializeDriveManagerMock = vi.fn();
+const isUsingMockDriveMock = vi.fn();
+
+vi.mock('@/infrastructure/google-drive/index.js', () => ({
+  initializeDriveManager: (...args) => initializeDriveManagerMock(...args),
+  isUsingMockDrive: () => isUsingMockDriveMock(),
+}));
+
+const { useAppInitialization } = await import('@/app/providers/useAppInitialization.js');
 
 describe('useAppInitialization', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    vi.clearAllMocks();
   });
 
   test('sets loading state to false on initialize', async () => {
+    initializeDriveManagerMock.mockReturnValue(null);
+    isUsingMockDriveMock.mockReturnValue(false);
     const uiStore = useUiStore();
     uiStore.setLoading(true);
     const { initialize } = useAppInitialization();
     await initialize();
     expect(uiStore.isLoading).toBe(false);
+  });
+
+  test('marks drive as unavailable instead of falling back to mock when init fails', async () => {
+    initializeDriveManagerMock.mockReturnValue({
+      onGapiLoad: vi.fn().mockRejectedValue(new Error('gapi load failed')),
+      restoreSession: vi.fn(),
+    });
+    isUsingMockDriveMock.mockReturnValue(false);
+    const uiStore = useUiStore();
+    const { initialize } = useAppInitialization();
+
+    await initialize();
+
+    // モックに切り替わって「サインイン済み」を装わないこと
+    expect(uiStore.isGapiInitialized).toBe(false);
+    expect(uiStore.isSignedIn).toBe(false);
+    expect(uiStore.isLoading).toBe(false);
+  });
+
+  test('keeps mock drive available when explicitly enabled and init fails', async () => {
+    initializeDriveManagerMock.mockReturnValue({
+      onGapiLoad: vi.fn().mockRejectedValue(new Error('mock init failed')),
+      restoreSession: vi.fn(),
+    });
+    isUsingMockDriveMock.mockReturnValue(true);
+    const uiStore = useUiStore();
+    const { initialize } = useAppInitialization();
+
+    await initialize();
+
+    expect(uiStore.isGapiInitialized).toBe(true);
+    expect(uiStore.isSignedIn).toBe(true);
   });
 });

--- a/tests/unit/composables/useGoogleDrive.test.js
+++ b/tests/unit/composables/useGoogleDrive.test.js
@@ -185,6 +185,27 @@ describe('useGoogleDrive', () => {
     expect(result).toEqual({ id: 'existing-id', name: 'Knight.zip' });
   });
 
+  test('saveCharacterToDrive treats a null result as failure instead of success', async () => {
+    const dataManager = {
+      saveCharacterToDrive: vi.fn().mockResolvedValue(null),
+      googleDriveManager: {},
+      getDriveFileName: vi.fn().mockReturnValue('Hero.zip'),
+    };
+    const { saveCharacterToDrive } = useGoogleDrive(dataManager);
+    const uiStore = useUiStore();
+    uiStore.isGapiInitialized = true;
+    uiStore.isSignedIn = true;
+
+    const result = await saveCharacterToDrive();
+
+    expect(result).toBeNull();
+    expect(uiStore.currentDriveFileId).toBeNull();
+    expect(uiStore.lastSavedSnapshot).toBeNull();
+    // showAsyncToastに渡されたPromiseはrejectし、エラートーストが表示される
+    const toastPromise = showAsyncToastMock.mock.calls[showAsyncToastMock.mock.calls.length - 1][0];
+    await expect(toastPromise).rejects.toThrow(messages.googleDrive.save.error().message);
+  });
+
   test('saveCharacterToDrive uses new success message for brand-new files', async () => {
     const dataManager = {
       saveCharacterToDrive: vi.fn().mockResolvedValue({ id: 'new-id', name: 'Rookie.zip' }),

--- a/tests/unit/googleDriveManager.test.js
+++ b/tests/unit/googleDriveManager.test.js
@@ -112,6 +112,21 @@ describe('GoogleDriveManager configuration and folder handling', () => {
     expect(gapi.client.request).not.toHaveBeenCalled();
   });
 
+  test('loadConfig retries after a failed listing instead of caching the default config', async () => {
+    gapi.client.drive.files.list
+      .mockRejectedValueOnce(new Error('network error'))
+      .mockResolvedValueOnce({ result: { files: [{ id: 'cfg-retry', name: 'aioniacs.cfg' }] } });
+    gapi.client.drive.files.get.mockResolvedValue({ body: JSON.stringify({ characterFolderId: 'folder-after-retry' }) });
+
+    const failedConfig = await gdm.loadConfig();
+    expect(failedConfig.characterFolderId).toBeNull();
+
+    // 通信回復後の呼び出しでは保存済みの設定が読み直されること
+    const retriedConfig = await gdm.loadConfig();
+    expect(retriedConfig.characterFolderId).toBe('folder-after-retry');
+    expect(gdm.configFileId).toBe('cfg-retry');
+  });
+
   test('findOrCreateConfiguredCharacterFolder recreates folder when cached folder is trashed', async () => {
     gdm.config = { characterFolderId: 'trashed-folder' };
     gdm.aioniaFolderId = 'trashed-folder';

--- a/tests/unit/googleDriveManager.test.js
+++ b/tests/unit/googleDriveManager.test.js
@@ -102,6 +102,42 @@ describe('GoogleDriveManager configuration and folder handling', () => {
     });
   });
 
+  test('loadConfig does not persist a new config file when listing fails', async () => {
+    gapi.client.drive.files.list.mockRejectedValue(new Error('network error'));
+
+    const config = await gdm.loadConfig();
+
+    expect(config.characterFolderId).toBeNull();
+    // 一覧取得に失敗しただけで保存すると重複したaioniacs.cfgが作られるため、書き込みしない
+    expect(gapi.client.request).not.toHaveBeenCalled();
+  });
+
+  test('findOrCreateConfiguredCharacterFolder recreates folder when cached folder is trashed', async () => {
+    gdm.config = { characterFolderId: 'trashed-folder' };
+    gdm.aioniaFolderId = 'trashed-folder';
+    gapi.client.drive.files.get.mockResolvedValue({ result: { id: 'trashed-folder', trashed: true } });
+    gapi.client.drive.files.create.mockResolvedValue({ result: { id: 'fresh-folder', name: 'Aionia TRPG Character Sheet' } });
+    gapi.client.request.mockResolvedValue({ result: { id: 'cfg-9', name: 'aioniacs.cfg' } });
+
+    const folderId = await gdm.findOrCreateConfiguredCharacterFolder();
+
+    expect(folderId).toBe('fresh-folder');
+    expect(gdm.config.characterFolderId).toBe('fresh-folder');
+    expect(gapi.client.drive.files.create).toHaveBeenCalledTimes(1);
+  });
+
+  test('concurrent findOrCreateConfiguredCharacterFolder calls create only one folder', async () => {
+    gdm.config = { characterFolderId: null };
+    gapi.client.drive.files.create.mockResolvedValue({ result: { id: 'only-folder', name: 'Aionia TRPG Character Sheet' } });
+    gapi.client.request.mockResolvedValue({ result: { id: 'cfg-10', name: 'aioniacs.cfg' } });
+
+    const [first, second] = await Promise.all([gdm.findOrCreateConfiguredCharacterFolder(), gdm.findOrCreateConfiguredCharacterFolder()]);
+
+    expect(first).toBe('only-folder');
+    expect(second).toBe('only-folder');
+    expect(gapi.client.drive.files.create).toHaveBeenCalledTimes(1);
+  });
+
   test('createCharacterFile uploads to configured folder', async () => {
     // loadConfig: no config file found → saves default config
     gapi.client.drive.files.list.mockResolvedValue({ result: { files: [] } });


### PR DESCRIPTION
## 概要

調査で特定した2つのバグを修正します。

1. Google Driveに「Aionia TRPG Character Sheet」フォルダが作成されない/「保存成功」と表示されるのにキャラクターシートが実際には保存されていない
2. ヘルプ画面がスクロールできない

## 1. Drive保存まわりの修正

### モックDriveへの無言フォールバックを廃止（最重要）
gapiスクリプトの読み込みや初期化に失敗すると、本番環境でも `MockGoogleDriveManager`（localStorage保存）へ無言で切り替わっていました。モックは常時サインイン済みを装うため、ログインも保存も成功したように見えて**実際のGoogleドライブには何も書き込まれません**。これが「フォルダが作成されたりされなかったりする」「保存成功と言われるのにシートが見つからない」の主因です。フォールバックを廃止し、初期化失敗時はエラートーストを表示して未接続として扱います（`VITE_USE_MOCK_DRIVE=true` の開発用モックは従来どおり動作）。

### 保存失敗時に成功トーストが出る問題を修正
`GoogleDriveManager` はAPIエラー時に `null` を返しますが、呼び出し側がこれを成功として扱い「保存しました」と表示していました。`null` を失敗として扱い、エラートーストを表示します（呼び出し元への戻り値は従来どおり `null` を維持）。

### フォルダ削除後にゴミ箱へ保存される問題を修正
保存先フォルダIDのメモリキャッシュをそのまま信用していたため、セッション中にユーザーがDrive上でフォルダを削除すると、**ゴミ箱内のフォルダを親としたファイル作成が成功**し、シートが見えない場所に保存されていました。毎回 `files.get` で存在と `trashed` を確認し、削除されていれば新しいフォルダを作り直します。

### その他の堅牢化
- `findOrCreateConfiguredCharacterFolder` の並行呼び出しで重複フォルダが作られないよう、in-flightガードを追加
- 設定ファイル（`aioniacs.cfg`）の一覧取得が一時的に失敗しただけで新規作成して重複させてしまう問題を修正（確実に存在しない場合のみ作成）

## 2. ヘルプ画面のスクロール修正

`.help-panel` は `position: fixed` なのに `max-height` / `overflow-y` がなく、ヘルプの内容が画面より長くなるとはみ出した部分を読む手段がありませんでした。`max-height: calc(100vh - 112px)` と `overflow-y: auto` を追加し、パネル内でスクロールできるようにしました。

## テスト

- 追加: フォルダがゴミ箱の場合の再作成 / 並行呼び出しでフォルダが1つだけ作られる / 一覧取得失敗時にcfgを重複作成しない / 保存結果nullでエラートースト / 初期化失敗時にモックへフォールバックしない
- `npm test`（178件）、`npm run lint`、`npm run build` すべて通過

https://claude.ai/code/session_01YbartRnuE7AYqP8MPisGFS

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbartRnuE7AYqP8MPisGFS)_