### PR TITLE
feat: モックGoogle Driveを強化し実装との契約テストを追加

### DIFF
--- a/docs/mock-google-drive.md
+++ b/docs/mock-google-drive.md
@@ -1,0 +1,49 @@
+# モックGoogle Drive(開発用)
+
+`VITE_USE_MOCK_DRIVE=true` を設定して起動すると、Google認証やバックエンドなしで
+Drive連携機能を試せるモック実装(`MockGoogleDriveManager`)が使われます。
+データは `localStorage`(キー: `mockGoogleDriveData`)に保存され、リロード後も保持されます。
+
+```bash
+VITE_USE_MOCK_DRIVE=true npm run dev
+```
+
+## 実装との対応
+
+モックは実装(`GoogleDriveManager`)と同じpublicメソッドを持ち、主要な挙動を再現します:
+
+- サインイン/サインアウト状態とトークン管理(サインアウト中のDrive操作は
+  `Authentication required.` で失敗)
+- 設定フォルダの存在確認と自動再作成(フォルダが消えた場合は実装と同様に作り直す)
+- 削除済みファイルの更新は実装の404相当のエラー
+  (`Parent folder not found. Please select a new folder.`)をスロー
+- 共有(`ensureFilePublic` / `unshareFile`)と一覧での `shared` フラグ
+
+APIの乖離は `tests/unit/mockGoogleDriveManager.test.js` の契約テストで検出されます。
+実装にpublicメソッドを追加した場合はモックにも追加してください。
+
+## 障害シミュレーション
+
+エラーハンドリング(トースト表示、リトライ等)の動作確認用に、開発コンソールから
+失敗や遅延を注入できます。インスタンスは `window.__DRIVE_DEV__` に公開されています。
+
+```js
+// saveFile を1回だけ失敗させる(2回目以降は成功)
+__DRIVE_DEV__.simulateFailure('saveFile', { times: 1 });
+
+// 全メソッドをカスタムエラーで失敗させ続ける
+__DRIVE_DEV__.simulateFailure('*', { error: 'network down' });
+
+// 全操作に2秒の遅延を加える(ローディング表示の確認用)
+__DRIVE_DEV__.setLatency(2000);
+
+// 解除
+__DRIVE_DEV__.clearSimulatedFailures();
+__DRIVE_DEV__.setLatency(0);
+
+// 保存データごと初期状態に戻す
+__DRIVE_DEV__.reset();
+```
+
+シミュレーション設定はメモリ上のみで、`localStorage` には永続化されません
+(リロードで解除されます)。

--- a/src/infrastructure/google-drive/mockGoogleDriveManager.js
+++ b/src/infrastructure/google-drive/mockGoogleDriveManager.js
@@ -36,6 +36,9 @@ export class MockGoogleDriveManager {
     this.storageKey = 'mockGoogleDriveData';
     this.configFileId = 'mock-config';
     this.currentTokenInfo = null;
+    // 障害シミュレーション設定(localStorageには永続化しない)
+    this._failureRules = new Map();
+    this._latencyMs = 0;
     this._loadState();
     singletonInstance = this;
     if (typeof window !== 'undefined') {
@@ -102,8 +105,49 @@ export class MockGoogleDriveManager {
     this.state = this._getDefaultState();
     this.configuredFolderId = null;
     this.currentTokenInfo = null;
+    this._failureRules.clear();
+    this._latencyMs = 0;
     this._seedSampleData();
     this._saveState();
+  }
+
+  // --- 障害シミュレーション ---
+  // 開発時は window.__DRIVE_DEV__.simulateFailure('saveFile') のように使う。
+  // methodName に '*' を指定すると全メソッドが対象になる。
+
+  simulateFailure(methodName, { times = Infinity, error } = {}) {
+    if (!methodName) {
+      throw new Error('simulateFailure requires a method name (or "*" for all methods).');
+    }
+    this._failureRules.set(methodName, { remaining: times, error });
+  }
+
+  clearSimulatedFailures() {
+    this._failureRules.clear();
+  }
+
+  setLatency(ms) {
+    this._latencyMs = Number(ms) > 0 ? Number(ms) : 0;
+  }
+
+  async _simulate(methodName) {
+    if (this._latencyMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, this._latencyMs));
+    }
+    const key = this._failureRules.has(methodName) ? methodName : this._failureRules.has('*') ? '*' : null;
+    if (!key) {
+      return;
+    }
+    const rule = this._failureRules.get(key);
+    rule.remaining -= 1;
+    if (rule.remaining <= 0) {
+      this._failureRules.delete(key);
+    }
+    const error = rule.error;
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error(typeof error === 'string' ? error : `Simulated Drive failure in ${methodName}.`);
   }
 
   getDefaultConfig() {
@@ -111,10 +155,12 @@ export class MockGoogleDriveManager {
   }
 
   async onGapiLoad() {
+    await this._simulate('onGapiLoad');
     return Promise.resolve();
   }
 
   async ensureAccessToken() {
+    await this._simulate('ensureAccessToken');
     if (!this.state.signedIn) {
       throw new Error('Authentication required.');
     }
@@ -132,11 +178,14 @@ export class MockGoogleDriveManager {
       await this.ensureAccessToken();
       return true;
     } catch {
+      // 実装と同様、復元失敗時はトークンを破棄してゲスト扱いにする
+      this.currentTokenInfo = null;
       return false;
     }
   }
 
   async handleSignIn() {
+    await this._simulate('handleSignIn');
     this.state.signedIn = true;
     this._saveState();
     await this.ensureAccessToken();
@@ -144,6 +193,7 @@ export class MockGoogleDriveManager {
   }
 
   async handleSignOut(callback) {
+    await this._simulate('handleSignOut');
     this.state.signedIn = false;
     this.currentTokenInfo = null;
     this._saveState();
@@ -151,15 +201,20 @@ export class MockGoogleDriveManager {
   }
 
   async loadConfig() {
+    await this._simulate('loadConfig');
+    await this.ensureAccessToken();
     return this.state.config;
   }
 
   async saveConfig() {
+    await this._simulate('saveConfig');
+    await this.ensureAccessToken();
     this._saveState();
     return { id: this.configFileId, name: 'aioniacs.cfg' };
   }
 
   async createFolder(name, parentId = 'root') {
+    await this._simulate('createFolder');
     await this.ensureAccessToken();
     const existing = await this.findFolder(name, parentId);
     if (existing) {
@@ -173,6 +228,7 @@ export class MockGoogleDriveManager {
   }
 
   async findFolder(name, parentId = 'root') {
+    await this._simulate('findFolder');
     await this.ensureAccessToken();
     if (parentId === 'root' && name === 'root') {
       return { id: 'root', name: 'root', parentId: null };
@@ -181,8 +237,9 @@ export class MockGoogleDriveManager {
   }
 
   async getOrCreateAppFolder(appFolderName) {
+    await this._simulate('getOrCreateAppFolder');
     await this.ensureAccessToken();
-    const targetName = appFolderName || this.getDefaultConfig().characterFolderPath;
+    const targetName = appFolderName || MockGoogleDriveManager.DEFAULT_FOLDER_NAME;
     let folder = await this.findFolder(targetName, 'root');
     if (!folder) {
       folder = await this.createFolder(targetName, 'root');
@@ -191,17 +248,18 @@ export class MockGoogleDriveManager {
   }
 
   async findOrCreateConfiguredCharacterFolder() {
-    if (this.configuredFolderId) {
-      return this.configuredFolderId;
-    }
-
+    await this._simulate('findOrCreateConfiguredCharacterFolder');
     const config = await this.loadConfig();
 
-    // Try to use stored folder ID
-    if (config?.characterFolderId && this.state.folders[config.characterFolderId]) {
-      this.configuredFolderId = config.characterFolderId;
+    // 実装と同様、キャッシュ済みIDも毎回存在確認する。Drive上(モックでは
+    // state上)からフォルダが消えた場合に、消えたIDを親にした保存が成功して
+    // しまわないようにするため。
+    const candidateId = this.configuredFolderId || config?.characterFolderId;
+    if (candidateId && this.state.folders[candidateId]) {
+      this.configuredFolderId = candidateId;
       return this.configuredFolderId;
     }
+    this.configuredFolderId = null;
 
     // Create a new folder with the fixed name
     const folder = await this.createFolder(MockGoogleDriveManager.DEFAULT_FOLDER_NAME, 'root');
@@ -216,7 +274,10 @@ export class MockGoogleDriveManager {
   }
 
   async listFiles(folderId, mimeType = 'application/json') {
+    await this._simulate('listFiles');
     await this.ensureAccessToken();
+    // キャラクターファイルはzipで保存されるため、本番の一覧クエリ
+    // (useDriveLoadPageState)と同様にzipも常に含める
     return Object.values(this.state.files)
       .filter((file) => file.parentId === folderId && (!mimeType || file.mimeType === mimeType || file.mimeType === 'application/zip'))
       .map((file) => ({
@@ -231,7 +292,12 @@ export class MockGoogleDriveManager {
   }
 
   async saveFile(folderId, fileName, fileContent, fileId = null, mimeType = 'application/json', contentHints = null) {
+    await this._simulate('saveFile');
     await this.ensureAccessToken();
+    if (fileId && !this.state.files[fileId]) {
+      // 実装ではDrive APIが404を返し、このメッセージのエラーがスローされる
+      throw new Error('Parent folder not found. Please select a new folder.');
+    }
     const now = new Date().toISOString();
     const id = fileId || `file-${this.state.fileCounter++}`;
     const existing = this.state.files[id];
@@ -251,12 +317,14 @@ export class MockGoogleDriveManager {
   }
 
   async loadFileContent(fileId) {
+    await this._simulate('loadFileContent');
     await this.ensureAccessToken();
     const file = this.state.files[fileId];
     return file ? file.content : null;
   }
 
   async uploadAndShareFile(fileContent, fileName, mimeType = 'application/json') {
+    await this._simulate('uploadAndShareFile');
     await this.ensureAccessToken();
     const info = await this.saveFile('shared', fileName, fileContent, null, mimeType);
     await this.ensureFilePublic(info.id);
@@ -264,6 +332,7 @@ export class MockGoogleDriveManager {
   }
 
   async ensureFilePublic(fileId) {
+    await this._simulate('ensureFilePublic');
     await this.ensureAccessToken();
     if (!fileId) {
       return null;
@@ -278,6 +347,7 @@ export class MockGoogleDriveManager {
   }
 
   async unshareFile(fileId) {
+    await this._simulate('unshareFile');
     await this.ensureAccessToken();
     const file = this.state.files[fileId];
     if (!file) return false;
@@ -287,6 +357,7 @@ export class MockGoogleDriveManager {
   }
 
   async findFileByName(fileName) {
+    await this._simulate('findFileByName');
     await this.ensureAccessToken();
     if (!fileName) return null;
     const folderId = await this.findOrCreateConfiguredCharacterFolder();
@@ -296,6 +367,8 @@ export class MockGoogleDriveManager {
   }
 
   async isFileInConfiguredFolder(fileId) {
+    await this._simulate('isFileInConfiguredFolder');
+    if (!fileId) return false;
     const folderId = await this.findOrCreateConfiguredCharacterFolder();
     if (!folderId) return false;
     const file = this.state.files[fileId];
@@ -324,6 +397,7 @@ export class MockGoogleDriveManager {
   }
 
   async createCharacterFile(payload) {
+    await this._simulate('createCharacterFile');
     const params = await this._buildCharacterFileParams(payload);
     if (!params) return null;
     const { mimeType, fileName, folderId, contentHints } = params;
@@ -331,6 +405,7 @@ export class MockGoogleDriveManager {
   }
 
   async updateCharacterFile(id, payload) {
+    await this._simulate('updateCharacterFile');
     const params = await this._buildCharacterFileParams(payload);
     if (!params) return null;
     const { mimeType, fileName, folderId, contentHints } = params;
@@ -338,6 +413,7 @@ export class MockGoogleDriveManager {
   }
 
   async renameFile(id, newName) {
+    await this._simulate('renameFile');
     await this.ensureAccessToken();
     if (!id || !newName) {
       throw new Error('File ID and new name are required to rename a file.');
@@ -347,16 +423,19 @@ export class MockGoogleDriveManager {
       throw new Error('File not found');
     }
     file.name = newName;
+    file.modifiedTime = new Date().toISOString();
     this._saveState();
     return { id, name: newName };
   }
 
   async loadCharacterFile(id) {
+    await this._simulate('loadCharacterFile');
     const content = await this.loadFileContent(id);
     return content ? await deserializeCharacterPayload(content) : null;
   }
 
   async deleteCharacterFile(id) {
+    await this._simulate('deleteCharacterFile');
     await this.ensureAccessToken();
     delete this.state.files[id];
     this._saveState();

--- a/tests/unit/mockGoogleDriveManager.test.js
+++ b/tests/unit/mockGoogleDriveManager.test.js
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { GoogleDriveManager } from '@/infrastructure/google-drive/googleDriveManager.js';
+import {
+  MockGoogleDriveManager,
+  initializeMockGoogleDriveManager,
+  resetMockGoogleDriveManagerForTests,
+} from '@/infrastructure/google-drive/mockGoogleDriveManager.js';
+
+function publicMethodNames(cls) {
+  return Object.getOwnPropertyNames(cls.prototype).filter(
+    (name) => name !== 'constructor' && !name.startsWith('_') && typeof cls.prototype[name] === 'function',
+  );
+}
+
+describe('MockGoogleDriveManager', () => {
+  let gdm;
+
+  beforeEach(() => {
+    resetMockGoogleDriveManagerForTests();
+    gdm = initializeMockGoogleDriveManager('key', 'client');
+  });
+
+  afterEach(() => {
+    resetMockGoogleDriveManagerForTests();
+  });
+
+  describe('API parity with GoogleDriveManager', () => {
+    it('implements every public method of the real manager', () => {
+      const realMethods = publicMethodNames(GoogleDriveManager);
+      const mockMethods = new Set(publicMethodNames(MockGoogleDriveManager));
+      const missing = realMethods.filter((name) => !mockMethods.has(name));
+      expect(missing).toEqual([]);
+    });
+
+    it('uses the same default folder name', () => {
+      expect(MockGoogleDriveManager.DEFAULT_FOLDER_NAME).toBe(GoogleDriveManager.DEFAULT_FOLDER_NAME);
+    });
+  });
+
+  describe('character file lifecycle', () => {
+    it('creates, renames, lists, and deletes character files', async () => {
+      const created = await gdm.createCharacterFile({
+        name: 'Hero',
+        content: '{"character":{"name":"Hero"}}',
+        mimeType: 'application/json',
+      });
+      expect(created.id).toBeTruthy();
+      expect(created.name).toBe('Hero.json');
+
+      const loaded = await gdm.loadCharacterFile(created.id);
+      expect(loaded.character.name).toBe('Hero');
+
+      await gdm.renameFile(created.id, 'Hero2.json');
+      const folderId = await gdm.findOrCreateConfiguredCharacterFolder();
+      const files = await gdm.listFiles(folderId);
+      expect(files.map((file) => file.name)).toContain('Hero2.json');
+
+      await gdm.deleteCharacterFile(created.id);
+      expect(await gdm.loadCharacterFile(created.id)).toBeNull();
+    });
+
+    it('throws the same error as the real 404 path when updating a deleted file', async () => {
+      const created = await gdm.createCharacterFile({ name: 'Ghost', content: '{}', mimeType: 'application/json' });
+      await gdm.deleteCharacterFile(created.id);
+
+      await expect(gdm.updateCharacterFile(created.id, { name: 'Ghost', content: '{}', mimeType: 'application/json' })).rejects.toThrow(
+        'Parent folder not found',
+      );
+    });
+
+    it('falls back to the default folder name in getOrCreateAppFolder', async () => {
+      const folder = await gdm.getOrCreateAppFolder();
+      expect(folder.name).toBe(MockGoogleDriveManager.DEFAULT_FOLDER_NAME);
+    });
+  });
+
+  describe('configured folder resilience', () => {
+    it('recreates the folder when it disappears from Drive', async () => {
+      const firstId = await gdm.findOrCreateConfiguredCharacterFolder();
+      delete gdm.state.folders[firstId];
+
+      const secondId = await gdm.findOrCreateConfiguredCharacterFolder();
+      expect(secondId).toBeTruthy();
+      expect(secondId).not.toBe(firstId);
+      expect(gdm.state.config.characterFolderId).toBe(secondId);
+    });
+  });
+
+  describe('authentication gating', () => {
+    it('rejects Drive operations after sign-out and recovers after sign-in', async () => {
+      await gdm.handleSignOut();
+
+      await expect(gdm.listFiles('folder-1')).rejects.toThrow('Authentication required.');
+      await expect(gdm.loadConfig()).rejects.toThrow('Authentication required.');
+      expect(await gdm.restoreSession()).toBe(false);
+
+      await gdm.handleSignIn();
+      expect(await gdm.restoreSession()).toBe(true);
+      await expect(gdm.listFiles('folder-1')).resolves.toEqual(expect.any(Array));
+    });
+  });
+
+  describe('sharing', () => {
+    it('marks files shared/unshared and reports it in listings', async () => {
+      const created = await gdm.createCharacterFile({ name: 'Shared', content: '{}', mimeType: 'application/json' });
+
+      const link = await gdm.ensureFilePublic(created.id);
+      expect(link).toContain(created.id);
+
+      const folderId = await gdm.findOrCreateConfiguredCharacterFolder();
+      let files = await gdm.listFiles(folderId);
+      expect(files.find((file) => file.id === created.id).shared).toBe(true);
+
+      expect(await gdm.unshareFile(created.id)).toBe(true);
+      files = await gdm.listFiles(folderId);
+      expect(files.find((file) => file.id === created.id).shared).toBe(false);
+    });
+  });
+
+  describe('failure simulation', () => {
+    it('fails the requested method the requested number of times', async () => {
+      gdm.simulateFailure('saveFile', { times: 1 });
+
+      await expect(gdm.createCharacterFile({ name: 'X', content: '{}' })).rejects.toThrow('Simulated Drive failure');
+
+      const retried = await gdm.createCharacterFile({ name: 'X', content: '{}' });
+      expect(retried.id).toBeTruthy();
+    });
+
+    it('supports wildcard failures with custom errors until cleared', async () => {
+      gdm.simulateFailure('*', { error: 'network down' });
+
+      await expect(gdm.listFiles('folder-1')).rejects.toThrow('network down');
+      await expect(gdm.loadFileContent('file-1')).rejects.toThrow('network down');
+
+      gdm.clearSimulatedFailures();
+      await expect(gdm.listFiles('folder-1')).resolves.toEqual(expect.any(Array));
+    });
+
+    it('applies configured latency to operations', async () => {
+      vi.useFakeTimers();
+      try {
+        gdm.setLatency(500);
+        let resolved = false;
+        const pending = gdm.listFiles('folder-1').then((files) => {
+          resolved = true;
+          return files;
+        });
+
+        await vi.advanceTimersByTimeAsync(499);
+        expect(resolved).toBe(false);
+
+        // 内部で呼ばれる ensureAccessToken にも遅延が適用されるため余分に進める
+        await vi.advanceTimersByTimeAsync(1000);
+        await pending;
+        expect(resolved).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('reset clears failure rules and latency', async () => {
+      gdm.simulateFailure('*');
+      gdm.setLatency(10000);
+
+      gdm.reset();
+
+      await expect(gdm.listFiles('folder-1')).resolves.toEqual(expect.any(Array));
+    });
+  });
+});


### PR DESCRIPTION
## 概要

開発用モックGoogle Drive(`MockGoogleDriveManager`)を強化し、実装との乖離を防ぐ契約テストを追加しました。

## 変更内容

### 忠実性の修正(実装との挙動乖離を解消)
- **設定フォルダの毎回検証**: 実装は「ゴミ箱入りフォルダへの保存事故」防止のため毎回フォルダの存在を確認しますが、モックはメモリキャッシュを無条件に信用していました。実装と同様に毎回検証し、消えていたら再作成してconfigを更新するように修正
- **削除済みファイル更新時のエラー**: 実装ではDrive APIの404から `Parent folder not found. Please select a new folder.` がスローされますが、モックは黙って新規作成していました。同じエラーをスローするように修正
- **`getOrCreateAppFolder` のフォールバック修正**: 存在しないフィールド `characterFolderPath` を参照して「undefined」という名前のフォルダを作っていたのを `DEFAULT_FOLDER_NAME` に修正
- `loadConfig` / `saveConfig` にも実装と同様の認証チェックを追加

### 障害シミュレーション機能(新規)
エラーハンドリング(トースト表示・リトライ等)の動作確認用に、devコンソールの `window.__DRIVE_DEV__` から失敗・遅延を注入できるようになりました:

```js
__DRIVE_DEV__.simulateFailure('saveFile', { times: 1 });  // 1回だけ失敗
__DRIVE_DEV__.simulateFailure('*', { error: 'network down' });  // 全メソッド失敗
__DRIVE_DEV__.setLatency(2000);  // ローディング表示の確認用
__DRIVE_DEV__.clearSimulatedFailures();
```

設定はメモリ上のみで `localStorage` には永続化されません(リロードで解除)。

### テスト(12件追加、計202件)
- **契約テスト**: 実装(`GoogleDriveManager`)のpublicメソッドをモックが全て備えているか自動検証。今後実装にメソッドが増えてモックが追従し忘れるとテストで検出されます
- **挙動テスト**: ファイルのライフサイクル、認証ゲート、共有、フォルダ再作成、障害シミュレーション

### ドキュメント
`VITE_USE_MOCK_DRIVE` の開発モードは未文書だったため、`docs/mock-google-drive.md` に使い方をまとめました。

## テスト
- `npm run lint` ✅(ESLint / Stylelint / HTMLHint すべてパス)
- `npx vitest run` ✅(202件すべてパス)

https://claude.ai/code/session_016gt2XQM41t1uCa5hp1Vsu5

---
_Generated by [Claude Code](https://claude.ai/code/session_016gt2XQM41t1uCa5hp1Vsu5)_